### PR TITLE
Voice event fixes

### DIFF
--- a/src/Structures/Server.js
+++ b/src/Structures/Server.js
@@ -192,7 +192,7 @@ export default class Server extends Equality {
 		channel.members.add(user);
 		user.voiceChannel = channel;
 
-		if (oldChannel.id) {
+		if (oldChannel.id && channel.name !== oldChannel.name) {
 			this.client.emit("voiceLeave", oldChannel, user);
 			this.client.emit("voiceSwitch", oldChannel, channel, user);
 		}

--- a/src/Structures/Server.js
+++ b/src/Structures/Server.js
@@ -192,7 +192,7 @@ export default class Server extends Equality {
 		channel.members.add(user);
 		user.voiceChannel = channel;
 
-		if (oldChannel.id && channel.name !== oldChannel.name) {
+		if (oldChannel.id && channel.id !== oldChannel.id) {
 			this.client.emit("voiceLeave", oldChannel, user);
 			this.client.emit("voiceSwitch", oldChannel, channel, user);
 		}


### PR DESCRIPTION
I noticed that the voiceSwitch event is sometimes emitted when no user actually did anything. My bot logs all channel switch events and sometimes logged ```user switched to x from x```, so I made a small patch for that.