### PR TITLE
Indev rewrite - Changed GuildChannel type

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -35,8 +35,9 @@ class GuildChannel extends Channel {
      * The type of the Guild Channel
      * @type {String}
      */
-    //Returns either text, voice, or the id of the channel
-    this.type = data.type == 0 ? 'text' : data.type == 2 ? 'voice' : data.type.toString();
+    if(data.type === 0) this.type = 'text';
+    else if(data.type === 2) this.type = 'voice'
+    else this.type = data.type.toString();
     /**
      * The topic of the Guild Channel, if there is one.
      * @type {?String}

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -35,8 +35,8 @@ class GuildChannel extends Channel {
      * The type of the Guild Channel
      * @type {String}
      */
-    if(data.type === 0) this.type = 'text';
-    else if(data.type === 2) this.type = 'voice'
+    if (data.type === 0) this.type = 'text';
+    else if (data.type === 2) this.type = 'voice';
     else this.type = data.type.toString();
     /**
      * The topic of the Guild Channel, if there is one.

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -36,7 +36,7 @@ class GuildChannel extends Channel {
      * @type {String}
      */
     //Returns either text, voice, or the id of the channel
-    this.type = data.type == '0' ? 'text' : data.type == 2 ? 'voice' : data.type.toString();
+    this.type = data.type == 0 ? 'text' : data.type == 2 ? 'voice' : data.type.toString();
     /**
      * The topic of the Guild Channel, if there is one.
      * @type {?String}

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -33,9 +33,10 @@ class GuildChannel extends Channel {
     super.setup(data);
     /**
      * The type of the Guild Channel
-     * @type {Number}
+     * @type {String}
      */
-    this.type = data.type;
+    //Returns either text, voice, or the id of the channel
+    this.type = data.type == '0' ? 'text' : data.type == 2 ? 'voice' : data.type.toString();
     /**
      * The topic of the Guild Channel, if there is one.
      * @type {?String}


### PR DESCRIPTION
Altered GuildChannel.type to return either 'text', 'voice' or the id of the type (if it does not fit the known types of channel).