### PR TITLE
Add opus sanity check

### DIFF
--- a/src/Voice/AudioEncoder.js
+++ b/src/Voice/AudioEncoder.js
@@ -15,6 +15,22 @@ export default class AudioEncoder {
 			this.opus = new opus.OpusEncoder(48000, 2);
 		}
 		this.choice = false;
+		this.sanityCheckPassed = undefined;
+	}
+
+	sanityCheck() {
+		var _opus = this.opus;
+		var encodeZeroes = function() {
+			try {
+				var zeroes = new Buffer(1920);
+				zeroes.fill(0);
+				return _opus.encode(zeroes, 1920).readUIntBE(0, 3);
+			} catch(err) {
+				return false;
+			}
+		};
+		if(this.sanityCheckPassed === undefined) this.sanityCheckPassed = (encodeZeroes() === 16056318);
+		return this.sanityCheckPassed;
 	}
 
 	opusBuffer(buffer) {

--- a/src/Voice/VoiceConnection.js
+++ b/src/Voice/VoiceConnection.js
@@ -189,6 +189,14 @@ export default class VoiceConnection extends EventEmitter {
 				self.client.emit("debug", "Tried to use node-opus, but opus not available - install it!");
 				return;
 			}
+
+			if (!self.encoder.sanityCheck()) {
+				self.playing = false;
+				self.emit("error", "Opus sanity check failed!");
+				self.client.emit("debug", "Opus sanity check failed - opus is installed but not correctly! Please reinstall opus and make sure it's installed correctly.");
+				return;
+			}
+
 			var buffer = self.encoder.opusBuffer(rawbuffer);
 			var packet = new VoicePacket(buffer, sequence, timestamp, self.vWSData.ssrc);
 			return self.sendPacket(packet, callback);


### PR DESCRIPTION
This should throw an error similar to the `Tried to use node-opus, but opus not available - install it!` error. This is untested (because I wasn't able to simulate a broken build environment) but it should work - at least it doesn't break working installs. If someone on Windows that has problems getting discord.js to work could test it, that would be really nice.