### PR TITLE
fix econnreset in playRawStream

### DIFF
--- a/lib/Voice/AudioEncoder.js
+++ b/lib/Voice/AudioEncoder.js
@@ -89,7 +89,14 @@ var AudioEncoder = (function () {
 
 			var enc = _child_process2["default"].spawn(_this.getCommand(), ['-i', '-', '-f', 's16le', '-ar', '48000', '-ss', options.seek || 0, '-ac', 2, 'pipe:1']);
 
-			stream.pipe(enc.stdin);
+			var dest = stream.pipe(enc.stdin);
+
+			dest.on('unpipe', function () {
+				return dest.destroy();
+			});
+			dest.on('error', function (err) {
+				return dest.destroy();
+			});
 
 			_this.hookEncodingProcess(resolve, reject, enc, stream);
 		});

--- a/src/Voice/AudioEncoder.js
+++ b/src/Voice/AudioEncoder.js
@@ -71,7 +71,10 @@ export default class AudioEncoder {
 				'pipe:1'
 			]);
 
-			stream.pipe(enc.stdin);
+			var dest = stream.pipe(enc.stdin);
+
+			dest.on('unpipe', () => dest.destroy());
+			dest.on('error', err => dest.destroy());
 
 			this.hookEncodingProcess(resolve, reject, enc, stream);
 		});


### PR DESCRIPTION
Fixes econnreset when stream is interrupted.
```
Error: read ECONNRESET
    at exports._errnoException (util.js:953:11)
    at Pipe.onread (net.js:563:26)
```