### PR TITLE
Voice State Update crash & small friends property fix

### DIFF
--- a/lib/Client/InternalClient.js
+++ b/lib/Client/InternalClient.js
@@ -2083,9 +2083,11 @@ var InternalClient = (function () {
 						client.emit("warn", "voice state update but user or server not in cache");
 					}
 
-					if (connection) {
+					if (user.id === self.user.id) {
+						// only for detecting self user movements for connections.
+						var connection = self.voiceConnections.get("server", server);
 						// existing connection, perhaps channel moved
-						if (connection.voiceChannel.id !== data.channel_id) {
+						if (connection && connection.voiceChannel.id !== data.channel_id) {
 							// moved, update info
 							connection.voiceChannel = self.channels.get("id", data.channel_id);
 							client.emit("voiceMoved", connection.voiceChannel); // Moved to a new channel

--- a/lib/Client/InternalClient.js
+++ b/lib/Client/InternalClient.js
@@ -1585,9 +1585,9 @@ var InternalClient = (function () {
 							}
 						});
 					} else {
-						data.friends = null;
-						data.incoming_friend_requests = null;
-						data.outgoing_friend_requests = null;
+						self.friends = null;
+						self.incoming_friend_requests = null;
+						self.outgoing_friend_requests = null;
 					}
 					self.state = _ConnectionState2["default"].READY;
 

--- a/src/Client/InternalClient.js
+++ b/src/Client/InternalClient.js
@@ -1321,9 +1321,9 @@ export default class InternalClient {
 							}
 						});
 					} else {
-						data.friends = null;
-						data.incoming_friend_requests = null;
-						data.outgoing_friend_requests = null;
+						self.friends = null;
+						self.incoming_friend_requests = null;
+						self.outgoing_friend_requests = null;
 					}
 					self.state = ConnectionState.READY;
 

--- a/src/Client/InternalClient.js
+++ b/src/Client/InternalClient.js
@@ -1771,9 +1771,10 @@ export default class InternalClient {
 						client.emit("warn", "voice state update but user or server not in cache");
 					}
 
-					if (connection) {
+					if (user.id === self.user.id) { // only for detecting self user movements for connections.
+						var connection = self.voiceConnections.get("server", server);
 						// existing connection, perhaps channel moved
-						if (connection.voiceChannel.id !== data.channel_id) {
+						if (connection && connection.voiceChannel.id !== data.channel_id) {
 							// moved, update info
 							connection.voiceChannel = self.channels.get("id", data.channel_id);
 							client.emit("voiceMoved", connection.voiceChannel); // Moved to a new channel


### PR DESCRIPTION
First: `TypeError: Cannot read property 'id' of null` when another user moves from another server's voice channel that the client is in and then moves into another server's that it is in (sorry, a bit hard to explain). I also think that the code I wrote for that is intended to only keep track of the bot client itself and if it gets forcefully moved by another privileged user, not for other user's updates.

Second: just should be setting that friends stuff to null if its a bot account...


*(I think these two fixes are actually fixes at my own code...)*