### PR TITLE
Fixed user.equals(null)

### DIFF
--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -81,6 +81,7 @@ class User {
    */
   equals(user) {
     let base = (
+      user &&
       this.username === user.username &&
       this.id === user.id &&
       this.discriminator === user.discriminator &&


### PR DESCRIPTION
This fixes `user.equals` when passing `null` or `undefined`.