### PR TITLE
Make Collection.deleteAll use .values()

### DIFF
--- a/src/util/Collection.js
+++ b/src/util/Collection.js
@@ -51,7 +51,7 @@ class Collection extends Map {
    */
   deleteAll() {
     const returns = [];
-    for (const item of this.array()) {
+    for (const item of this.values()) {
       if (item.delete) {
         returns.push(item.delete());
       }


### PR DESCRIPTION
This should improve the performance of `deleteAll()`, as it will no longer have to make a copy of the map's values into an array before iterating.