### PR TITLE
Fix for the playArbitraryFFmpeg issue

### DIFF
--- a/docs/docs_voiceconnection.rst
+++ b/docs/docs_voiceconnection.rst
@@ -88,7 +88,7 @@ This method is used in much the same way as `playFile`, except it plays data bac
 
 | See voiceConnection.playFile_ for usage information.
 
-playArbitraryFFmpeg(options, `callback`)
+playArbitraryFFmpeg(ffmpegOptions, `volume`, `callback`)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This method can be used to play data obtained from an arbitrary call to ffmpeg. Note that the array of options given as the parameter will

--- a/src/Voice/AudioEncoder.js
+++ b/src/Voice/AudioEncoder.js
@@ -147,9 +147,9 @@ export default class AudioEncoder {
 		});
 	}
 
-	encodeArbitraryFFmpeg(ffmpegOptions) {
+	encodeArbitraryFFmpeg(ffmpegOptions, volume) {
 		return new Promise((resolve, reject) => {
-			this.volume = new VolumeTransformer(1);
+			this.volume = new VolumeTransformer(volume);
 
 			// add options discord.js needs
 			var options = ffmpegOptions.concat([

--- a/src/Voice/VoiceConnection.js
+++ b/src/Voice/VoiceConnection.js
@@ -277,20 +277,20 @@ export default class VoiceConnection extends EventEmitter {
 		})
 	}
 
-	playArbitraryFFmpeg(ffmpegOptions, callback = function (err, str) { }) {
+	playArbitraryFFmpeg(ffmpegOptions, volume, callback = function (err, str) { }) {
 		var self = this;
 		self.stopPlaying();
-		if (typeof options === "function") {
-			// options is the callback
-			callback = options;
+		if (typeof volume === "function") {
+			// volume is the callback
+			callback = volume;
 		}
-        if (typeof options !== "object") {
-            options = {};
+        if (!ffmpegOptions instanceof Array) {
+            ffmpegOptions = [];
         }
-		options.volume = options.volume !== undefined ? options.volume : this.getVolume();
+		var volume = volume !== undefined ? volume : this.getVolume();
 		return new Promise((resolve, reject) => {
 			this.encoder
-				.encodeArbitraryFFmpeg(ffmpegOptions)
+				.encodeArbitraryFFmpeg(ffmpegOptions, volume)
 				.catch(error)
 				.then(data => {
 					self.streamProc = data.proc;


### PR DESCRIPTION
I wasn't able to setup the correct dev environment, so I couldn't test this fully.
I also hope it was ok to handle the volume with a new variable.
Anyway, I hacked the lib files in a similar way for my own bot and it works.

And for anyone who wants to know what I used `playArbitraryFFmpeg` for, it's to pitch/speed up/down sounds. It is actually really funny, so I hope more people can use this now.