### PR TITLE
Added end parentheses to shortcut in delete method (Message)

### DIFF
--- a/docs/docs_message.rst
+++ b/docs/docs_message.rst
@@ -107,7 +107,7 @@ Returns the content of the Message.
 delete(`options`, `callback`)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-| **Shortcut of** ``client.deleteMessage(message, options, callback``
+| **Shortcut of** ``client.deleteMessage(message, options, callback)``
 | **See** client.deleteMessage_
 
 update(content, `options`, `callback`)


### PR DESCRIPTION
The shortcut of message.delete example was missing the end parentheses.
See:
| **Shortcut of** ``client.deleteMessage(message, options, callback``
