### PR TITLE
Overhaul channel typing system

### DIFF
--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -18,7 +18,7 @@ class ClientUser extends User {
      */
     this.email = data.email;
 
-    this._typing = {};
+    this._typing = new Map();
   }
 
   /**

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -18,7 +18,7 @@ class ClientUser extends User {
      */
     this.email = data.email;
 
-    this._typing = new Map();
+    this._typing = {};
   }
 
   /**

--- a/src/structures/DMChannel.js
+++ b/src/structures/DMChannel.js
@@ -71,6 +71,14 @@ class DMChannel extends Channel {
     return;
   }
 
+  get typing() {
+    return;
+  }
+
+  get typingCount() {
+    return;
+  }
+
   fetchPinnedMessages() {
     return;
   }

--- a/src/structures/DMChannel.js
+++ b/src/structures/DMChannel.js
@@ -63,7 +63,11 @@ class DMChannel extends Channel {
     return;
   }
 
-  setTyping() {
+  startTyping() {
+    return;
+  }
+
+  stopTyping() {
     return;
   }
 

--- a/src/structures/GroupDMChannel.js
+++ b/src/structures/GroupDMChannel.js
@@ -140,7 +140,11 @@ class GroupDMChannel extends Channel {
     return;
   }
 
-  setTyping() {
+  startTyping() {
+    return;
+  }
+
+  stopTyping() {
     return;
   }
 

--- a/src/structures/GroupDMChannel.js
+++ b/src/structures/GroupDMChannel.js
@@ -148,6 +148,14 @@ class GroupDMChannel extends Channel {
     return;
   }
 
+  get typing() {
+    return;
+  }
+
+  get typingCount() {
+    return;
+  }
+
   fetchPinnedMessages() {
     return;
   }

--- a/src/structures/TextChannel.js
+++ b/src/structures/TextChannel.js
@@ -56,6 +56,14 @@ class TextChannel extends GuildChannel {
     return;
   }
 
+  get typing() {
+    return;
+  }
+
+  get typingCount() {
+    return;
+  }
+
   fetchPinnedMessages() {
     return;
   }

--- a/src/structures/TextChannel.js
+++ b/src/structures/TextChannel.js
@@ -48,7 +48,11 @@ class TextChannel extends GuildChannel {
     return;
   }
 
-  setTyping() {
+  startTyping() {
+    return;
+  }
+
+  stopTyping() {
     return;
   }
 

--- a/src/structures/interface/TextBasedChannel.js
+++ b/src/structures/interface/TextBasedChannel.js
@@ -311,10 +311,10 @@ class TextBasedChannel {
   }
 
   /**
-   * Checks whether or not the typing indicator is being shown in the channel.
-   * @returns {Boolean}
+   * Whether or not the typing indicator is being shown in the channel.
+   * @type {Boolean}
    */
-  isTyping() {
+  get typing() {
     return Boolean(this.client.user._typing[this.id]);
   }
 

--- a/src/structures/interface/TextBasedChannel.js
+++ b/src/structures/interface/TextBasedChannel.js
@@ -264,6 +264,7 @@ class TextBasedChannel {
    * channel.startTyping();
    */
   startTyping(count) {
+    if (count < 0) throw new RangeError('count must be at least 1');
     if (!this.client.user._typing[this.id]) {
       this.client.user._typing[this.id] = {
         count: count || 1,

--- a/src/structures/interface/TextBasedChannel.js
+++ b/src/structures/interface/TextBasedChannel.js
@@ -283,7 +283,7 @@ class TextBasedChannel {
    * Stops the typing indicator in the channel.
    * The indicator will only stop if this is called as many times as startTyping().
    * <info>It can take a few seconds for the Client User to stop typing.</info>
-   * @param {Boolean} [force] whether or not to force the indicator to stop regardless of call count
+   * @param {Boolean} [force=false] whether or not to force the indicator to stop regardless of call count
    * @returns {null}
    * @example
    * // stop typing in a channel
@@ -292,7 +292,7 @@ class TextBasedChannel {
    * // force typing to fully stop in a channel
    * channel.stopTyping(true);
    */
-  stopTyping(force) {
+  stopTyping(force = false) {
     if (this.client.user._typing.has(this.id)) {
       const entry = this.client.user._typing.get(this.id);
       entry.count--;

--- a/src/structures/interface/TextBasedChannel.js
+++ b/src/structures/interface/TextBasedChannel.js
@@ -302,10 +302,10 @@ class TextBasedChannel {
   }
 
   /**
-   * Gets the number of times `startTyping` has been called.
-   * @returns {Number}
+   * Number of times `startTyping` has been called.
+   * @type {Number}
    */
-  getTypingCount() {
+  get typingCount() {
     if (this.client.user._typing[this.id]) return this.client.user._typing[this.id].count;
     return 0;
   }

--- a/src/structures/interface/TextBasedChannel.js
+++ b/src/structures/interface/TextBasedChannel.js
@@ -264,7 +264,7 @@ class TextBasedChannel {
    * channel.startTyping();
    */
   startTyping(count) {
-    if (count < 0) throw new RangeError('count must be at least 1');
+    if (typeof count !== 'undefined' && count < 1) throw new RangeError('count must be at least 1');
     if (!this.client.user._typing[this.id]) {
       this.client.user._typing[this.id] = {
         count: count || 1,

--- a/src/structures/interface/TextBasedChannel.js
+++ b/src/structures/interface/TextBasedChannel.js
@@ -399,7 +399,7 @@ class TextBasedChannel {
 }
 
 function applyProp(structure, prop) {
-  structure.prototype[prop] = TextBasedChannel.prototype[prop];
+  Object.defineProperty(structure.prototype, prop, Object.getOwnPropertyDescriptor(TextBasedChannel.prototype, prop));
 }
 
 exports.applyToClass = (structure, full = false) => {

--- a/src/structures/interface/TextBasedChannel.js
+++ b/src/structures/interface/TextBasedChannel.js
@@ -302,6 +302,15 @@ class TextBasedChannel {
   }
 
   /**
+   * Gets the number of times `startTyping` has been called.
+   * @returns {Number}
+   */
+  getTypingCount() {
+    if (this.client.user._typing[this.id]) return this.client.user._typing[this.id].count;
+    return 0;
+  }
+
+  /**
    * Checks whether or not the typing indicator is being shown in the channel.
    * @returns {Boolean}
    */

--- a/src/structures/interface/TextBasedChannel.js
+++ b/src/structures/interface/TextBasedChannel.js
@@ -300,6 +300,14 @@ class TextBasedChannel {
   }
 
   /**
+   * Checks whether or not the typing indicator is being shown in the channel.
+   * @returns {Boolean}
+   */
+  isTyping() {
+    return Boolean(this.client.user._typing[this.id]);
+  }
+
+  /**
    * Creates a Message Collector
    * @param {CollectorFilterFunction} filter the filter to create the collector with
    * @param {CollectorOptions} [options={}] the options to pass to the collector

--- a/src/structures/interface/TextBasedChannel.js
+++ b/src/structures/interface/TextBasedChannel.js
@@ -268,7 +268,7 @@ class TextBasedChannel {
         count: 1,
         interval: this.client.setInterval(() => {
           this.client.rest.methods.sendTyping(this.id);
-        }, 4000)
+        }, 4000),
       };
       this.client.rest.methods.sendTyping(this.id);
     } else {

--- a/src/structures/interface/TextBasedChannel.js
+++ b/src/structures/interface/TextBasedChannel.js
@@ -257,22 +257,23 @@ class TextBasedChannel {
 
   /**
    * Starts a typing indicator in the channel.
+   * @param {Number} [count] The number of times startTyping should be considered to have been called
    * @returns {null}
    * @example
    * // start typing in a channel
    * channel.startTyping();
    */
-  startTyping() {
+  startTyping(count) {
     if (!this.client.user._typing[this.id]) {
       this.client.user._typing[this.id] = {
-        count: 1,
+        count: count || 1,
         interval: this.client.setInterval(() => {
           this.client.rest.methods.sendTyping(this.id);
         }, 4000),
       };
       this.client.rest.methods.sendTyping(this.id);
     } else {
-      this.client.user._typing[this.id].count++;
+      this.client.user._typing[this.id].count = count || this.client.user._typing[this.id].count + 1;
     }
   }
 


### PR DESCRIPTION
This replaces the `channel.setTyping()` method with `channel.startTyping()` and `channel.stopTyping()`.
Each time `startTyping` is called, an internal counter is incremented.
Each time `stopTyping` is called, the counter is decremented.
If the counter is at 0 or less, the typing indicator is finally stopped.
Alternatively, the indicator can be fully reset by using `stopTyping(true)`.

This allows long-running commands in bots to set the typing status without cancelling each others' status if one finishes before the other.