### PR TITLE
sendFile() to use original file name by default

### DIFF
--- a/lib/Client/Client.js
+++ b/lib/Client/Client.js
@@ -206,9 +206,10 @@ var Client = (function (_EventEmitter) {
 
 	// def sendFile
 
-	Client.prototype.sendFile = function sendFile(where, attachment) {
-		var name = arguments.length <= 2 || arguments[2] === undefined ? "image.png" : arguments[2];
+	Client.prototype.sendFile = function sendFile(where, attachment, name) {
 		var callback = arguments.length <= 3 || arguments[3] === undefined ? function () /*err, m*/{} : arguments[3];
+
+		name = name ? name : require('path').basename(attachment);
 
 		return this.internal.sendFile(where, attachment, name).then(dataCallback(callback), errorCallback(callback));
 	};

--- a/lib/Client/Client.js
+++ b/lib/Client/Client.js
@@ -209,7 +209,11 @@ var Client = (function (_EventEmitter) {
 	Client.prototype.sendFile = function sendFile(where, attachment, name) {
 		var callback = arguments.length <= 3 || arguments[3] === undefined ? function () /*err, m*/{} : arguments[3];
 
-		name = name ? name : require('path').basename(attachment);
+		if (typeof name === "function") {
+			// name is the callback
+			callback = name;
+			name = undefined; // Will get resolved into original filename in internal
+		}
 
 		return this.internal.sendFile(where, attachment, name).then(dataCallback(callback), errorCallback(callback));
 	};

--- a/lib/Client/InternalClient.js
+++ b/lib/Client/InternalClient.js
@@ -568,10 +568,10 @@ var InternalClient = (function () {
 
 	// def sendFile
 
-	InternalClient.prototype.sendFile = function sendFile(where, _file) {
+	InternalClient.prototype.sendFile = function sendFile(where, _file, name) {
 		var _this14 = this;
 
-		var name = arguments.length <= 2 || arguments[2] === undefined ? "image.png" : arguments[2];
+		name = name ? name : require('path').basename(attachment);
 
 		return this.resolver.resolveChannel(where).then(function (channel) {
 			return _this14.apiRequest("post", _Constants.Endpoints.CHANNEL_MESSAGES(channel.id), true, null, {

--- a/lib/Client/InternalClient.js
+++ b/lib/Client/InternalClient.js
@@ -571,7 +571,16 @@ var InternalClient = (function () {
 	InternalClient.prototype.sendFile = function sendFile(where, _file, name) {
 		var _this14 = this;
 
-		name = name ? name : require('path').basename(attachment);
+		if (!name) {
+			if (_file instanceof String || typeof _file === "string") {
+				name = require("path").basename(attachment);
+			} else if (_file.path) {
+				// fs.createReadStream()'s have .path that give the path. Not sure about other streams though.
+				name = require("path").basename(_file.path);
+			} else {
+				name = "image.png"; // Just have to go with default filenames.
+			}
+		}
 
 		return this.resolver.resolveChannel(where).then(function (channel) {
 			return _this14.apiRequest("post", _Constants.Endpoints.CHANNEL_MESSAGES(channel.id), true, null, {

--- a/src/Client/Client.js
+++ b/src/Client/Client.js
@@ -191,8 +191,12 @@ export default class Client extends EventEmitter {
 
 	// def sendFile
 	sendFile(where, attachment, name, callback = (/*err, m*/) => { }) {
-		name = name ? name : require('path').basename(attachment);
-		
+		if (typeof name === "function") {
+			// name is the callback
+			callback = name;
+			name = undefined; // Will get resolved into original filename in internal
+		}
+
 		return this.internal.sendFile(where, attachment, name)
 			.then(dataCallback(callback), errorCallback(callback));
 	}

--- a/src/Client/Client.js
+++ b/src/Client/Client.js
@@ -190,7 +190,9 @@ export default class Client extends EventEmitter {
 	}
 
 	// def sendFile
-	sendFile(where, attachment, name = "image.png", callback = (/*err, m*/) => { }) {
+	sendFile(where, attachment, name, callback = (/*err, m*/) => { }) {
+		name = name ? name : require('path').basename(attachment);
+		
 		return this.internal.sendFile(where, attachment, name)
 			.then(dataCallback(callback), errorCallback(callback));
 	}

--- a/src/Client/InternalClient.js
+++ b/src/Client/InternalClient.js
@@ -460,7 +460,9 @@ export default class InternalClient {
 	}
 
 	// def sendFile
-	sendFile(where, _file, name = "image.png") {
+	sendFile(where, _file, name) {
+		name = name ? name : require('path').basename(attachment);
+		
 		return this.resolver.resolveChannel(where)
 		.then(channel =>
 			this.apiRequest("post", Endpoints.CHANNEL_MESSAGES(channel.id), true, null, {

--- a/src/Client/InternalClient.js
+++ b/src/Client/InternalClient.js
@@ -461,7 +461,17 @@ export default class InternalClient {
 
 	// def sendFile
 	sendFile(where, _file, name) {
-		name = name ? name : require('path').basename(attachment);
+		
+		if (!name) {
+			if (_file instanceof String || typeof _file === "string") {
+				name = require("path").basename(attachment);
+			} else if (_file.path) {
+				// fs.createReadStream()'s have .path that give the path. Not sure about other streams though.
+				name = require("path").basename(_file.path);
+			} else {
+				name = "image.png"; // Just have to go with default filenames.
+			}
+		}
 		
 		return this.resolver.resolveChannel(where)
 		.then(channel =>


### PR DESCRIPTION
Fixes #157 by using the original file name instead of `image.png`.

(It uses node's `path` module to resolve the basename, but I can try using other substring/regex methods to implement it.)