### PR TITLE
fix resolveServer undefined when TextChannel

### DIFF
--- a/lib/Client/Resolver/Resolver.js
+++ b/lib/Client/Resolver/Resolver.js
@@ -96,7 +96,7 @@ var Resolver = (function () {
 		}
 		if (resource instanceof _StructuresMessage2["default"]) {
 			if (resource.channel instanceof _StructuresTextChannel2["default"]) {
-				return resource.server;
+				return resource.channel.server;
 			}
 		}
 		return null;

--- a/src/Client/Resolver/Resolver.js
+++ b/src/Client/Resolver/Resolver.js
@@ -54,7 +54,7 @@ export default class Resolver {
 		}
 		if (resource instanceof Message) {
 			if (resource.channel instanceof TextChannel) {
-				return resource.server;
+				return resource.channel.server;
 			}
 		}
 		return null;


### PR DESCRIPTION
So far it has been the case that resolveServer has been returning
undefined in the case that the resource was a Message from a TextChannel.
This was the case because the conditional returned the value of member
"server" in the Message object. The Message object doesn't have a server
member though. The fix is to use the "channel" member of the Message
object and return its "server" member which was likely the original
intention considering the if statement.