### PR TITLE
Fixed incorrect documentation

### DIFF
--- a/docs/docs_message.rst
+++ b/docs/docs_message.rst
@@ -77,7 +77,7 @@ cleanContent
 mentions
 ~~~~~~~~
 
-A Cache_ of User_ objects that were mentioned in the message.
+An array of User_ objects that were mentioned in the message.
 
 Functions
 ---------


### PR DESCRIPTION
`message.mentions` is an array, not a Cache it seems.