### PR TITLE
Make JSDocs follow general conventions

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -67,22 +67,22 @@ class Client extends EventEmitter {
     this.voice = new ClientVoiceManager(this);
     /**
      * A Collection of the Client's stored users
-     * @type {Collection<String, User>}
+     * @type {Collection<string, User>}
      */
     this.users = new Collection();
     /**
      * A Collection of the Client's stored guilds
-     * @type {Collection<String, Guild>}
+     * @type {Collection<string, Guild>}
      */
     this.guilds = new Collection();
     /**
      * A Collection of the Client's stored channels
-     * @type {Collection<String, Channel>}
+     * @type {Collection<string, Channel>}
      */
     this.channels = new Collection();
     /**
      * The authorization token for the logged in user/bot.
-     * @type {?String}
+     * @type {?string}
      */
     this.token = null;
     /**
@@ -92,17 +92,17 @@ class Client extends EventEmitter {
     this.user = null;
     /**
      * The email, if there is one, for the logged in Client
-     * @type {?String}
+     * @type {?string}
      */
     this.email = null;
     /**
      * The password, if there is one, for the logged in Client
-     * @type {?String}
+     * @type {?string}
      */
     this.password = null;
     /**
      * The time in milliseconds the Client connected
-     * @type {?Number}
+     * @type {?number}
      */
     this.readyTime = null;
     this._intervals = [];
@@ -114,10 +114,10 @@ class Client extends EventEmitter {
    * much better to use a bot account rather than a user account.
    * Bot accounts have higher rate limits and have access to some features user accounts don't have. User bots
    * that are making a lot of API requests can even be banned.</warn>
-   * @param  {String} emailOrToken The email or token used for the account. If it is an email, a password _must_ be
+   * @param  {string} emailOrToken The email or token used for the account. If it is an email, a password _must_ be
    * provided.
-   * @param  {String} [password] The password for the account, only needed if an email was provided.
-   * @return {Promise<String>}
+   * @param  {string} [password] The password for the account, only needed if an email was provided.
+   * @return {Promise<string>}
    * @example
    * // log the client in using a token
    * const token = 'my token';
@@ -176,7 +176,7 @@ class Client extends EventEmitter {
   /**
    * Caches a user, or obtains it from the cache if it's already cached.
    * If the user isn't already cached, it will only be obtainable by OAuth bot accounts.
-   * @param {String} id The ID of the user to obtain
+   * @param {string} id The ID of the user to obtain
    * @return {Promise<User>}
    */
   fetchUser(id) {
@@ -187,7 +187,7 @@ class Client extends EventEmitter {
   /**
    * Returns a Collection, mapping Guild ID to Voice Connections.
    * @readonly
-   * @type {Collection<String, VoiceConnection>}
+   * @type {Collection<string, VoiceConnection>}
    */
   get voiceConnections() {
     return this.voice.connections;
@@ -196,7 +196,7 @@ class Client extends EventEmitter {
   /**
    * The uptime for the logged in Client.
    * @readonly
-   * @type {?Number}
+   * @type {?number}
    */
   get uptime() {
     return this.readyTime ? Date.now() - this.readyTime : null;

--- a/src/client/ClientDataResolver.js
+++ b/src/client/ClientDataResolver.js
@@ -156,7 +156,7 @@ class ClientDataResolver {
 
   /**
    * Resolves a StringResolvable to a String
-   * @param {stringResolvable} stringResolvable the string resolvable to resolve
+   * @param {StringResolvable} StringResolvable the string resolvable to resolve
    * @returns {string}
    */
   resolveString(data) {

--- a/src/client/ClientDataResolver.js
+++ b/src/client/ClientDataResolver.js
@@ -106,13 +106,13 @@ class ClientDataResolver {
    * Data that resolves to give a Base64 string, typically for image uploading. This can be:
    * * A Buffer
    * * A Base64 String
-   * @typedef {Buffer|String} Base64Resolvable
+   * @typedef {Buffer|string} Base64Resolvable
    */
 
   /**
    * Resolves a Base64Resolvable to a Base 64 image
    * @param {Base64Resolvable} dataResolvable the base 64 resolvable you want to resolve
-   * @returns {?String}
+   * @returns {?string}
    */
   resolveBase64(data) {
     if (data instanceof Buffer) {
@@ -126,7 +126,7 @@ class ClientDataResolver {
    * Data that can be resolved to give a Channel. This can be:
    * * An instance of a Channel
    * * An ID of a Channel
-   * @typedef {Channel|String} ChannelResolvable
+   * @typedef {Channel|string} ChannelResolvable
    */
 
   /**
@@ -151,13 +151,13 @@ class ClientDataResolver {
    * * A String
    * * An Array (joined with a new line delimiter to give a string)
    * * Any object
-   * @typedef {String|Array|Object} StringResolvable
+   * @typedef {string|Array|Object} StringResolvable
    */
 
   /**
    * Resolves a StringResolvable to a String
-   * @param {StringResolvable} stringResolvable the string resolvable to resolve
-   * @returns {String}
+   * @param {stringResolvable} stringResolvable the string resolvable to resolve
+   * @returns {string}
    */
   resolveString(data) {
     if (data instanceof String) {
@@ -176,13 +176,13 @@ class ClientDataResolver {
    * * A Buffer
    * * The path to a local file
    * * An URL
-   * @typedef {String|Buffer} FileResolvable
+   * @typedef {string|Buffer} FileResolvable
    */
 
   /**
    * Resolves a FileResolvable to a Buffer
    * @param {FileResolvable} fileResolvable the file resolvable to resolve
-   * @returns {String|Buffer}
+   * @returns {string|Buffer}
    */
   resolveFile(resource) {
     if ($string(resource)) {

--- a/src/client/ClientManager.js
+++ b/src/client/ClientManager.js
@@ -14,17 +14,17 @@ class ClientManager {
     this.client = client;
     /**
      * The heartbeat interval, null if not yet set
-     * @type {?Number}
+     * @type {?number}
      */
     this.heartbeatInterval = null;
   }
 
   /**
    * Connects the Client to the WebSocket
-   * @param {String} token the authorization token
+   * @param {string} token the authorization token
    * @param {Function} resolve function to run when connection is successful
    * @param {Function} reject function to run when connection fails
-   * @returns {null}
+   * @returns {void}
    */
   connectToWebSocket(token, resolve, reject) {
     this.client.token = token;
@@ -40,8 +40,8 @@ class ClientManager {
 
   /**
    * Sets up a keep-alive interval to keep the Client's connection valid
-   * @param {Number} time the interval in milliseconds at which heartbeat packets should be sent
-   * @returns {null}
+   * @param {number} time the interval in milliseconds at which heartbeat packets should be sent
+   * @returns {void}
    */
   setupKeepAlive(time) {
     this.heartbeatInterval = this.client.setInterval(() => {

--- a/src/client/ClientManager.js
+++ b/src/client/ClientManager.js
@@ -22,8 +22,8 @@ class ClientManager {
   /**
    * Connects the Client to the WebSocket
    * @param {string} token the authorization token
-   * @param {Function} resolve function to run when connection is successful
-   * @param {Function} reject function to run when connection fails
+   * @param {function} resolve function to run when connection is successful
+   * @param {function} reject function to run when connection fails
    * @returns {void}
    */
   connectToWebSocket(token, resolve, reject) {

--- a/src/client/rest/RequestHandlers/RequestHandler.js
+++ b/src/client/rest/RequestHandlers/RequestHandler.js
@@ -19,7 +19,7 @@ class RequestHandler {
 
   /**
    * Whether or not the client is being rate limited on every endpoint.
-   * @type {Boolean}
+   * @type {boolean}
    */
   get globalLimit() {
     return this.restManager.globallyRateLimited;

--- a/src/client/rest/RequestHandlers/Sequential.js
+++ b/src/client/rest/RequestHandlers/Sequential.js
@@ -14,20 +14,20 @@ class SequentialRequestHandler extends RequestHandler {
 
     /**
      * Whether this rate limiter is waiting for a response from a request
-     * @type {Boolean}
+     * @type {boolean}
      */
     this.waiting = false;
 
     /**
      * The endpoint that this handler is handling
-     * @type {String}
+     * @type {string}
      */
     this.endpoint = endpoint;
 
     /**
      * The time difference between Discord's Dates and the local computer's Dates. A positive number means the local
      * computer's time is ahead of Discord's.
-     * @type {Number}
+     * @type {number}
      */
     this.timeDifference = 0;
   }

--- a/src/client/voice/ClientVoiceManager.js
+++ b/src/client/voice/ClientVoiceManager.js
@@ -16,12 +16,12 @@ class ClientVoiceManager {
     this.client = client;
     /**
      * A collection mapping connection IDs to the Connection objects
-     * @type {Collection<String, VoiceConnection>}
+     * @type {Collection<string, VoiceConnection>}
      */
     this.connections = new Collection();
     /**
      * Pending connection attempts, maps Guild ID to VoiceChannel
-     * @type {Collection<String, VoiceChannel>}
+     * @type {Collection<string, VoiceChannel>}
      */
     this.pending = new Collection();
   }
@@ -29,7 +29,7 @@ class ClientVoiceManager {
   /**
    * Checks whether a pending request can be processed
    * @private
-   * @param {String} guildID The ID of the Guild
+   * @param {string} guildID The ID of the Guild
    */
   _checkPendingReady(guildID) {
     const pendingRequest = this.pending.get(guildID);
@@ -49,9 +49,9 @@ class ClientVoiceManager {
 
   /**
    * Called when the Client receives information about this voice server update.
-   * @param {String} guildID the ID of the Guild
-   * @param {String} token the token to authorise with
-   * @param {String} endpoint the endpoint to connect to
+   * @param {string} guildID the ID of the Guild
+   * @param {string} token the token to authorise with
+   * @param {string} endpoint the endpoint to connect to
    */
   _receivedVoiceServer(guildID, token, endpoint) {
     const pendingRequest = this.pending.get(guildID);
@@ -66,8 +66,8 @@ class ClientVoiceManager {
 
   /**
    * Called when the Client receives information about the voice state update.
-   * @param {String} guildID the ID of the Guild
-   * @param {String} sessionID the session id to authorise with
+   * @param {string} guildID the ID of the Guild
+   * @param {string} sessionID the session id to authorise with
    */
   _receivedVoiceStateUpdate(guildID, sessionID) {
     const pendingRequest = this.pending.get(guildID);
@@ -99,7 +99,7 @@ class ClientVoiceManager {
   /**
    * Sets up a request to join a voice channel
    * @param {VoiceChannel} channel the voice channel to join
-   * @returns {null}
+   * @returns {void}
    */
   joinChannel(channel) {
     return new Promise((resolve, reject) => {

--- a/src/client/voice/VoiceConnection.js
+++ b/src/client/voice/VoiceConnection.js
@@ -25,7 +25,7 @@ class VoiceConnection extends EventEmitter {
     this.player = new DefaultPlayer(this);
     /**
      * The endpoint of the connection
-     * @type {String}
+     * @type {string}
      */
     this.endpoint = endpoint;
     /**
@@ -41,7 +41,7 @@ class VoiceConnection extends EventEmitter {
     this.websocket = new VoiceConnectionWebSocket(this, channel.guild.id, token, sessionID, endpoint);
     /**
      * Whether or not the connection is ready
-     * @type {Boolean}
+     * @type {boolean}
      */
     this.ready = false;
     /**
@@ -66,7 +66,7 @@ class VoiceConnection extends EventEmitter {
    * Executed whenever an error occurs with the UDP/WebSocket sub-client
    * @private
    * @param {Error} error
-   * @returns {null}
+   * @returns {void}
    */
   _onError(e) {
     this._reject(e);
@@ -82,7 +82,7 @@ class VoiceConnection extends EventEmitter {
   /**
    * Disconnects the Client from the Voice Channel
    * @param {string} [reason='user requested'] the reason of the disconnection
-   * @returns {null}
+   * @returns {void}
    */
   disconnect(reason = 'user requested') {
     this.manager.client.ws.send({
@@ -122,7 +122,7 @@ class VoiceConnection extends EventEmitter {
 
   /**
    * Binds listeners to the WebSocket and UDP sub-clients
-   * @returns {null}
+   * @returns {void}
    * @private
    */
   bindListeners() {
@@ -195,7 +195,7 @@ class VoiceConnection extends EventEmitter {
        * Emitted whenever a user starts/stops speaking
        * @event VoiceConnection#speaking
        * @param {User} user the user that has started/stopped speaking
-       * @param {Boolean} speaking whether or not the user is speaking
+       * @param {boolean} speaking whether or not the user is speaking
        */
       if (this.ready) {
         this.emit('speaking', user, data.speaking);
@@ -208,7 +208,7 @@ class VoiceConnection extends EventEmitter {
 
   /**
    * Play the given file in the voice connection
-   * @param {String} filepath the path to the file
+   * @param {string} filepath the path to the file
    * @returns {StreamDispatcher}
    * @example
    * // play files natively

--- a/src/client/voice/VoiceConnection.js
+++ b/src/client/voice/VoiceConnection.js
@@ -46,13 +46,13 @@ class VoiceConnection extends EventEmitter {
     this.ready = false;
     /**
      * The resolve function for the promise associated with creating this connection
-     * @type {Function}
+     * @type {function}
      * @private
      */
     this._resolve = resolve;
     /**
      * The reject function for the promise associated with creating this connection
-     * @type {Function}
+     * @type {function}
      * @private
      */
     this._reject = reject;

--- a/src/client/voice/dispatcher/StreamDispatcher.js
+++ b/src/client/voice/dispatcher/StreamDispatcher.js
@@ -26,7 +26,7 @@ class StreamDispatcher extends EventEmitter {
   /**
   * Emitted when the dispatcher starts/stops speaking
   * @event StreamDispatcher#speaking
-  * @param {Boolean} value whether or not the dispatcher is speaking
+  * @param {boolean} value whether or not the dispatcher is speaking
   */
   _setSpeaking(value) {
     this.speaking = value;
@@ -129,7 +129,7 @@ class StreamDispatcher extends EventEmitter {
     /**
     * Emitted when the stream wants to give debug information.
     * @event StreamDispatcher#debug
-    * @param {String} information the debug information
+    * @param {string} information the debug information
     */
     this.emit('debug', `triggered terminal state ${state} - stream is now dead`);
     this._triggered = true;
@@ -172,7 +172,7 @@ class StreamDispatcher extends EventEmitter {
 
   /**
    * Stops the current stream permanently and emits an `end` event.
-   * @returns {null}
+   * @returns {void}
    */
   end() {
     this._triggerTerminalState('end', 'user requested');
@@ -180,7 +180,7 @@ class StreamDispatcher extends EventEmitter {
 
   /**
    * Stops sending voice packets to the voice connection (stream may still progress however)
-   * @returns {null}
+   * @returns {void}
    */
   pause() {
     this._pause(true);
@@ -188,7 +188,7 @@ class StreamDispatcher extends EventEmitter {
 
   /**
    * Resumes sending voice packets to the voice connection (may be further on in the stream than when paused)
-   * @returns {null}
+   * @returns {void}
    */
   resume() {
     this._pause(false);

--- a/src/client/voice/receiver/VoiceReceiver.js
+++ b/src/client/voice/receiver/VoiceReceiver.js
@@ -89,7 +89,7 @@ class VoiceReceiver extends EventEmitter {
       /**
        * Emitted whenever a voice packet cannot be decrypted
        * @event VoiceReceiver#warn
-       * @param {String} message the warning message
+       * @param {string} message the warning message
        */
       return this.emit('warn', 'failed to decrypt voice packet');
     }

--- a/src/client/websocket/WebSocketManager.js
+++ b/src/client/websocket/WebSocketManager.js
@@ -23,33 +23,33 @@ class WebSocketManager {
     this.packetManager = new PacketManager(this);
     /**
      * The status of the WebSocketManager, a type of Constants.Status. It defaults to IDLE.
-     * @type {Number}
+     * @type {number}
      */
     this.status = Constants.Status.IDLE;
 
     /**
      * The session ID of the connection, null if not yet available.
-     * @type {?String}
+     * @type {?string}
      */
     this.sessionID = null;
 
     /**
      * The packet count of the client, null if not yet available.
-     * @type {?Number}
+     * @type {?number}
      */
     this.sequence = -1;
 
     /**
      * The gateway address for this WebSocket connection, null if not yet available.
-     * @type {?String}
+     * @type {?string}
      */
     this.gateway = null;
   }
 
   /**
    * Connects the client to a given gateway
-   * @param {String} gateway the gateway to connect to
-   * @returns {null}
+   * @param {string} gateway the gateway to connect to
+   * @returns {void}
    */
   connect(gateway) {
     this.status = Constants.Status.CONNECTING;
@@ -69,7 +69,7 @@ class WebSocketManager {
   /**
    * Sends a packet to the gateway
    * @param {Object} packet An object that can be JSON stringified
-   * @returns {null}
+   * @returns {void}
    */
   send(data) {
     this._queue.push(JSON.stringify(data));
@@ -100,7 +100,7 @@ class WebSocketManager {
 
   /**
    * Run whenever the gateway connections opens up
-   * @returns {null}
+   * @returns {void}
    */
   eventOpen() {
     if (this.reconnecting) {
@@ -112,7 +112,7 @@ class WebSocketManager {
 
   /**
    * Sends a gatway resume packet, in cases of unexpected disconnections.
-   * @returns {null}
+   * @returns {void}
    */
   _sendResume() {
     const payload = {
@@ -129,7 +129,7 @@ class WebSocketManager {
 
   /**
    * Sends a new identification packet, in cases of new connections or failed reconnections.
-   * @returns {null}
+   * @returns {void}
    */
   _sendNewIdentify() {
     this.reconnecting = false;
@@ -147,7 +147,7 @@ class WebSocketManager {
 
   /**
    * Run whenever the connection to the gateway is closed, it will try to reconnect the client.
-   * @returns {null}
+   * @returns {void}
    */
   eventClose(event) {
     if (event.code === 4004) {
@@ -162,7 +162,7 @@ class WebSocketManager {
    * Run whenever a message is received from the WebSocket. Returns `true` if the message
    * was handled properly.
    * @param {Object} data the received websocket data
-   * @returns {Boolean}
+   * @returns {boolean}
    */
   eventMessage($event) {
     let packet;
@@ -188,7 +188,7 @@ class WebSocketManager {
 
   /**
    * Run whenever an error occurs with the WebSocket connection. Tries to reconnect
-   * @returns {null}
+   * @returns {void}
    */
   eventError(e) {
     /**
@@ -214,7 +214,7 @@ class WebSocketManager {
   /**
    * Runs on new packets before `READY` to see if the Client is ready yet, if it is prepares
    * the `READY` event.
-   * @returns {null}
+   * @returns {void}
    */
   checkIfReady() {
     if (this.status !== Constants.Status.READY && this.status !== Constants.Status.NEARLY) {
@@ -238,7 +238,7 @@ class WebSocketManager {
 
   /**
    * Tries to reconnect the client, changing the status to Constants.Status.RECONNECTING.
-   * @returns {null}
+   * @returns {void}
    */
   tryReconnect() {
     this.status = Constants.Status.RECONNECTING;

--- a/src/client/websocket/packets/handlers/MessageDeleteBulk.js
+++ b/src/client/websocket/packets/handlers/MessageDeleteBulk.js
@@ -15,7 +15,7 @@ class MessageDeleteBulkHandler extends AbstractHandler {
 * Emitted whenever a messages are deleted in bulk
 *
 * @event Client#messageDeleteBulk
-* @param {Collection<String, Message>} messages The deleted messages, mapped by their ID
+* @param {Collection<string, Message>} messages The deleted messages, mapped by their ID
 */
 
 module.exports = MessageDeleteBulkHandler;

--- a/src/structures/Channel.js
+++ b/src/structures/Channel.js
@@ -19,7 +19,7 @@ class Channel {
      * * `group` - a Group DM channel
      * * `text` - a guild text channel
      * * `voice` - a guild voice channel
-     * @type {String}
+     * @type {string}
      */
     this.type = null;
     if (data) {
@@ -30,7 +30,7 @@ class Channel {
   setup(data) {
     /**
      * The unique ID of the channel
-     * @type {String}
+     * @type {string}
      */
     this.id = data.id;
   }

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -9,12 +9,12 @@ class ClientUser extends User {
     super.setup(data);
     /**
      * Whether or not this account has been verified
-     * @type {Boolean}
+     * @type {boolean}
      */
     this.verified = data.verified;
     /**
      * The email of this account
-     * @type {String}
+     * @type {string}
      */
     this.email = data.email;
 
@@ -25,7 +25,7 @@ class ClientUser extends User {
    * Set the username of the logged in Client.
    * <info>Changing usernames in Discord is heavily rate limited, with only 2 requests
    * every hour. Use this sparingly!</info>
-   * @param {String} username the new username
+   * @param {string} username the new username
    * @returns {Promise<ClientUser>}
    * @example
    * // set username
@@ -40,7 +40,7 @@ class ClientUser extends User {
   /**
    * If this user is a "self bot" or logged in using a normal user's details (which should be avoided), you can set the
    * email here.
-   * @param {String} email the new email
+   * @param {string} email the new email
    * @returns {Promise<ClientUser>}
    * @example
    * // set email
@@ -55,7 +55,7 @@ class ClientUser extends User {
   /**
    * If this user is a "self bot" or logged in using a normal user's details (which should be avoided), you can set the
    * password here.
-   * @param {String} password the new password
+   * @param {string} password the new password
    * @returns {Promise<ClientUser>}
    * @example
    * // set password
@@ -83,8 +83,8 @@ class ClientUser extends User {
 
   /**
    * Set the status and playing game of the logged in client.
-   * @param {String} [status] the status, can be `online` or `idle`.
-   * @param {String|Object} [game] the game that is being played
+   * @param {string} [status] the status, can be `online` or `idle`.
+   * @param {string|Object} [game] the game that is being played
    * @returns {Promise<ClientUser, Error>}
    * @example
    * // set status

--- a/src/structures/DMChannel.js
+++ b/src/structures/DMChannel.js
@@ -24,7 +24,7 @@ class DMChannel extends Channel {
     this.recipient = recipient;
     /**
      * The ID of the last sent message, if available
-     * @type {?String}
+     * @type {?string}
      */
     this.lastMessageID = data.last_message_id;
     this.type = 'dm';
@@ -33,7 +33,7 @@ class DMChannel extends Channel {
   /**
    * When concatenated with a String, this automatically concatenates the recipient's mention instead of the
    * DM channel object.
-   * @returns {String}
+   * @returns {string}
    */
   toString() {
     return this.recipient.toString();

--- a/src/structures/Emoji.js
+++ b/src/structures/Emoji.js
@@ -22,30 +22,30 @@ class Emoji {
   setup(data) {
     /**
      * The ID of the Emoji
-     * @type {String}
+     * @type {string}
      */
     this.id = data.id;
     /**
      * The name of the Emoji
-     * @type {String}
+     * @type {string}
      */
     this.name = data.name;
     this.roleIDS = data.roles;
     /**
      * Whether or not this emoji requires colons surrounding it
-     * @type {Boolean}
+     * @type {boolean}
      */
     this.requiresColons = data.require_colons;
     /**
      * Whether this emoji is managed by an external service
-     * @type {Boolean}
+     * @type {boolean}
      */
     this.managed = data.managed;
   }
 
   /**
    * A collection of roles this emoji is active for (empty if all). Mapped by role ID.
-   * @type {Collection<String, Role>}
+   * @type {Collection<string, Role>}
    * @readonly
    */
   get roles() {
@@ -60,7 +60,7 @@ class Emoji {
 
   /**
    * The URL to the emoji file
-   * @type {String}
+   * @type {string}
    * @readonly
    */
   get url() {
@@ -69,7 +69,7 @@ class Emoji {
 
   /**
    * When concatenated with a String, this automatically returns the emoji mention rather than the object.
-   * @returns {String}
+   * @returns {string}
    * @example
    * // send an emoji:
    * const emoji = guild.emojis.array()[0];

--- a/src/structures/EvaluatedPermissions.js
+++ b/src/structures/EvaluatedPermissions.js
@@ -13,7 +13,7 @@ class EvaluatedPermissions {
     /**
      * A number representing the packed permissions.
      * @private
-     * @type {Number}
+     * @type {number}
      */
     this.permissions = permissions;
   }
@@ -21,7 +21,7 @@ class EvaluatedPermissions {
   /**
    * Get an object mapping permission name, e.g. `READ_MESSAGES` to a boolean - whether the user
    * can perform this or not.
-   * @returns {Object<String, Boolean>}
+   * @returns {Object<string, boolean>}
    */
   serialize() {
     const serializedPermissions = {};
@@ -34,9 +34,9 @@ class EvaluatedPermissions {
 
   /**
    * Checks whether a user has a certain permission, e.g. `READ_MESSAGES`.
-   * @param {String} permission the permission to check for
-   * @param {Boolean} [explicit=false] whether the user should explicitly have the permission.
-   * @returns {Boolean}
+   * @param {string} permission the permission to check for
+   * @param {boolean} [explicit=false] whether the user should explicitly have the permission.
+   * @returns {boolean}
    */
   hasPermission(permission, explicit = false) {
     if (permission instanceof String || typeof permission === 'string') {

--- a/src/structures/GroupDMChannel.js
+++ b/src/structures/GroupDMChannel.js
@@ -77,7 +77,7 @@ class GroupDMChannel extends Channel {
     if (!this.recipients) {
       /**
        * A collection of the recipients of this DM, mapped by their ID.
-       * @type {Collection<String, User>}
+       * @type {Collection<string, User>}
        */
       this.recipients = new Collection();
     }
@@ -90,22 +90,22 @@ class GroupDMChannel extends Channel {
     }
     /**
      * The name of this Group DM, can be null if one isn't set.
-     * @type {String}
+     * @type {string}
      */
     this.name = data.name;
     /**
      * The ID of this Group DM Channel.
-     * @type {String}
+     * @type {string}
      */
     this.id = data.id;
     /**
      * A hash of the Group DM icon.
-     * @type {String}
+     * @type {string}
      */
     this.icon = data.icon;
     /**
      * The ID of the last message in the channel, if one was sent.
-     * @type {?String}
+     * @type {?string}
      */
     this.lastMessageID = data.last_message_id;
     /**

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -34,19 +34,19 @@ class Guild {
 
     /**
      * A Collection of members that are in this Guild. The key is the member's ID, the value is the member.
-     * @type {Collection<String, GuildMember>}
+     * @type {Collection<string, GuildMember>}
      */
     this.members = new Collection();
 
     /**
      * A Collection of channels that are in this Guild. The key is the channel's ID, the value is the channel.
-     * @type {Collection<String, GuildChannel>}
+     * @type {Collection<string, GuildChannel>}
      */
     this.channels = new Collection();
 
     /**
      * A Collection of roles that are in this Guild. The key is the role's ID, the value is the role.
-     * @type {Collection<String, Role>}
+     * @type {Collection<string, Role>}
      */
     this.roles = new Collection();
 
@@ -57,12 +57,12 @@ class Guild {
     if (data.unavailable) {
       /**
        * Whether the Guild is available to access. If it is not available, it indicates a server outage.
-       * @type {Boolean}
+       * @type {boolean}
        */
       this.available = false;
       /**
        * The Unique ID of the Guild, useful for comparisons.
-       * @type {String}
+       * @type {string}
        */
       this.id = data.id;
     } else {
@@ -152,7 +152,7 @@ class Guild {
 
   /**
    * When concatenated with a String, this automatically concatenates the Guild's name instead of the Guild object.
-   * @returns {String}
+   * @returns {string}
    * @example
    * // logs: Hello from My Guild!
    * console.log(`Hello from ${guild}!`);
@@ -181,7 +181,7 @@ class Guild {
    * it is advisable to just compare `guild.id === guild2.id` as it is much faster and is often
    * what most users need.
    * @param {Guild} guild the guild to compare
-   * @returns {Boolean}
+   * @returns {boolean}
    */
   equals(data) {
     let base =
@@ -220,7 +220,7 @@ class Guild {
        * Emitted once a Guild Member starts/stops speaking
        * @event Client#guildMemberSpeaking
        * @param {GuildMember} member the member that started/stopped speaking
-       * @param {Boolean} speaking whether or not the member is speaking
+       * @param {boolean} speaking whether or not the member is speaking
        */
       this.client.emit(Constants.Events.GUILD_MEMBER_SPEAKING, member, speaking);
     }
@@ -228,8 +228,8 @@ class Guild {
 
   /**
    * Sets up the Guild
-   * @param {any} data
-   * @returns {null}
+   * @param {*} data
+   * @returns {void}
    * @private
    */
   setup(data) {
@@ -237,33 +237,33 @@ class Guild {
     this.available = !data.unavailable;
     /**
      * The hash of the guild splash image, or null if no splash (VIP only)
-     * @type {?String}
+     * @type {?string}
      */
     this.splash = data.splash;
     /**
      * The region the guild is located in
-     * @type {String}
+     * @type {string}
      */
     this.region = data.region;
     /**
      * The name of the guild
-     * @type {String}
+     * @type {string}
      */
     this.name = data.name;
     /**
      * The full amount of members in this Guild as of `READY`
-     * @type {Number}
+     * @type {number}
      */
     this.memberCount = data.member_count;
     /**
      * Whether the guild is "large" (has more than 250 members)
-     * @type {Boolean}
+     * @type {boolean}
      */
     this.large = data.large;
     this._joinDate = new Date(data.joined_at).getTime();
     /**
      * The hash of the guild icon, or null if there is no icon.
-     * @type {?String}
+     * @type {?string}
      */
     this.icon = data.icon;
     /**
@@ -281,22 +281,22 @@ class Guild {
     }
     /**
      * The time in seconds before a user is counted as "away from keyboard".
-     * @type {?Number}
+     * @type {?number}
      */
     this.afkTimeout = data.afk_timeout;
     /**
      * The ID of the voice channel where AFK members are moved.
-     * @type {?String}
+     * @type {?string}
      */
     this.afkChannelID = data.afk_channel_id;
     /**
      * Whether embedded images are enabled on this guild.
-     * @type {Boolean}
+     * @type {boolean}
      */
     this.embedEnabled = data.embed_enabled;
     /**
      * The verification level of the guild.
-     * @type {Number}
+     * @type {number}
      */
     this.verificationLevel = data.verification_level;
     this.features = data.features || [];
@@ -365,8 +365,8 @@ class Guild {
 
   /**
    * Creates a new Channel in the Guild.
-   * @param {String} name the name of the new channel.
-   * @param {String} type the type of the new channel, either `text` or `voice`.
+   * @param {string} name the name of the new channel.
+   * @param {string} type the type of the new channel, either `text` or `voice`.
    * @returns {Promise<TextChannel|VoiceChannel, Error>}
    * @example
    * // create a new text channel
@@ -436,7 +436,7 @@ class Guild {
 
   /**
    * Edit the name of the Guild.
-   * @param {String} name the new name of the Guild.
+   * @param {string} name the new name of the Guild.
    * @returns {Promise<Guild, Error>}
    * @example
    * // edit the guild name
@@ -492,7 +492,7 @@ class Guild {
 
   /**
    * Edit the AFK timeout of the Guild.
-   * @param {Number} afkTimeout the time in seconds that a user must be idle to be considered AFK.
+   * @param {number} afkTimeout the time in seconds that a user must be idle to be considered AFK.
    * @returns {Promise<Guild, Error>}
    * @example
    * // edit the guild AFK channel
@@ -562,7 +562,7 @@ class Guild {
 
   /**
    * Fetch a Collection of banned users in this Guild.
-   * @returns {Promise<Collection<String, User>, Error>}
+   * @returns {Promise<Collection<string, User>, Error>}
    */
   fetchBans() {
     return this.client.rest.methods.getGuildBans(this);
@@ -570,7 +570,7 @@ class Guild {
 
   /**
    * Fetch a Collection of invites to this Guild. Resolves with a Collection mapping invites by their codes.
-   * @returns {Promise<Collection<String, Invite>, Error>}
+   * @returns {Promise<Collection<string, Invite>, Error>}
    */
   fetchInvites() {
     return this.client.rest.methods.getGuildInvites(this);
@@ -579,7 +579,7 @@ class Guild {
   /**
    * Fetches all the members in the Guild, even if they are offline. If the Guild has less than 250 members,
    * this should not be necessary.
-   * @param {String} [query=''] An optional query to provide when fetching members
+   * @param {string} [query=''] An optional query to provide when fetching members
    * @returns {Promise<Guild, Error>}
    */
   fetchMembers(query = '') {
@@ -606,7 +606,7 @@ class Guild {
 
   /**
    * Gets the URL to this guild's icon (if it has one, otherwise it returns null)
-   * @type {?String}
+   * @type {?string}
    * @readonly
    */
   get iconURL() {

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -33,23 +33,23 @@ class GuildChannel extends Channel {
     super.setup(data);
     /**
      * The topic of the Guild Channel, if there is one.
-     * @type {?String}
+     * @type {?string}
      */
     this.topic = data.topic;
     /**
      * The position of the channel in the list.
-     * @type {Number}
+     * @type {number}
      */
     this.position = data.position;
     /**
      * The name of the Guild Channel
-     * @type {String}
+     * @type {string}
      */
     this.name = data.name;
     this.ow = data.permission_overwrites;
     /**
      * A map of permission overwrites in this channel for roles and users.
-     * @type {Collection<String, PermissionOverwrites>}
+     * @type {Collection<string, PermissionOverwrites>}
      */
     this.permissionOverwrites = new Collection();
     if (data.permission_overwrites) {
@@ -63,7 +63,7 @@ class GuildChannel extends Channel {
    * Checks if this channel has the same type, topic, position, name, overwrites and ID as another channel.
    * In most cases, a simple `channel.id === channel2.id` will do, and is much faster too.
    * @param {GuildChannel} channel the channel to compare this channel to
-   * @returns {Boolean}
+   * @returns {boolean}
    */
   equals(other) {
     let base = (
@@ -222,7 +222,7 @@ class GuildChannel extends Channel {
 
   /**
    * Set a new name for the Guild Channel
-   * @param {String} name the new name for the guild channel
+   * @param {string} name the new name for the guild channel
    * @returns {Promise<GuildChannel>}
    * @example
    * // set a new channel name
@@ -236,7 +236,7 @@ class GuildChannel extends Channel {
 
   /**
    * Set a new position for the Guild Channel
-   * @param {Number} position the new position for the guild channel
+   * @param {number} position the new position for the guild channel
    * @returns {Promise<GuildChannel>}
    * @example
    * // set a new channel position
@@ -250,7 +250,7 @@ class GuildChannel extends Channel {
 
   /**
    * Set a new topic for the Guild Channel
-   * @param {String} topic the new topic for the guild channel
+   * @param {string} topic the new topic for the guild channel
    * @returns {Promise<GuildChannel>}
    * @example
    * // set a new channel topic
@@ -264,7 +264,7 @@ class GuildChannel extends Channel {
 
   /**
    * When concatenated with a String, this automatically returns the Channel's mention instead of the Channel object.
-   * @returns {String}
+   * @returns {string}
    * @example
    * // Outputs: Hello from #general
    * console.log(`Hello from ${channel}`);

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -31,43 +31,43 @@ class GuildMember {
     this.user = data.user;
     /**
      * Whether this member is deafened server-wide
-     * @type {Boolean}
+     * @type {boolean}
      */
     this.serverDeaf = data.deaf;
     /**
      * Whether this member is muted server-wide
-     * @type {Boolean}
+     * @type {boolean}
      */
     this.serverMute = data.mute;
     /**
      * Whether this member is self-muted
-     * @type {Boolean}
+     * @type {boolean}
      */
     this.selfMute = data.self_mute;
     /**
      * Whether this member is self-deafened
-     * @type {Boolean}
+     * @type {boolean}
      */
     this.selfDeaf = data.self_deaf;
     /**
      * The voice session ID of this member, if any
-     * @type {?String}
+     * @type {?string}
      */
     this.voiceSessionID = data.session_id;
     /**
      * The voice channel ID of this member, if any
-     * @type {?String}
+     * @type {?string}
      */
     this.voiceChannelID = data.channel_id;
     this._joinDate = new Date(data.joined_at).getTime();
     /**
      * Whether this meember is speaking
-     * @type {?Boolean}
+     * @type {?boolean}
      */
     this.speaking = this.speaking;
     /**
      * The nickname of this Guild Member, if they have one
-     * @type {?String}
+     * @type {?string}
      */
     this.nickname = data.nick;
     this._roles = data.roles;
@@ -106,7 +106,7 @@ class GuildMember {
 
   /**
    * Whether this member is muted in any way
-   * @type {Boolean}
+   * @type {boolean}
    * @readonly
    */
   get mute() {
@@ -115,7 +115,7 @@ class GuildMember {
 
   /**
    * Whether this member is deafened in any way
-   * @type {Boolean}
+   * @type {boolean}
    * @readonly
    */
   get deaf() {
@@ -133,7 +133,7 @@ class GuildMember {
 
   /**
    * The ID of this User
-   * @type {String}
+   * @type {string}
    * @readonly
    */
   get id() {
@@ -142,7 +142,7 @@ class GuildMember {
 
   /**
    * Mute/unmute a user
-   * @param {Boolean} mute whether or not the member should be muted
+   * @param {boolean} mute whether or not the member should be muted
    * @returns {Promise<GuildMember, Error>}
    */
   setMute(mute) {
@@ -151,7 +151,7 @@ class GuildMember {
 
   /**
    * Deafen/undeafen a user
-   * @param {Boolean} deaf whether or not the member should be deafened
+   * @param {boolean} deaf whether or not the member should be deafened
    * @returns {Promise<GuildMember, Error>}
    */
   setDeaf(deaf) {
@@ -169,7 +169,7 @@ class GuildMember {
 
   /**
    * Sets the Roles applied to the member.
-   * @param {Collection<String, Role>|Array<Role>} roles the roles to apply
+   * @param {Collection<string, Role>|Array<Role>} roles the roles to apply
    * @returns {Promise<GuildMember, Error>}
    */
   setRoles(roles) {
@@ -178,7 +178,7 @@ class GuildMember {
 
   /**
    * Set the nickname for the Guild Member
-   * @param {String} nick the nickname for the Guild Member
+   * @param {string} nick the nickname for the Guild Member
    * @returns {Promise<GuildMember, Error>}
    */
   setNickname(nick) {

--- a/src/structures/Invite.js
+++ b/src/structures/Invite.js
@@ -38,32 +38,32 @@ class Invite {
   setup(data) {
     /**
      * The maximum age of the invite, in seconds
-     * @type {?Number}
+     * @type {?number}
      */
     this.maxAge = data.max_age;
 
     /**
      * The code for this invite
-     * @type {String}
+     * @type {string}
      */
     this.code = data.code;
     this._creationDate = new Date(data.created_at).getTime();
 
     /**
      * Whether or not this invite is temporary
-     * @type {Boolean}
+     * @type {boolean}
      */
     this.temporary = data.temporary;
 
     /**
      * How many times this invite has been used
-     * @type {Number}
+     * @type {number}
      */
     this.uses = data.uses;
 
     /**
      * The maximum uses of this invite
-     * @type {Number}
+     * @type {number}
      */
     this.maxUses = data.max_uses;
 

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -34,7 +34,7 @@ class Message {
   setup(data) {
     /**
      * Whether or not this message is pinned
-     * @type {Boolean}
+     * @type {boolean}
      */
     this.pinned = data.pinned;
     /**
@@ -52,19 +52,19 @@ class Message {
     }
     /**
      * The content of the message
-     * @type {String}
+     * @type {string}
      */
     this.content = data.content;
     this._timestamp = new Date(data.timestamp).getTime();
     this._editedTimestamp = data.edited_timestamp ? new Date(data.edited_timestamp).getTime() : null;
     /**
      * Whether or not the message was Text-To-Speech
-     * @type {Boolean}
+     * @type {boolean}
      */
     this.tts = data.tts;
     /**
      * A random number used for checking message delivery
-     * @type {String}
+     * @type {string}
      */
     this.nonce = data.nonce;
     /**
@@ -74,7 +74,7 @@ class Message {
     this.embeds = data.embeds.map(e => new Embed(this, e));
     /**
      * A collection of attachments in the message - e.g. Pictures - mapped by their ID.
-     * @type {Collection<String, MessageAttachment>}
+     * @type {Collection<string, MessageAttachment>}
      */
     this.attachments = new Collection();
     for (const attachment of data.attachments) {
@@ -83,11 +83,11 @@ class Message {
     /**
      * An object containing a further users, roles or channels collections
      * @type {Object}
-     * @property {Collection<String, User>} mentions.users Mentioned users, maps their ID to the user object.
-     * @property {Collection<String, Role>} mentions.roles Mentioned roles, maps their ID to the role object.
-     * @property {Collection<String, GuildChannel>}
+     * @property {Collection<string, User>} mentions.users Mentioned users, maps their ID to the user object.
+     * @property {Collection<string, Role>} mentions.roles Mentioned roles, maps their ID to the role object.
+     * @property {Collection<string, GuildChannel>}
      * mentions.channels Mentioned channels, maps their ID to the channel object.
-     * @property {Boolean} mentions.everyone whether or not @everyone was mentioned.
+     * @property {boolean} mentions.everyone whether or not @everyone was mentioned.
      */
     this.mentions = {
       users: new Collection(),
@@ -97,7 +97,7 @@ class Message {
     };
     /**
      * The ID of the message (unique in the channel it was sent)
-     * @type {String}
+     * @type {string}
      */
     this.id = data.id;
 
@@ -132,7 +132,7 @@ class Message {
 
     /**
      * Whether or not this message was sent by Discord, not actually a user (e.g. pin notifications)
-     * @type {Boolean}
+     * @type {boolean}
      */
     this.system = false;
     if (data.type === 6) {
@@ -234,7 +234,7 @@ class Message {
    * method allows you to see if there are differences in content, embeds, attachments, nonce and tts properties.
    * @param {Message} message The message to compare it to
    * @param {Object} rawData Raw data passed through the WebSocket about this message
-   * @returns {Boolean}
+   * @returns {boolean}
    */
   equals(message, rawData) {
     const embedUpdate = !message.author && !message.attachments;
@@ -263,7 +263,7 @@ class Message {
 
   /**
    * Deletes the message
-   * @param {Number} [timeout=0] How long to wait to delete the message in milliseconds
+   * @param {number} [timeout=0] How long to wait to delete the message in milliseconds
    * @returns {Promise<Message, Error>}
    * @example
    * // delete a message
@@ -283,7 +283,7 @@ class Message {
 
   /**
    * Edit the content of a message
-   * @param {String} content the new content of a message
+   * @param {string} content the new content of a message
    * @returns {Promise<Message, Error>}
    * @example
    * // update the content of a message
@@ -297,7 +297,7 @@ class Message {
 
   /**
    * Reply to a message
-   * @param {String} content the content of the message
+   * @param {string} content the content of the message
    * @param {MessageOptions} [options = {}] the options to provide
    * @returns {Promise<Message, Error>}
    * @example

--- a/src/structures/MessageAttachment.js
+++ b/src/structures/MessageAttachment.js
@@ -19,37 +19,37 @@ class MessageAttachment {
   setup(data) {
     /**
      * The ID of this attachment
-     * @type {String}
+     * @type {string}
      */
     this.id = data.id;
     /**
      * The file name of this attachment
-     * @type {String}
+     * @type {string}
      */
     this.filename = data.filename;
     /**
      * The size of this attachment in bytes
-     * @type {Number}
+     * @type {number}
      */
     this.filesize = data.size;
     /**
      * The URL to this attachment
-     * @type {String}
+     * @type {string}
      */
     this.url = data.url;
     /**
      * The Proxy URL to this attachment
-     * @type {String}
+     * @type {string}
      */
     this.proxyURL = data.url;
     /**
      * The height of this attachment (if an image)
-     * @type {?Number}
+     * @type {?number}
      */
     this.height = data.height;
     /**
      * The width of this attachment (if an image)
-     * @type {?Number}
+     * @type {?number}
      */
     this.width = data.width;
   }

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -14,22 +14,22 @@ class MessageEmbedThumbnail {
   setup(data) {
     /**
      * The URL for this thumbnail
-     * @type {String}
+     * @type {string}
      */
     this.url = data.url;
     /**
      * The Proxy URL for this thumbnail
-     * @type {String}
+     * @type {string}
      */
     this.proxyURL = data.proxy_url;
     /**
      * The height of the thumbnail
-     * @type {Number}
+     * @type {number}
      */
     this.height = data.height;
     /**
      * The width of the thumbnail
-     * @type {Number}
+     * @type {number}
      */
     this.width = data.width;
   }
@@ -51,12 +51,12 @@ class MessageEmbedProvider {
   setup(data) {
     /**
      * The name of this provider
-     * @type {String}
+     * @type {string}
      */
     this.name = data.name;
     /**
      * The URL of this provider
-     * @type {String}
+     * @type {string}
      */
     this.url = data.url;
   }
@@ -83,22 +83,22 @@ class MessageEmbed {
   setup(data) {
     /**
      * The title of this embed, if there is one
-     * @type {?String}
+     * @type {?string}
      */
     this.title = data.title;
     /**
      * The type of this embed
-     * @type {String}
+     * @type {string}
      */
     this.type = data.type;
     /**
      * The description of this embed, if there is one
-     * @type {?String}
+     * @type {?string}
      */
     this.description = data.description;
     /**
      * The URL of this embed
-     * @type {String}
+     * @type {string}
      */
     this.url = data.url;
     if (data.thumbnail) {

--- a/src/structures/PartialGuild.js
+++ b/src/structures/PartialGuild.js
@@ -21,22 +21,22 @@ class PartialGuild {
   setup(data) {
     /**
      * The hash of the guild splash image, or null if no splash (VIP only)
-     * @type {?String}
+     * @type {?string}
      */
     this.splash = data.splash;
     /**
      * The ID of this guild
-     * @type {String}
+     * @type {string}
      */
     this.id = data.id;
     /**
      * The hash of this guild's icon, or null if there is none.
-     * @type {?String}
+     * @type {?string}
      */
     this.icon = data.icon;
     /**
      * The name of this guild
-     * @type {String}
+     * @type {string}
      */
     this.name = data.name;
   }

--- a/src/structures/PartialGuildChannel.js
+++ b/src/structures/PartialGuildChannel.js
@@ -20,17 +20,17 @@ class PartialGuildChannel {
   setup(data) {
     /**
      * The ID of this Guild Channel
-     * @type {String}
+     * @type {string}
      */
     this.id = data.id;
     /**
      * The name of this Guild Channel
-     * @type {String}
+     * @type {string}
      */
     this.name = data.name;
     /**
      * The type of this Guild Channel - `text` or `voice`
-     * @type {String}
+     * @type {string}
      */
     this.type = Constants.ChannelTypes.text === data.type ? 'text' : 'voice';
   }

--- a/src/structures/PermissionOverwrites.js
+++ b/src/structures/PermissionOverwrites.js
@@ -16,12 +16,12 @@ class PermissionOverwrites {
   setup(data) {
     /**
      * The type of this overwrite
-     * @type {String}
+     * @type {string}
      */
     this.type = data.type;
     /**
      * The ID of this overwrite, either a User ID or a Role ID
-     * @type {String}
+     * @type {string}
      */
     this.id = data.id;
     this.denyData = data.deny;

--- a/src/structures/Role.js
+++ b/src/structures/Role.js
@@ -36,37 +36,37 @@ class Role {
   setup(data) {
     /**
      * The ID of the role (unique to the guild it is part of)
-     * @type {String}
+     * @type {string}
      */
     this.id = data.id;
     /**
      * The name of the role
-     * @type {String}
+     * @type {string}
      */
     this.name = data.name;
     /**
      * The base 10 color of the role
-     * @type {Number}
+     * @type {number}
      */
     this.color = data.color;
     /**
      * If true, users that are part of this role will appear in a separate category in the users list
-     * @type {Boolean}
+     * @type {boolean}
      */
     this.hoist = data.hoist;
     /**
      * The position of the role in the role manager
-     * @type {Number}
+     * @type {number}
      */
     this.position = data.position;
     /**
      * The evaluated permissions number
-     * @type {Number}
+     * @type {number}
      */
     this.permissions = data.permissions;
     /**
      * Whether or not the role is managed by an external service
-     * @type {Boolean}
+     * @type {boolean}
      */
     this.managed = data.managed;
   }
@@ -100,7 +100,7 @@ class Role {
 
   /**
    * Set a new name for the role
-   * @param {String} name the new name of the role
+   * @param {string} name the new name of the role
    * @returns {Promise<Role, Error>}
    * @example
    * // set the name of the role
@@ -114,7 +114,7 @@ class Role {
 
   /**
    * Set a new color for the role
-   * @param {Number|String} color the new color for the role, either a hex string or a base 10 number
+   * @param {number|string} color the new color for the role, either a hex string or a base 10 number
    * @returns {Promise<Role, Error>}
    * @example
    * // set the color of a role
@@ -128,7 +128,7 @@ class Role {
 
   /**
    * Set whether or not the role should be hoisted
-   * @param {Boolean} hoist whether or not to hoist the role
+   * @param {boolean} hoist whether or not to hoist the role
    * @returns {Promise<Role, Error>}
    * @example
    * // set the hoist of the role
@@ -142,7 +142,7 @@ class Role {
 
   /**
    * Set the position of the role
-   * @param {Number} position the position of the role
+   * @param {number} position the position of the role
    * @returns {Promise<Role, Error>}
    * @example
    * // set the position of the role
@@ -156,7 +156,7 @@ class Role {
 
   /**
    * Set the permissions of the role
-   * @param {Array<String>} permissions the permissions of the role
+   * @param {Array<string>} permissions the permissions of the role
    * @returns {Promise<Role, Error>}
    * @example
    * // set the permissions of the role
@@ -170,7 +170,7 @@ class Role {
 
   /**
    * Get an object mapping permission names to whether or not the role enables that permission
-   * @returns {Object<String, Boolean>}
+   * @returns {Object<string, boolean>}
    * @example
    * // print the serialized role
    * console.log(role.serialize());
@@ -186,9 +186,9 @@ class Role {
 
   /**
    * Whether or not the role includes the given permission
-   * @param {String} permission the name of the permission to test
-   * @param {Boolean} [explicit=false] whether or not the inclusion of the permission is explicit
-   * @returns {Boolean}
+   * @param {string} permission the name of the permission to test
+   * @param {boolean} [explicit=false] whether or not the inclusion of the permission is explicit
+   * @returns {boolean}
    * @example
    * // see if a role can ban a member
    * if (role.hasPermission('BAN_MEMBERS')) {
@@ -217,7 +217,7 @@ class Role {
 
   /**
    * When concatenated with a String, this automatically concatenates the Role mention rather than the Role object.
-   * @returns {String}
+   * @returns {string}
    */
   toString() {
     return `<@&${this.id}>`;
@@ -225,7 +225,7 @@ class Role {
 
   /**
    * The hexadecimal version of the role color, with a leading hashtag.
-   * @type {String}
+   * @type {string}
    * @readonly
    */
   get hexColor() {

--- a/src/structures/TextChannel.js
+++ b/src/structures/TextChannel.js
@@ -18,7 +18,7 @@ class TextChannel extends GuildChannel {
     super.setup(data);
     /**
      * The ID of the last message in the channel, if one was sent.
-     * @type {?String}
+     * @type {?string}
      */
     this.lastMessageID = data.last_message_id;
     this.type = 'text';

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -16,27 +16,27 @@ class User {
   setup(data) {
     /**
      * The username of the User
-     * @type {String}
+     * @type {string}
      */
     this.username = data.username;
     /**
      * The ID of the User
-     * @type {String}
+     * @type {string}
      */
     this.id = data.id;
     /**
      * A discriminator based on username for the User
-     * @type {String}
+     * @type {string}
      */
     this.discriminator = data.discriminator;
     /**
      * The ID of the user's avatar
-     * @type {String}
+     * @type {string}
      */
     this.avatar = data.avatar;
     /**
      * Whether or not the User is a Bot.
-     * @type {Boolean}
+     * @type {boolean}
      */
     this.bot = Boolean(data.bot);
     /**
@@ -45,19 +45,19 @@ class User {
      * * **`online`** - user is online
      * * **`offline`** - user is offline
      * * **`idle`** - user is AFK
-     * @type {String}
+     * @type {string}
      */
     this.status = data.status || this.status || 'offline';
     /**
      * The game that the user is playing, `null` if they aren't playing a game.
-     * @type {String}
+     * @type {string}
      */
     this.game = data.game || this.game;
   }
 
   /**
    * When concatenated with a String, this automatically concatenates the User's mention instead of the User object.
-   * @returns {String}
+   * @returns {string}
    * @example
    * // logs: Hello from <@123456789>!
    * console.log(`Hello from ${user}!`);
@@ -68,7 +68,7 @@ class User {
 
   /**
    * A link to the user's avatar (if they have one, otherwise null)
-   * @type {?String}
+   * @type {?string}
    * @readonly
    */
   get avatarURL() {
@@ -90,7 +90,7 @@ class User {
    * Checks if the user is equal to another. It compares username, ID, discriminator, status and the game being played.
    * It is recommended to compare equality by using `user.id === user2.id` unless you want to compare all properties.
    * @param {User} user the user to compare
-   * @returns {Boolean}
+   * @returns {boolean}
    */
   equals(user) {
     let base = (

--- a/src/structures/VoiceChannel.js
+++ b/src/structures/VoiceChannel.js
@@ -10,7 +10,7 @@ class VoiceChannel extends GuildChannel {
     super(guild, data);
     /**
      * The members in this Voice Channel.
-     * @type {Collection<String, GuildMember>}
+     * @type {Collection<string, GuildMember>}
      */
     this.members = new Collection();
   }
@@ -19,12 +19,12 @@ class VoiceChannel extends GuildChannel {
     super.setup(data);
     /**
      * The bitrate of this voice channel
-     * @type {Number}
+     * @type {number}
      */
     this.bitrate = data.bitrate;
     /**
      * The maximum amount of users allowed in this channel - 0 means unlimited.
-     * @type {Number}
+     * @type {number}
      */
     this.userLimit = data.user_limit;
     this.type = 'voice';
@@ -32,7 +32,7 @@ class VoiceChannel extends GuildChannel {
 
   /**
    * Sets the bitrate of the channel
-   * @param {Number} bitrate the new bitrate
+   * @param {number} bitrate the new bitrate
    * @returns {Promise<VoiceChannel>}
    * @example
    * // set the bitrate of a voice channel
@@ -59,7 +59,7 @@ class VoiceChannel extends GuildChannel {
 
   /**
    * Leaves this voice channel
-   * @returns {null}
+   * @returns {void}
    * @example
    * // leave a voice channel
    * voiceChannel.leave();

--- a/src/structures/interface/TextBasedChannel.js
+++ b/src/structures/interface/TextBasedChannel.js
@@ -52,14 +52,14 @@ class MessageCollector extends EventEmitter {
     this.options = options;
     /**
      * Whether this collector has stopped collecting Messages.
-     * @type {Boolean}
+     * @type {boolean}
      */
     this.ended = false;
     this.listener = (message => this.verify(message));
     this.channel.client.on('message', this.listener);
     /**
      * A collection of collected messages, mapped by message ID.
-     * @type {Collection<String, Message>}
+     * @type {Collection<string, Message>}
      */
     this.collected = new Collection();
     if (options.time) {
@@ -71,7 +71,7 @@ class MessageCollector extends EventEmitter {
    * Verifies a message against the filter and options
    * @private
    * @param {Message} message
-   * @returns {Boolean}
+   * @returns {boolean}
    */
   verify(message) {
     if (this.channel ? this.channel.id !== message.channel.id : false) {
@@ -109,10 +109,10 @@ class MessageCollector extends EventEmitter {
     this.channel.client.removeListener('message', this.listener);
     /**
      * Emitted when the Collector stops collecting.
-     * @param {Collection<String, Message>} collection A collection of messages collected
+     * @param {Collection<string, Message>} collection A collection of messages collected
      * during the lifetime of the Collector.
      * Mapped by the ID of the Messages.
-     * @param {String} reason The reason for the end of the collector. If it ended because it reached the specified time
+     * @param {string} reason The reason for the end of the collector. If it ended because it reached the specified time
      * limit, this would be `time`. If you invoke `.stop()` without specifying a reason, this would be `user`. If it
      * ended because it reached its message limit, it will be `limit`.
      * @event MessageCollector#end
@@ -130,15 +130,15 @@ class TextBasedChannel {
   constructor() {
     /**
      * A Collection containing the messages sent to this channel.
-     * @type {Collection<String, Message>}
+     * @type {Collection<string, Message>}
      */
     this.messages = new Collection();
   }
 
   /**
    * Bulk delete a given Collection or Array of messages in one go. Returns the deleted messages after.
-   * @param {Map<String, Message>|Array<Message>} messages the messages to delete
-   * @returns {Collection<String, Message>}
+   * @param {Map<string, Message>|Array<Message>} messages the messages to delete
+   * @returns {Collection<string, Message>}
    */
   bulkDelete(messages) {
     if (messages instanceof Map) {
@@ -162,7 +162,7 @@ class TextBasedChannel {
    */
   /**
    * Send a message to this channel
-   * @param {String} content the content to send
+   * @param {string} content the content to send
    * @param {MessageOptions} [options={}] the options to provide
    * @returns {Promise<Message>}
    * @example
@@ -176,7 +176,7 @@ class TextBasedChannel {
   }
   /**
    * Send a text-to-speech message to this channel
-   * @param {String} content the content to send
+   * @param {string} content the content to send
    * @param {MessageOptions} [options={}] the options to provide
    * @returns {Promise<Message>}
    * @example
@@ -191,7 +191,7 @@ class TextBasedChannel {
   /**
    * Send a file to this channel
    * @param {FileResolvable} attachment The file to send
-   * @param {String} [fileName="file.jpg"] The name and extension of the file
+   * @param {string} [fileName="file.jpg"] The name and extension of the file
    * @returns {Promise<Message>}
    */
   sendFile(attachment, fileName) {
@@ -232,7 +232,7 @@ class TextBasedChannel {
   /**
    * Gets the past messages sent in this channel. Resolves with a Collection mapping message ID's to Message objects.
    * @param {ChannelLogsQueryOptions} [options={}] the query parameters to pass in
-   * @returns {Promise<Collection<String, Message>, Error>}
+   * @returns {Promise<Collection<string, Message>, Error>}
    * @example
    * // get messages
    * channel.fetchMessages({limit: 10})
@@ -257,8 +257,8 @@ class TextBasedChannel {
 
   /**
    * Starts a typing indicator in the channel.
-   * @param {Number} [count] The number of times startTyping should be considered to have been called
-   * @returns {null}
+   * @param {number} [count] The number of times startTyping should be considered to have been called
+   * @returns {void}
    * @example
    * // start typing in a channel
    * channel.startTyping();
@@ -283,8 +283,8 @@ class TextBasedChannel {
    * Stops the typing indicator in the channel.
    * The indicator will only stop if this is called as many times as startTyping().
    * <info>It can take a few seconds for the Client User to stop typing.</info>
-   * @param {Boolean} [force=false] whether or not to force the indicator to stop regardless of call count
-   * @returns {null}
+   * @param {boolean} [force=false] whether or not to force the indicator to stop regardless of call count
+   * @returns {void}
    * @example
    * // stop typing in a channel
    * channel.stopTyping();
@@ -305,7 +305,7 @@ class TextBasedChannel {
 
   /**
    * Whether or not the typing indicator is being shown in the channel.
-   * @type {Boolean}
+   * @type {boolean}
    */
   get typing() {
     return this.client.user._typing.has(this.id);
@@ -313,7 +313,7 @@ class TextBasedChannel {
 
   /**
    * Number of times `startTyping` has been called.
-   * @type {Number}
+   * @type {number}
    */
   get typingCount() {
     if (this.client.user._typing.has(this.id)) return this.client.user._typing.get(this.id).count;
@@ -354,7 +354,7 @@ class TextBasedChannel {
    * filter.
    * @param {CollectorFilterFunction} filter the filter function to use
    * @param {AwaitMessagesOptions} [options={}] optional options to pass to the internal collector
-   * @returns {Promise<Collection<String, Message>>}
+   * @returns {Promise<Collection<string, Message>>}
    * @example
    * // await !vote messages
    * const filter = m => m.content.startsWith('!vote');
@@ -394,7 +394,7 @@ class TextBasedChannel {
 
   /**
    * Fetches the pinned messages of this Channel and returns a Collection of them.
-   * @returns {Promise<Collection<String, Message>, Error>}
+   * @returns {Promise<Collection<string, Message>, Error>}
    */
   fetchPinnedMessages() {
     return new Promise((resolve, reject) => {

--- a/src/structures/interface/TextBasedChannel.js
+++ b/src/structures/interface/TextBasedChannel.js
@@ -13,7 +13,7 @@ const EventEmitter = require('events').EventEmitter;
  *  return false; // failed the filter test
  * }
  * ```
- * @typedef {Function} CollectorFilterFunction
+ * @typedef {function} CollectorFilterFunction
  */
 
 /**

--- a/src/util/Collection.js
+++ b/src/util/Collection.js
@@ -62,7 +62,7 @@ class Collection extends Map {
   /**
    * The length (size) of this collection.
    * @readonly
-   * @type {Number}
+   * @type {number}
    */
   get length() {
     return this.size;
@@ -70,8 +70,8 @@ class Collection extends Map {
 
   /**
    * Returns an array of items where `item[key] === value` of the collection
-   * @param {String} key the key to filter by
-   * @param {any} value the expected value
+   * @param {string} key the key to filter by
+   * @param {*} value the expected value
    * @returns {Array<Object>}
    * @example
    * collection.getAll('username', 'Bob');
@@ -90,8 +90,8 @@ class Collection extends Map {
 
   /**
    * Returns a single item where `item[key] === value`
-   * @param {String} key the key to filter by
-   * @param {any} value the expected value
+   * @param {string} key the key to filter by
+   * @param {*} value the expected value
    * @returns {Object}
    * @example
    * collection.get('id', '123123...');
@@ -109,9 +109,9 @@ class Collection extends Map {
 
   /**
    * Returns true if the collection has an item where `item[key] === value`
-   * @param {String} key the key to filter by
-   * @param {any} value the expected value
-   * @returns {Object}
+   * @param {string} key the key to filter by
+   * @param {*} value the expected value
+   * @returns {boolean}
    * @example
    * if (collection.exists('id', '123123...')) {
    *  console.log('user here!');

--- a/src/util/Collection.js
+++ b/src/util/Collection.js
@@ -129,7 +129,7 @@ class Collection extends Map {
    * Identical to
    * [Array.filter()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter),
    * but returns a Collection instead of an Array.
-   * @param {Function} callback the callback used to filter
+   * @param {function} callback the callback used to filter
    * @param {Object} [thisArg] value to set as this when filtering
    * @returns {Collection}
    */


### PR DESCRIPTION
This makes the JSDocs across the codebase follow the usual standard conventions for type names:
- Primitive types (`boolean`, `number`, `string`, and `function`) should be lowercase
- Returning nothing should be `{void}`, not `{null}`, as that's not a type, but rather a value - `typeof null` will return `object`, and functions that don't return anything technically return `undefined`. `{void}` is the usual convention. See #581 
- Any type should be indicated with `*`

I also fixed the return type of `Collection.exists()`.