### PR TITLE
Fixes some bool options

### DIFF
--- a/lib/Client/Client.js
+++ b/lib/Client/Client.js
@@ -71,8 +71,8 @@ var Client = (function (_EventEmitter) {
    * @type {ClientOptions}
    */
 		this.options = options || {};
-		this.options.compress = options.compress || !process.browser;
-		this.options.autoReconnect = options.autoReconnect || true;
+		this.options.compress = options.compress === undefined ? !process.browser : options.compress;
+		this.options.autoReconnect = options.autoReconnect === undefined ? true : options.autoReconnect;
 		this.options.rateLimitAsError = options.rateLimitAsError || false;
 		this.options.largeThreshold = options.largeThreshold || 250;
 		this.options.maxCachedMessages = options.maxCachedMessages || 1000;

--- a/src/Client/Client.js
+++ b/src/Client/Client.js
@@ -44,9 +44,10 @@ export default class Client extends EventEmitter {
 		 * @readonly
 		 * @type {ClientOptions}
 		 */
+		console.log(options.compress, options.autoReconnect, options.rateLimitAsError, options.disableEveryone);
 		this.options = options || {};
-		this.options.compress = options.compress || (!process.browser);
-		this.options.autoReconnect = options.autoReconnect || true;
+		this.options.compress = options.compress === undefined ? !process.browser : options.compress;
+		this.options.autoReconnect = options.autoReconnect === undefined ? true : options.autoReconnect;
 		this.options.rateLimitAsError = options.rateLimitAsError || false;
 		this.options.largeThreshold = options.largeThreshold || 250;
 		this.options.maxCachedMessages = options.maxCachedMessages || 1000;

--- a/src/Client/Client.js
+++ b/src/Client/Client.js
@@ -44,7 +44,6 @@ export default class Client extends EventEmitter {
 		 * @readonly
 		 * @type {ClientOptions}
 		 */
-		console.log(options.compress, options.autoReconnect, options.rateLimitAsError, options.disableEveryone);
 		this.options = options || {};
 		this.options.compress = options.compress === undefined ? !process.browser : options.compress;
 		this.options.autoReconnect = options.autoReconnect === undefined ? true : options.autoReconnect;


### PR DESCRIPTION
Noticed these a while ago. 

The option was always true on these, even if you set them to false in the options. Not sure about the way I'm checking them here, it worked fine for me, but there might be some cleaner way instead of checking if the option is undefined, so giff feedback pls.