### PR TITLE
Some doc fixes

### DIFF
--- a/docs/docs_client.rst
+++ b/docs/docs_client.rst
@@ -254,7 +254,7 @@ Attempts to delete a message
 - **message** - The Message_ to delete
 - **options** - `object` containing the following:
     - **wait** - Milliseconds as a `number` to wait before deleting the message
-- **callback**
+- **callback** - `function` that takes the following parameters:
     - **error** - error object if any occurred
 
 getChannelLogs(channel, `limit`, `options`, `callback`)
@@ -430,7 +430,7 @@ deleteInvite(invite, `callback`)
 
 Deletes an invite
 
-- **invite** - An `Invite ID Resolvable`_
+- **invite** - An `Invite Resolvable`_
 - **callback** - a `function` taking the following:
     - **error** - error if any occurred
 

--- a/docs/docs_message.rst
+++ b/docs/docs_message.rst
@@ -87,4 +87,4 @@ isMentioned(user)
 
 Returns true if the given user was mentioned in the message.
 
-- **user** : A `User Resolvable`_
+- **user** - A `User Resolvable`_

--- a/docs/docs_resolvables.rst
+++ b/docs/docs_resolvables.rst
@@ -89,7 +89,7 @@ Invite ID Resolvable
 An Invite ID Resolvable allows:
 
 - Invite_
-- String_ containing either a http link to the invite or the invite code on its own.
+- String containing either a http link to the invite or the invite code on its own.
 
 Base64 Resolvable
 -----------------

--- a/docs/docs_server.rst
+++ b/docs/docs_server.rst
@@ -106,12 +106,12 @@ Returns an object containing metadata of a user within the server, containing a 
 .. code-block:: js
 
 	{
-		joinedAt : 1449339323747,
-        roles: [],
-        mute : false,
-        self_mute : false,
-		deaf : false,
-        self_deaf : false
+		joinedAt: 1449339323747,
+		roles: [],
+		mute: false,
+		self_mute: false,
+		deaf: false,
+		self_deaf: false
 	}
 
 leave()

--- a/docs/docs_serverchannel.rst
+++ b/docs/docs_serverchannel.rst
@@ -50,4 +50,4 @@ Returns a ChannelPermissions_ object of a user's permissions in that channel.
 mention()
 ~~~~~~~~~
 
-Returns a `string` that can be used in discord messages to mention a channel. ``serverChannel.toString()` defaults to this.
+Returns a `string` that can be used in discord messages to mention a channel. `serverChannel.toString()` defaults to this.

--- a/docs/docs_voiceconnection.rst
+++ b/docs/docs_voiceconnection.rst
@@ -64,7 +64,7 @@ Plays a file to the voice channel. The file can be in practically any format; if
 In addition to a file path local to your computer, it can also accept a URL, however this is not recommended as the entire content of the URL will be read before any playback starts.
 This can cause delays from seconds to minutes - you can use `playRawStream` with a Stream obtained from the URL instead.
 
-The `options` object can be used to control playback properties, currently, it currently allows setting the seek (in seconds) using the `seek` property, and the volume using the `volume` property, which can be in any of the following formats:
+The `options` object can be used to control playback properties, currently, it allows setting the seek (in seconds) using the `seek` property, and the volume using the `volume` property, which can be in any of the following formats:
 
  - A number representing the linear change in volume; 1 is equal to no change, 0 is completely silent, 0.5 is half the regular volume and 2 is double the regular volume.
  - A string representing the linear change in volume, if this is more convenient for you.
@@ -95,11 +95,12 @@ This method can be used to play data obtained from an arbitrary call to ffmpeg. 
 still be concatenated with the following options so it can be used with Discord:
 
 .. code::
-  -loglevel 0
-  -f s16le
-  -ar 48000
-  -ac 2
-  pipe:1
+
+    -loglevel 0
+    -f s16le
+    -ar 48000
+    -ac 2
+    pipe:1
 
 setSpeaking(value)
 ~~~~~~~~~~~~~~~~~~
@@ -107,7 +108,7 @@ setSpeaking(value)
 Sets whether or not the user is speaking (green circle around user on the official client). discord.js does this automatically when playing something,
 but you may want to spoof it or manually disable it.
 
- - `value` - `true` or `false`: whether or not you want the bot to show as speaking
+ - **value** - `true` or `false`: whether or not you want the bot to show as speaking
 
 setVolume(volume)
 ~~~~~~~~~~~~~
@@ -130,6 +131,6 @@ destroy()
 Disconnects from the voice server and destroys all network connection. It's impossible to play anything on this connection afterwards, you will have to re-initiate
 a connection using client.joinVoiceChannel_. This method also calls `stopPlaying` internally, you don't have to do that yourself.
 
-:: _Format list : https://ffmpeg.org/general.html#File-Formats
-:: _voiceConnection.playFile : ./docs_voiceconnection.html#playfile-path-options-callback
-:: _client.joinVoiceChannel : ./docs_client.html#joinvoicechannel-channel-callback
+.. _Format list: https://ffmpeg.org/general.html#File-Formats
+.. _voiceConnection.playFile: ./docs_voiceconnection.html#playfile-path-options-callback
+.. _client.joinVoiceChannel: ./docs_client.html#joinvoicechannel-channel-callback

--- a/docs/vars.rst
+++ b/docs/vars.rst
@@ -29,3 +29,4 @@
 
 .. _VoiceChannel Resolvable : http://discordjs.readthedocs.org/en/latest/docs_resolvables.html#voice-channel-resolvable
 .. _File Resolvable : http://discordjs.readthedocs.org/en/latest/docs_resolvables.html#file-resolvable
+.. _Role Resolvable : http://discordjs.readthedocs.org/en/latest/docs_resolvables.html#role-resolvable


### PR DESCRIPTION
### docs_client.rst:
- 257: Add proper eplanation of callback, like in every other method
- 433: Fix linking for Invite Resolvable

### docs_message.rst:
- 90 : Replace ':' with '-', just for consistency with the others

### docs_resolvables.rst:
- 92 : String doesn't link to anything (?) -> Link removed

### docs_servers.rst:
- 109 : Properly indent code-block because it didn't show at all on rtfd

### docs_serverchannel.rst:
- 53 : Remove doulbe '`' causing it not to display properly

### docs_voiceconnection.rst:
- 67 : Remove 'currently, it currently

### docs_voiceconnection.rst:
- 32 : Add links for Role Resolvable, as used in client#addMemberToRole,
client#removeMemberFromRole and client#memberHasRole