### PR TITLE
Voice State Update crash fix (different from other one)

### DIFF
--- a/lib/Client/InternalClient.js
+++ b/lib/Client/InternalClient.js
@@ -250,7 +250,6 @@ var InternalClient = (function () {
 			var leave = function leave(connection) {
 				return new Promise(function (resolve, reject) {
 					connection.destroy();
-					_this3.voiceConnections.remove(connection);
 					resolve();
 				});
 			};
@@ -280,7 +279,6 @@ var InternalClient = (function () {
 			// preserve old functionality for non-bots
 			if (this.voiceConnections[0]) {
 				this.voiceConnections[0].destroy();
-				this.voiceConnections.remove(this.voiceConnections[0]);
 			}
 			return Promise.resolve();
 		}

--- a/lib/Voice/VoiceConnection.js
+++ b/lib/Voice/VoiceConnection.js
@@ -105,6 +105,7 @@ var VoiceConnection = (function (_EventEmitter) {
 				self_deaf: false
 			}
 		});
+		this.client.internal.voiceConnections.remove(this);
 	};
 
 	VoiceConnection.prototype.stopPlaying = function stopPlaying() {

--- a/src/Client/InternalClient.js
+++ b/src/Client/InternalClient.js
@@ -180,7 +180,6 @@ export default class InternalClient {
 			var leave = (connection) => {
 				return new Promise((resolve, reject) => {
 					connection.destroy();
-					this.voiceConnections.remove(connection);
 					resolve();
 				});
 			};
@@ -210,7 +209,6 @@ export default class InternalClient {
 			// preserve old functionality for non-bots
 			if (this.voiceConnections[0]) {
                 this.voiceConnections[0].destroy();
-                this.voiceConnections.remove(this.voiceConnections[0])
 			}
 			return Promise.resolve();
 		}

--- a/src/Voice/VoiceConnection.js
+++ b/src/Voice/VoiceConnection.js
@@ -69,6 +69,7 @@ export default class VoiceConnection extends EventEmitter {
 				}
 			}
 		);
+		this.client.internal.voiceConnections.remove(this);
 	}
 
 	stopPlaying() {


### PR DESCRIPTION
The other Voice State Update fix doesn't seem to fix crashes where InternalClient.leaveVoiceChannel isn't used, and the connection is simply destroyed.

Modified VoiceConnection.destroy() to remove the connection from InternalClient.voiceConnections

Also removes instances where VoiceConnection.destroy() is called and then manually removed from InternalClient.voiceConnections