### PR TITLE
Replace {null} in JSDocs with {void}

### DIFF
--- a/src/client/ClientManager.js
+++ b/src/client/ClientManager.js
@@ -24,7 +24,7 @@ class ClientManager {
    * @param {String} token the authorization token
    * @param {Function} resolve function to run when connection is successful
    * @param {Function} reject function to run when connection fails
-   * @returns {null}
+   * @returns {void}
    */
   connectToWebSocket(token, resolve, reject) {
     this.client.token = token;
@@ -41,7 +41,7 @@ class ClientManager {
   /**
    * Sets up a keep-alive interval to keep the Client's connection valid
    * @param {Number} time the interval in milliseconds at which heartbeat packets should be sent
-   * @returns {null}
+   * @returns {void}
    */
   setupKeepAlive(time) {
     this.heartbeatInterval = this.client.setInterval(() => {

--- a/src/client/voice/ClientVoiceManager.js
+++ b/src/client/voice/ClientVoiceManager.js
@@ -99,7 +99,7 @@ class ClientVoiceManager {
   /**
    * Sets up a request to join a voice channel
    * @param {VoiceChannel} channel the voice channel to join
-   * @returns {null}
+   * @returns {void}
    */
   joinChannel(channel) {
     return new Promise((resolve, reject) => {

--- a/src/client/voice/VoiceConnection.js
+++ b/src/client/voice/VoiceConnection.js
@@ -66,7 +66,7 @@ class VoiceConnection extends EventEmitter {
    * Executed whenever an error occurs with the UDP/WebSocket sub-client
    * @private
    * @param {Error} error
-   * @returns {null}
+   * @returns {void}
    */
   _onError(e) {
     this._reject(e);
@@ -82,7 +82,7 @@ class VoiceConnection extends EventEmitter {
   /**
    * Disconnects the Client from the Voice Channel
    * @param {string} [reason='user requested'] the reason of the disconnection
-   * @returns {null}
+   * @returns {void}
    */
   disconnect(reason = 'user requested') {
     this.manager.client.ws.send({
@@ -122,7 +122,7 @@ class VoiceConnection extends EventEmitter {
 
   /**
    * Binds listeners to the WebSocket and UDP sub-clients
-   * @returns {null}
+   * @returns {void}
    * @private
    */
   bindListeners() {

--- a/src/client/voice/dispatcher/StreamDispatcher.js
+++ b/src/client/voice/dispatcher/StreamDispatcher.js
@@ -172,7 +172,7 @@ class StreamDispatcher extends EventEmitter {
 
   /**
    * Stops the current stream permanently and emits an `end` event.
-   * @returns {null}
+   * @returns {void}
    */
   end() {
     this._triggerTerminalState('end', 'user requested');
@@ -180,7 +180,7 @@ class StreamDispatcher extends EventEmitter {
 
   /**
    * Stops sending voice packets to the voice connection (stream may still progress however)
-   * @returns {null}
+   * @returns {void}
    */
   pause() {
     this._pause(true);
@@ -188,7 +188,7 @@ class StreamDispatcher extends EventEmitter {
 
   /**
    * Resumes sending voice packets to the voice connection (may be further on in the stream than when paused)
-   * @returns {null}
+   * @returns {void}
    */
   resume() {
     this._pause(false);

--- a/src/client/websocket/WebSocketManager.js
+++ b/src/client/websocket/WebSocketManager.js
@@ -49,7 +49,7 @@ class WebSocketManager {
   /**
    * Connects the client to a given gateway
    * @param {String} gateway the gateway to connect to
-   * @returns {null}
+   * @returns {void}
    */
   connect(gateway) {
     this.status = Constants.Status.CONNECTING;
@@ -69,7 +69,7 @@ class WebSocketManager {
   /**
    * Sends a packet to the gateway
    * @param {Object} packet An object that can be JSON stringified
-   * @returns {null}
+   * @returns {void}
    */
   send(data) {
     this._queue.push(JSON.stringify(data));
@@ -100,7 +100,7 @@ class WebSocketManager {
 
   /**
    * Run whenever the gateway connections opens up
-   * @returns {null}
+   * @returns {void}
    */
   eventOpen() {
     if (this.reconnecting) {
@@ -112,7 +112,7 @@ class WebSocketManager {
 
   /**
    * Sends a gatway resume packet, in cases of unexpected disconnections.
-   * @returns {null}
+   * @returns {void}
    */
   _sendResume() {
     const payload = {
@@ -129,7 +129,7 @@ class WebSocketManager {
 
   /**
    * Sends a new identification packet, in cases of new connections or failed reconnections.
-   * @returns {null}
+   * @returns {void}
    */
   _sendNewIdentify() {
     this.reconnecting = false;
@@ -147,7 +147,7 @@ class WebSocketManager {
 
   /**
    * Run whenever the connection to the gateway is closed, it will try to reconnect the client.
-   * @returns {null}
+   * @returns {void}
    */
   eventClose(event) {
     if (event.code === 4004) {
@@ -188,7 +188,7 @@ class WebSocketManager {
 
   /**
    * Run whenever an error occurs with the WebSocket connection. Tries to reconnect
-   * @returns {null}
+   * @returns {void}
    */
   eventError(e) {
     /**
@@ -214,7 +214,7 @@ class WebSocketManager {
   /**
    * Runs on new packets before `READY` to see if the Client is ready yet, if it is prepares
    * the `READY` event.
-   * @returns {null}
+   * @returns {void}
    */
   checkIfReady() {
     if (this.status !== Constants.Status.READY && this.status !== Constants.Status.NEARLY) {
@@ -238,7 +238,7 @@ class WebSocketManager {
 
   /**
    * Tries to reconnect the client, changing the status to Constants.Status.RECONNECTING.
-   * @returns {null}
+   * @returns {void}
    */
   tryReconnect() {
     this.status = Constants.Status.RECONNECTING;

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -229,7 +229,7 @@ class Guild {
   /**
    * Sets up the Guild
    * @param {any} data
-   * @returns {null}
+   * @returns {void}
    * @private
    */
   setup(data) {

--- a/src/structures/VoiceChannel.js
+++ b/src/structures/VoiceChannel.js
@@ -59,7 +59,7 @@ class VoiceChannel extends GuildChannel {
 
   /**
    * Leaves this voice channel
-   * @returns {null}
+   * @returns {void}
    * @example
    * // leave a voice channel
    * voiceChannel.leave();

--- a/src/structures/interface/TextBasedChannel.js
+++ b/src/structures/interface/TextBasedChannel.js
@@ -258,7 +258,7 @@ class TextBasedChannel {
   /**
    * Starts a typing indicator in the channel.
    * @param {Number} [count] The number of times startTyping should be considered to have been called
-   * @returns {null}
+   * @returns {void}
    * @example
    * // start typing in a channel
    * channel.startTyping();
@@ -284,7 +284,7 @@ class TextBasedChannel {
    * The indicator will only stop if this is called as many times as startTyping().
    * <info>It can take a few seconds for the Client User to stop typing.</info>
    * @param {Boolean} [force=false] whether or not to force the indicator to stop regardless of call count
-   * @returns {null}
+   * @returns {void}
    * @example
    * // stop typing in a channel
    * channel.stopTyping();


### PR DESCRIPTION
These functions are not returning `null`. They are returning nothing, so `{void}` is more appropriate.