### PR TITLE
Lower Node version requirement to 6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "node-opus": "^0.1.13"
   },
   "engines": {
-    "node": ">=6.4.0"
+    "node": ">=6.0.0"
   },
   "browser": {
     "./src/Util/TokenCacher.js": "./src/Util/TokenCacher-shim.js",


### PR DESCRIPTION
As far as I'm aware, we don't actually depend on anything in the newer versions of Node.