### PR TITLE
Add loadOfflineUsers option

### DIFF
--- a/src/client/ClientDataManager.js
+++ b/src/client/ClientDataManager.js
@@ -34,11 +34,12 @@ class ClientDataManager {
     return guild;
   }
 
-  newUser(data) {
+  newUser(data, force) {
     if (this.client.users.has(data.id)) {
       return this.client.users.get(data.id);
     }
     const user = new User(this.client, data);
+    user._forced = Boolean(force);
     this.client.users.set(user.id, user);
     return user;
   }
@@ -84,7 +85,7 @@ class ClientDataManager {
   }
 
   killUser(user) {
-    this.users.delete(user.id);
+    this.client.users.delete(user.id);
   }
 
   killChannel(channel) {

--- a/src/client/actions/UserGet.js
+++ b/src/client/actions/UserGet.js
@@ -4,7 +4,7 @@ class UserGetAction extends Action {
 
   handle(data) {
     const client = this.client;
-    const user = client.dataManager.newUser(data);
+    const user = client.dataManager.newUser(data, true);
 
     return {
       user,

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -19,6 +19,7 @@
  *   api_request_method: 'sequential',
  *   shard_id: 0,
  *   shard_count: 0,
+ *   loadOfflineUsers: true,
  * };
  * ```
  * @typedef {Object} ClientOptions
@@ -41,6 +42,7 @@ exports.DefaultOptions = {
   api_request_method: 'sequential',
   shard_id: 0,
   shard_count: 0,
+  loadOfflineUsers: true,
 };
 
 exports.Status = {


### PR DESCRIPTION
When this option is `false`, presence updates will remove the user from the cache if the user is offline and wasn't obtained via `client.fetchUser()`.
If it already isn't cached, it will also prevent the user from being added to the cache.

I also fixed `ClientDataManager.killUser()`.

Investigation into preventing initial loading of offline users is also worth pursuing.