### PR TITLE
Update docs_client.rst

### DIFF
--- a/docs/docs_client.rst
+++ b/docs/docs_client.rst
@@ -642,7 +642,7 @@ Emitted when a channel is deleted, supplies a Channel_ object.
 channelUpdated
 ~~~~~~~~~~~~~~
 
-Emitted when a channel is updated (e.g. name/topic change). Supplies a Channel_ object.
+Emitted when a channel is updated (e.g. name/topic change). Supplies two Channel_ objects, the first being the channel before the update, the second being the new, updated channel.
 
 serverRoleCreated
 ~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Fixes the `channelUpdated` documentation (the method returns two `Channel` objects).