### PR TITLE
Massively improve performance of message caching

### DIFF
--- a/src/structures/interface/TextBasedChannel.js
+++ b/src/structures/interface/TextBasedChannel.js
@@ -166,7 +166,7 @@ class TextBasedChannel {
     }
 
     if (this.messages.size >= maxSize) {
-      this.messages.delete(Array.from(this.messages.keys())[0]);
+      this.messages.delete(this.messages.keys().next().value);
     }
 
     this.messages.set(message.id, message);


### PR DESCRIPTION
Rather than creating an array copied from all of the keys to get the first element, just use the first value of the iterator.
This should drastically reduce both memory and CPU usage when pushing old messages out of the cache.