### PR TITLE
Improve Cache class performance

### DIFF
--- a/src/Client/InternalClient.js
+++ b/src/Client/InternalClient.js
@@ -1076,11 +1076,6 @@ export default class InternalClient {
 					var startTime = Date.now();
 					self.intervals.kai = setInterval(() => self.sendWS({ op: 1, d: Date.now() }), data.heartbeat_interval);
 
-					self.users.setHighPerformance();
-					self.servers.setHighPerformance();
-					self.channels.setHighPerformance();
-					self.private_channels.setHighPerformance();
-
 					self.user = self.users.add(new User(data.user, client));
 					data.guilds.forEach(server => {
 						self.servers.add(new Server(server, client));
@@ -1089,11 +1084,6 @@ export default class InternalClient {
 						self.private_channels.add(new PMChannel(pm, client));
 					});
 					self.state = ConnectionState.READY;
-
-					self.users.setNormalPerformance();
-					self.servers.setNormalPerformance();
-					self.channels.setNormalPerformance();
-					self.private_channels.setNormalPerformance();
 
 					client.emit("ready");
 					client.emit("debug", `ready packet took ${Date.now() - startTime}ms to process`);

--- a/src/Structures/Server.js
+++ b/src/Structures/Server.js
@@ -33,8 +33,6 @@ export default class Server extends Equality {
 		this.afkChannelID = data.afk_channel_id;
 		this.memberMap = {};
 
-		this.members.setHighPerformance();
-
 		var self = this;
 
 		data.roles.forEach((dataRole) => {
@@ -71,8 +69,6 @@ export default class Server extends Equality {
 				}
 			}
 		}
-
-		this.members.setNormalPerformance();
 	}
 
 	detailsOf(user) {


### PR DESCRIPTION
Use hashmap instead of array for caching by discriminator

Optimize `get` method by using `for` loop instead of `forEach`
and returning hashmap cache for queries by discriminator