### PR TITLE
Cache.remove bugfix

### DIFF
--- a/lib/Util/Cache.js
+++ b/lib/Util/Cache.js
@@ -132,6 +132,8 @@ var Cache = (function (_Array) {
 	};
 
 	Cache.prototype.remove = function remove(data) {
+		if (!this[discrimCacheS][data[this[discrimS]]]) return false;
+
 		delete this[discrimCacheS][data[this[discrimS]]];
 		for (var i in this) {
 			if (this[i] && this[i][this[discrimS]] === data[this[discrimS]]) {

--- a/src/Util/Cache.js
+++ b/src/Util/Cache.js
@@ -96,6 +96,8 @@ export default class Cache extends Array {
 	}
 
 	remove(data) {
+		if(!this[discrimCacheS][data[this[discrimS]]]) return false;
+
 		delete this[discrimCacheS][data[this[discrimS]]];
 		for (var i in this) {
 			if (this[i] && this[i][this[discrimS]] === data[this[discrimS]]) {


### PR DESCRIPTION
Fixes a bug where an invalid input into Cache.remove would delete its first value.

Example scenario:

```js
bot.servers[0].name; // Discord API
bot.servers[1].name; // Discord Developers

bot.servers.remove({}); // true

bot.servers[0].name; // Discord Developers
```
