### PR TITLE
Fix selfDeaf and selfMute being undefined if false #323

### DIFF
--- a/lib/Structures/Server.js
+++ b/lib/Structures/Server.js
@@ -157,15 +157,15 @@ var Server = (function (_Equality) {
 
 				var voiceState = _ref2;
 
-				var _user = this.members.get("id", voiceState.user_id);
+				var _user2 = this.members.get("id", voiceState.user_id);
 				var channel = this.channels.get("id", voiceState.channel_id);
-				this.memberMap[_user.id] = this.memberMap[_user.id] || {};
-				this.memberMap[_user.id].mute = voiceState.mute || this.memberMap[_user.id].mute;
-				this.memberMap[_user.id].selfMute = voiceState.self_mute || this.memberMap[_user.id].selfMute;
-				this.memberMap[_user.id].deaf = voiceState.deaf || this.memberMap[_user.id].deaf;
-				this.memberMap[_user.id].selfDeaf = voiceState.self_deaf || this.memberMap[_user.id].selfDeaf;
-				if (_user && channel) {
-					this.eventVoiceJoin(_user, channel);
+				this.memberMap[_user2.id] = this.memberMap[_user2.id] || {};
+				this.memberMap[_user2.id].mute = voiceState.mute || this.memberMap[_user2.id].mute;
+				this.memberMap[_user2.id].selfMute = 'self_mute' in voiceState ? voiceState.self_mute : this.memberMap[_user.id].selfMute;
+				this.memberMap[_user2.id].deaf = voiceState.deaf || this.memberMap[_user2.id].deaf;
+				this.memberMap[_user2.id].selfDeaf = 'self_deaf' in voiceState ? voiceState.self_mute : this.memberMap[_user.id].selfDeaf;
+				if (_user2 && channel) {
+					this.eventVoiceJoin(_user2, channel);
 				} else {
 					this.client.emit("warn", "user doesn't exist even though READY expects them to");
 				}

--- a/lib/Structures/Server.js
+++ b/lib/Structures/Server.js
@@ -157,15 +157,15 @@ var Server = (function (_Equality) {
 
 				var voiceState = _ref2;
 
-				var _user2 = this.members.get("id", voiceState.user_id);
+				var _user = this.members.get("id", voiceState.user_id);
 				var channel = this.channels.get("id", voiceState.channel_id);
-				this.memberMap[_user2.id] = this.memberMap[_user2.id] || {};
-				this.memberMap[_user2.id].mute = voiceState.mute || this.memberMap[_user2.id].mute;
-				this.memberMap[_user2.id].selfMute = 'self_mute' in voiceState ? voiceState.self_mute : this.memberMap[_user.id].selfMute;
-				this.memberMap[_user2.id].deaf = voiceState.deaf || this.memberMap[_user2.id].deaf;
-				this.memberMap[_user2.id].selfDeaf = 'self_deaf' in voiceState ? voiceState.self_mute : this.memberMap[_user.id].selfDeaf;
-				if (_user2 && channel) {
-					this.eventVoiceJoin(_user2, channel);
+				this.memberMap[_user.id] = this.memberMap[_user.id] || {};
+				this.memberMap[_user.id].mute = voiceState.mute || this.memberMap[_user.id].mute;
+				this.memberMap[_user.id].selfMute = voiceState.self_mute || this.memberMap[_user.id].selfMute;
+				this.memberMap[_user.id].deaf = voiceState.deaf || this.memberMap[_user.id].deaf;
+				this.memberMap[_user.id].selfDeaf = voiceState.self_deaf || this.memberMap[_user.id].selfDeaf;
+				if (_user && channel) {
+					this.eventVoiceJoin(_user, channel);
 				} else {
 					this.client.emit("warn", "user doesn't exist even though READY expects them to");
 				}

--- a/lib/Util/TokenCacher-shim.js
+++ b/lib/Util/TokenCacher-shim.js
@@ -6,23 +6,23 @@ exports.__esModule = true;
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 var TokenCacher = (function () {
-	function TokenCacher() {
-		_classCallCheck(this, TokenCacher);
-	}
+			function TokenCacher() {
+						_classCallCheck(this, TokenCacher);
+			}
 
-	TokenCacher.prototype.setToken = function setToken() {};
+			TokenCacher.prototype.setToken = function setToken() {};
 
-	TokenCacher.prototype.save = function save() {};
+			TokenCacher.prototype.save = function save() {};
 
-	TokenCacher.prototype.getToken = function getToken() {
-		return null;
-	};
+			TokenCacher.prototype.getToken = function getToken() {
+						return null;
+			};
 
-	TokenCacher.prototype.init = function init(ind) {
-		this.done = true;
-	};
+			TokenCacher.prototype.init = function init(ind) {
+						this.done = true;
+			};
 
-	return TokenCacher;
+			return TokenCacher;
 })();
 
 exports["default"] = TokenCacher;

--- a/lib/Util/TokenCacher-shim.js
+++ b/lib/Util/TokenCacher-shim.js
@@ -6,23 +6,23 @@ exports.__esModule = true;
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 var TokenCacher = (function () {
-			function TokenCacher() {
-						_classCallCheck(this, TokenCacher);
-			}
+	function TokenCacher() {
+		_classCallCheck(this, TokenCacher);
+	}
 
-			TokenCacher.prototype.setToken = function setToken() {};
+	TokenCacher.prototype.setToken = function setToken() {};
 
-			TokenCacher.prototype.save = function save() {};
+	TokenCacher.prototype.save = function save() {};
 
-			TokenCacher.prototype.getToken = function getToken() {
-						return null;
-			};
+	TokenCacher.prototype.getToken = function getToken() {
+		return null;
+	};
 
-			TokenCacher.prototype.init = function init(ind) {
-						this.done = true;
-			};
+	TokenCacher.prototype.init = function init(ind) {
+		this.done = true;
+	};
 
-			return TokenCacher;
+	return TokenCacher;
 })();
 
 exports["default"] = TokenCacher;

--- a/src/Structures/Server.js
+++ b/src/Structures/Server.js
@@ -96,9 +96,9 @@ export default class Server extends Equality {
 				let channel = this.channels.get("id", voiceState.channel_id);
 				this.memberMap[user.id] = this.memberMap[user.id] || {};
 				this.memberMap[user.id].mute = voiceState.mute || this.memberMap[user.id].mute;
-				this.memberMap[user.id].selfMute = voiceState.self_mute || this.memberMap[user.id].selfMute;
+				this.memberMap[user.id].selfMute = 'self_mute' in voiceState ? voiceState.self_mute : this.memberMap[_user.id].selfMute;
 				this.memberMap[user.id].deaf = voiceState.deaf || this.memberMap[user.id].deaf;
-				this.memberMap[user.id].selfDeaf = voiceState.self_deaf || this.memberMap[user.id].selfDeaf;
+				this.memberMap[user.id].selfDeaf = 'self_deaf' in voiceState ? voiceState.self_mute : this.memberMap[_user.id].selfDeaf;
 				if (user && channel) {
 					this.eventVoiceJoin(user, channel);
 				} else {

--- a/src/Structures/Server.js
+++ b/src/Structures/Server.js
@@ -96,9 +96,9 @@ export default class Server extends Equality {
 				let channel = this.channels.get("id", voiceState.channel_id);
 				this.memberMap[user.id] = this.memberMap[user.id] || {};
 				this.memberMap[user.id].mute = voiceState.mute || this.memberMap[user.id].mute;
-				this.memberMap[user.id].selfMute = 'self_mute' in voiceState ? voiceState.self_mute : this.memberMap[_user.id].selfMute;
+				this.memberMap[user.id].selfMute = voiceState.self_mute || this.memberMap[user.id].selfMute;
 				this.memberMap[user.id].deaf = voiceState.deaf || this.memberMap[user.id].deaf;
-				this.memberMap[user.id].selfDeaf = 'self_deaf' in voiceState ? voiceState.self_mute : this.memberMap[_user.id].selfDeaf;
+				this.memberMap[user.id].selfDeaf = voiceState.self_deaf || this.memberMap[user.id].selfDeaf;
 				if (user && channel) {
 					this.eventVoiceJoin(user, channel);
 				} else {


### PR DESCRIPTION
So uh since it's like this
```"foo" || "bar"; // returns "foo"```­­
```­­false || "bar"; // returns "bar"```­­

when selfMute/selfDeaf is false it jumps to the memberMap which doesn't have the property -> undefined

This doesn't apply to mute and deaf (well it does, but it's somehow already with the correct values in the membermap?) so I left it out there