### PR TITLE
Fixes for bot accounts

### DIFF
--- a/lib/Client/InternalClient.js
+++ b/lib/Client/InternalClient.js
@@ -1241,7 +1241,7 @@ var InternalClient = (function () {
 	//def updateDetails
 
 	InternalClient.prototype.updateDetails = function updateDetails(data) {
-		if (!this.bot && !(this.email || data.email)) throw new Error("Must provide email since a token was used to login");
+		if (!this.user.bot && !(this.email || data.email)) throw new Error("Must provide email since a token was used to login");
 
 		var options = {
 			avatar: this.resolver.resolveToBase64(data.avatar) || this.user.avatar,

--- a/lib/Voice/VoiceConnection.js
+++ b/lib/Voice/VoiceConnection.js
@@ -99,7 +99,7 @@ var VoiceConnection = (function (_EventEmitter) {
 		this.client.internal.sendWS({
 			op: 4,
 			d: {
-				guild_id: null,
+				guild_id: this.server.id,
 				channel_id: null,
 				self_mute: true,
 				self_deaf: false

--- a/src/Client/InternalClient.js
+++ b/src/Client/InternalClient.js
@@ -1013,7 +1013,7 @@ export default class InternalClient {
 
 	//def updateDetails
 	updateDetails(data) {
-		if (!this.bot && !(this.email || data.email)) 
+		if (!this.user.bot && !(this.email || data.email)) 
 			throw new Error("Must provide email since a token was used to login");
 
 		var options = {

--- a/src/Voice/VoiceConnection.js
+++ b/src/Voice/VoiceConnection.js
@@ -62,7 +62,7 @@ export default class VoiceConnection extends EventEmitter {
 			{
 				op : 4,
 				d : {
-					guild_id : null,
+					guild_id : this.server.id,
 					channel_id : null,
 					self_mute : true,
 					self_deaf : false


### PR DESCRIPTION
Detection on `.updateDetails()` was not detecting bot accounts so the `email/password required` error would throw wrongly.

Bot accounts also couldn't leave a voice channel without supplying the `guild_id` so fixed to provide that on leave. (based on some info that #q provided in the node-discord.js channel)

(both fixes have been tested by me and seem to work as intended)