### PR TITLE
Make Collection.find and findAll use .values()

### DIFF
--- a/src/util/Collection.js
+++ b/src/util/Collection.js
@@ -51,7 +51,7 @@ class Collection extends Map {
    */
   deleteAll() {
     const returns = [];
-    for (const item of this.array()) {
+    for (const item of this.values()) {
       if (item.delete) {
         returns.push(item.delete());
       }

--- a/src/util/Collection.js
+++ b/src/util/Collection.js
@@ -78,7 +78,7 @@ class Collection extends Map {
    */
   findAll(key, value) {
     const results = [];
-    for (const item of this.array()) {
+    for (const item of this.values()) {
       if (item[key] === value) {
         results.push(item);
       }
@@ -95,7 +95,7 @@ class Collection extends Map {
    * collection.get('id', '123123...');
    */
   find(key, value) {
-    for (const item of this.array()) {
+    for (const item of this.values()) {
       if (item[key] === value) {
         return item;
       }


### PR DESCRIPTION
This should improve performance of `find()` and `findAll()`, as they are no longer copying the map's values into an array before iterating.
Same goes for `deleteAll()`.