### PR TITLE
Added a voiceSpeaking event, fired when a user in a voiceChannel starts or stops speaking.

### DIFF
--- a/docs/docs_client.rst
+++ b/docs/docs_client.rst
@@ -1015,19 +1015,24 @@ Emitted when a note is updated. Supplies a User_ object (containing the updated 
 voiceJoin
 ~~~~~~~~
 
-Emitted when a user joins a voice channel, supplies a VoiceChannel_ and a User_
+Emitted when a user joins a voice channel, supplies a VoiceChannel_ and a User_.
 
 voiceSwitch
 ~~~~~~~~~~~
 
-Emitted when a user switches voice channels, supplies the old VoiceChannel_, the new VoiceChannel_, and a User_
+Emitted when a user switches voice channels, supplies the old VoiceChannel_, the new VoiceChannel_, and a User_.
 
 voiceLeave
 ~~~~~~~~~~
 
-Emitted when a user leaves a voice channel, supplies a VoiceChannel_ and a User_
+Emitted when a user leaves a voice channel, supplies a VoiceChannel_ and a User_.
 
 voiceStateUpdate
 ~~~~~~~~~~
 
-Emitted when a user mutes/deafens, supplies a VoiceChannel_, User_, an object containing the old mute/selfMute/deaf/selfDeaf properties, and an object containing the new mute/selfMute/deaf/selfDeaf properties
+Emitted when a user mutes/deafens, supplies a VoiceChannel_, User_, an object containing the old mute/selfMute/deaf/selfDeaf properties, and an object containing the new mute/selfMute/deaf/selfDeaf properties.
+
+voiceSpeaking
+~~~~~~~~~~~
+
+Emitted when a user speaks, supplies a VoiceChannel_, User_, and a boolean indicating whether the user started or ended speaking, started being true and ended being false respectively.

--- a/docs/docs_client.rst
+++ b/docs/docs_client.rst
@@ -1035,4 +1035,4 @@ Emitted when a user mutes/deafens, supplies a VoiceChannel_, User_, an object co
 voiceSpeaking
 ~~~~~~~~~~~
 
-Emitted when a user speaks, supplies a VoiceChannel_, User_, and a boolean indicating whether the user started or ended speaking, started being true and ended being false respectively.
+Emitted when a user starts or stops speaking, supplies a VoiceChannel_, and User_. The `speaking` property under the supplied User_ object can be used to determine whether the user started or stopped speaking.

--- a/docs/docs_user.rst
+++ b/docs/docs_user.rst
@@ -87,11 +87,15 @@ createdAt
 
 A `Date` referring to when the user was created.
 
-
 note
 ~~~~
 
 The note of the user, `String`.
+
+speaking
+~~~~~~~~
+
+A boolean that represents whether or not the user is speaking in a voice channel, default is `false`.
 
 Functions
 ---------

--- a/lib/Structures/User.js
+++ b/lib/Structures/User.js
@@ -40,6 +40,7 @@ var User = (function (_Equality) {
 		this.note = data.note || null;
 		this.voiceChannel = null;
 		this.voiceState = {};
+		this.speaking = false;
 	}
 
 	User.prototype.mention = function mention() {

--- a/lib/Voice/VoiceConnection.js
+++ b/lib/Voice/VoiceConnection.js
@@ -448,6 +448,23 @@ var VoiceConnection = (function (_EventEmitter) {
 						self.emit("ready", self);
 
 						break;
+					case 5:
+						var user = self.server.members.get("id", data.d.user_id);
+
+						if (user) {
+							var speaking = data.d.speaking;
+							var channel = user.voiceChannel;
+
+							if (channel) {
+								self.client.emit("voiceSpeaking", channel, user, speaking);
+							} else {
+								self.client.emit("warn", "channel doesn't exist even though SPEAKING expects them to");
+							}
+						} else {
+							self.client.emit("warn", "user doesn't exist even though SPEAKING expects them to");
+						}
+
+						break;
 				}
 			});
 

--- a/lib/Voice/VoiceConnection.js
+++ b/lib/Voice/VoiceConnection.js
@@ -456,7 +456,8 @@ var VoiceConnection = (function (_EventEmitter) {
 							var channel = user.voiceChannel;
 
 							if (channel) {
-								self.client.emit("voiceSpeaking", channel, user, speaking);
+								user.speaking = speaking;
+								self.client.emit("voiceSpeaking", channel, user);
 							} else {
 								self.client.emit("warn", "channel doesn't exist even though SPEAKING expects them to");
 							}

--- a/src/Structures/User.js
+++ b/src/Structures/User.js
@@ -4,7 +4,7 @@ import Equality from "../Util/Equality";
 import {Endpoints} from "../Constants";
 import {reg} from "../Util/ArgumentRegulariser";
 
-export default class User extends Equality{
+export default class User extends Equality {
 	constructor(data, client){
 		super();
 		this.client = client;
@@ -22,6 +22,7 @@ export default class User extends Equality{
 		this.note = data.note || null;
 		this.voiceChannel = null;
 		this.voiceState = {};
+		this.speaking = false;
 	}
 
 	get createdAt() {

--- a/src/Voice/VoiceConnection.js
+++ b/src/Voice/VoiceConnection.js
@@ -411,7 +411,8 @@ export default class VoiceConnection extends EventEmitter {
 							var channel = user.voiceChannel;
 
 							if (channel){
-								self.client.emit("voiceSpeaking", channel, user, speaking);
+								user.speaking = speaking;
+								self.client.emit("voiceSpeaking", channel, user);
 							} else {
 								self.client.emit("warn", "channel doesn't exist even though SPEAKING expects them to");
 							}

--- a/src/Voice/VoiceConnection.js
+++ b/src/Voice/VoiceConnection.js
@@ -403,6 +403,23 @@ export default class VoiceConnection extends EventEmitter {
 						self.emit("ready", self);
 
 						break;
+					case 5:
+                    	var user = self.server.members.get("id", data.d.user_id);
+
+                    	if (user){
+                    		var speaking = data.d.speaking;
+                    		var channel = user.voiceChannel;
+
+                    		if (channel){
+                    			self.client.emit("voiceSpeaking", channel, user, speaking);
+                    		} else {
+                    			self.client.emit("warn", "channel doesn't exist even though SPEAKING expects them to");
+                    		}
+                    	} else {
+                    		self.client.emit("warn", "user doesn't exist even though SPEAKING expects them to");
+                    	}
+
+                        break;
 				}
 			});
 

--- a/src/Voice/VoiceConnection.js
+++ b/src/Voice/VoiceConnection.js
@@ -231,9 +231,9 @@ export default class VoiceConnection extends EventEmitter {
 			// options is the callback
 			callback = options;
 		}
-        if (typeof options !== "object") {
-            options = {};
-        }
+		if (typeof options !== "object") {
+			options = {};
+		}
 		options.volume = options.volume !== undefined ? options.volume : this.getVolume();
 		return new Promise((resolve, reject) => {
 			this.encoder
@@ -260,9 +260,9 @@ export default class VoiceConnection extends EventEmitter {
 			// options is the callback
 			callback = options;
 		}
-        if (typeof options !== "object") {
-            options = {};
-        }
+		if (typeof options !== "object") {
+			options = {};
+		}
 		options.volume = options.volume !== undefined ? options.volume : this.getVolume();
 		return new Promise((resolve, reject) => {
 			this.encoder
@@ -290,9 +290,9 @@ export default class VoiceConnection extends EventEmitter {
 			// volume is the callback
 			callback = volume;
 		}
-        if (!ffmpegOptions instanceof Array) {
-            ffmpegOptions = [];
-        }
+		if (!ffmpegOptions instanceof Array) {
+			ffmpegOptions = [];
+		}
 		var volume = volume !== undefined ? volume : this.getVolume();
 		return new Promise((resolve, reject) => {
 			this.encoder
@@ -404,22 +404,22 @@ export default class VoiceConnection extends EventEmitter {
 
 						break;
 					case 5:
-                    	var user = self.server.members.get("id", data.d.user_id);
+						var user = self.server.members.get("id", data.d.user_id);
 
-                    	if (user){
-                    		var speaking = data.d.speaking;
-                    		var channel = user.voiceChannel;
+						if (user){
+							var speaking = data.d.speaking;
+							var channel = user.voiceChannel;
 
-                    		if (channel){
-                    			self.client.emit("voiceSpeaking", channel, user, speaking);
-                    		} else {
-                    			self.client.emit("warn", "channel doesn't exist even though SPEAKING expects them to");
-                    		}
-                    	} else {
-                    		self.client.emit("warn", "user doesn't exist even though SPEAKING expects them to");
-                    	}
+							if (channel){
+								self.client.emit("voiceSpeaking", channel, user, speaking);
+							} else {
+								self.client.emit("warn", "channel doesn't exist even though SPEAKING expects them to");
+							}
+						} else {
+							self.client.emit("warn", "user doesn't exist even though SPEAKING expects them to");
+						}
 
-                        break;
+						break;
 				}
 			});
 


### PR DESCRIPTION
This is the first time I've looked through the source of `discord.js`, so forgive me if the pull request contains code that doesn't follow the "rules" of the source. In the voice packet that gets sent over WS, there is a [speaking event](https://discordapp.com/developers/docs/topics/voice-connections#voice-events) that is sent when a user starts or stops speaking. It however was not implemented into `discord.js`, so I took the liberty of trying myself.

If there is anything wrong with the pull request, please feel free to let me know so I may fix said issue.