### PR TITLE
add node v4+ support for users who can't upgrade to v6

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -123,7 +123,6 @@
     "no-useless-computed-key": "error",
     "no-useless-constructor": "error",
     "prefer-arrow-callback": "error",
-    "prefer-rest-params": "error",
     "prefer-spread": "error",
     "prefer-template": "error",
     "rest-spread-spacing": "error",

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const EventEmitter = require('events').EventEmitter;
 const mergeDefault = require('../util/MergeDefault');
 const Constants = require('../util/Constants');
@@ -150,18 +152,17 @@ class Client extends EventEmitter {
     });
   }
 
-  setInterval(...params) {
-    const interval = setInterval(...params);
+  setInterval() {
+    const interval = setInterval.apply(this, arguments);
     this._intervals.push(interval);
     return interval;
   }
 
-  setTimeout(...params) {
-    const restParams = params.slice(1);
+  setTimeout() {
     const timeout = setTimeout(() => {
-      this._timeouts.splice(this._timeouts.indexOf(params[0]), 1);
-      params[0]();
-    }, ...restParams);
+      this._timeouts.splice(this._timeouts.indexOf(arguments[0]), 1);
+      arguments[0]();
+    }, arguments[1]);
     this._timeouts.push(timeout);
     return timeout;
   }
@@ -171,7 +172,8 @@ class Client extends EventEmitter {
    * if you wish to force a sync of Guild data, you can use this. Only applicable to user accounts.
    * @param {Guild[]} [guilds=this.guilds.array()] An array of guilds to sync
    */
-  syncGuilds(guilds = this.guilds.array()) {
+  syncGuilds(guilds) {
+    guilds = guilds || this.guilds.array();
     if (!this.user.bot) {
       this.ws.send({
         op: 12,

--- a/src/client/ClientDataManager.js
+++ b/src/client/ClientDataManager.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Constants = require('../util/Constants');
 const cloneObject = require('../util/CloneObject');
 const Guild = require('../structures/Guild');

--- a/src/client/ClientDataResolver.js
+++ b/src/client/ClientDataResolver.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const path = require('path');
 const fs = require('fs');
 const request = require('superagent');

--- a/src/client/ClientManager.js
+++ b/src/client/ClientManager.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Constants = require('../util/Constants');
 
 /**

--- a/src/client/actions/Action.js
+++ b/src/client/actions/Action.js
@@ -1,3 +1,4 @@
+'use strict';
 /*
 
 ABOUT ACTIONS

--- a/src/client/actions/ActionsManager.js
+++ b/src/client/actions/ActionsManager.js
@@ -1,3 +1,5 @@
+'use strict';
+
 class ActionsManager {
   constructor(client) {
     this.client = client;

--- a/src/client/actions/ChannelCreate.js
+++ b/src/client/actions/ChannelCreate.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Action = require('./Action');
 
 class ChannelCreateAction extends Action {

--- a/src/client/actions/ChannelDelete.js
+++ b/src/client/actions/ChannelDelete.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Action = require('./Action');
 
 class ChannelDeleteAction extends Action {

--- a/src/client/actions/ChannelUpdate.js
+++ b/src/client/actions/ChannelUpdate.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Action = require('./Action');
 const Constants = require('../../util/Constants');
 const cloneObject = require('../../util/CloneObject');

--- a/src/client/actions/GuildBanRemove.js
+++ b/src/client/actions/GuildBanRemove.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Action = require('./Action');
 const Constants = require('../../util/Constants');
 

--- a/src/client/actions/GuildDelete.js
+++ b/src/client/actions/GuildDelete.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Action = require('./Action');
 const Constants = require('../../util/Constants');
 

--- a/src/client/actions/GuildMemberGet.js
+++ b/src/client/actions/GuildMemberGet.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Action = require('./Action');
 
 class GuildMemberGetAction extends Action {

--- a/src/client/actions/GuildMemberRemove.js
+++ b/src/client/actions/GuildMemberRemove.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Action = require('./Action');
 const Constants = require('../../util/Constants');
 

--- a/src/client/actions/GuildRoleCreate.js
+++ b/src/client/actions/GuildRoleCreate.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Action = require('./Action');
 const Constants = require('../../util/Constants');
 const Role = require('../../structures/Role');

--- a/src/client/actions/GuildRoleDelete.js
+++ b/src/client/actions/GuildRoleDelete.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Action = require('./Action');
 const Constants = require('../../util/Constants');
 

--- a/src/client/actions/GuildRoleUpdate.js
+++ b/src/client/actions/GuildRoleUpdate.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Action = require('./Action');
 const Constants = require('../../util/Constants');
 const cloneObject = require('../../util/CloneObject');

--- a/src/client/actions/GuildSync.js
+++ b/src/client/actions/GuildSync.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Action = require('./Action');
 
 class GuildSync extends Action {

--- a/src/client/actions/GuildUpdate.js
+++ b/src/client/actions/GuildUpdate.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Action = require('./Action');
 const Constants = require('../../util/Constants');
 const cloneObject = require('../../util/CloneObject');

--- a/src/client/actions/MessageCreate.js
+++ b/src/client/actions/MessageCreate.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Action = require('./Action');
 const Message = require('../../structures/Message');
 

--- a/src/client/actions/MessageDelete.js
+++ b/src/client/actions/MessageDelete.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Action = require('./Action');
 
 class MessageDeleteAction extends Action {

--- a/src/client/actions/MessageDeleteBulk.js
+++ b/src/client/actions/MessageDeleteBulk.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Action = require('./Action');
 const Collection = require('../../util/Collection');
 const Constants = require('../../util/Constants');

--- a/src/client/actions/MessageUpdate.js
+++ b/src/client/actions/MessageUpdate.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Action = require('./Action');
 const Constants = require('../../util/Constants');
 const cloneObject = require('../../util/CloneObject');

--- a/src/client/actions/UserGet.js
+++ b/src/client/actions/UserGet.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Action = require('./Action');
 
 class UserGetAction extends Action {

--- a/src/client/actions/UserUpdate.js
+++ b/src/client/actions/UserUpdate.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Action = require('./Action');
 const Constants = require('../../util/Constants');
 const cloneObject = require('../../util/CloneObject');

--- a/src/client/rest/APIRequest.js
+++ b/src/client/rest/APIRequest.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const request = require('superagent');
 const Constants = require('../../util/Constants');
 

--- a/src/client/rest/RESTManager.js
+++ b/src/client/rest/RESTManager.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const UserAgentManager = require('./UserAgentManager');
 const RESTMethods = require('./RESTMethods');
 const SequentialRequestHandler = require('./RequestHandlers/Sequential');

--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Constants = require('../../util/Constants');
 const Collection = require('../../util/Collection');
 
@@ -278,9 +280,10 @@ class RESTMethods {
     });
   }
 
-  getChannelMessages(channel, payload = {}) {
+  getChannelMessages(channel, payload) {
     return new Promise((resolve, reject) => {
       const params = [];
+      payload = payload || {};
       if (payload.limit) params.push(`limit=${payload.limit}`);
       if (payload.around) params.push(`around=${payload.around}`);
       else if (payload.before) params.push(`before=${payload.before}`);

--- a/src/client/rest/RequestHandlers/RequestHandler.js
+++ b/src/client/rest/RequestHandlers/RequestHandler.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * A base class for different types of rate limiting handlers for the REST API.
  * @private

--- a/src/client/rest/RequestHandlers/Sequential.js
+++ b/src/client/rest/RequestHandlers/Sequential.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const RequestHandler = require('./RequestHandler');
 
 /**

--- a/src/client/rest/UserAgentManager.js
+++ b/src/client/rest/UserAgentManager.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Constants = require('../../util/Constants');
 
 class UserAgentManager {

--- a/src/client/voice/ClientVoiceManager.js
+++ b/src/client/voice/ClientVoiceManager.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Collection = require('../../util/Collection');
 const mergeDefault = require('../../util/MergeDefault');
 const Constants = require('../../util/Constants');
@@ -35,8 +37,8 @@ class ClientVoiceManager {
     const pendingRequest = this.pending.get(guildID);
     if (!pendingRequest) throw new Error('Guild not pending');
     if (pendingRequest.token && pendingRequest.sessionID && pendingRequest.endpoint) {
-      const { channel, token, sessionID, endpoint, resolve, reject } = pendingRequest;
-      const voiceConnection = new VoiceConnection(this, channel, token, sessionID, endpoint, resolve, reject);
+      const voiceConnection = new VoiceConnection(this, pendingRequest.channel, pendingRequest.token,
+        pendingRequest.sessionID, pendingRequest.endpoint, pendingRequest.resolve, pendingRequest.reject);
       this.pending.delete(guildID);
       this.connections.set(guildID, voiceConnection);
       voiceConnection.once('disconnected', () => {
@@ -77,7 +79,8 @@ class ClientVoiceManager {
    * @param {VoiceChannel} channel The channel to join
    * @param {Object} [options] The options to provide
    */
-  _sendWSJoin(channel, options = {}) {
+  _sendWSJoin(channel, options) {
+    options = options || {};
     options = mergeDefault({
       guild_id: channel.guild.id,
       channel_id: channel.id,

--- a/src/client/voice/VoiceConnection.js
+++ b/src/client/voice/VoiceConnection.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const VoiceConnectionWebSocket = require('./VoiceConnectionWebSocket');
 const VoiceConnectionUDPClient = require('./VoiceConnectionUDPClient');
 const VoiceReceiver = require('./receiver/VoiceReceiver');
@@ -88,7 +90,7 @@ class VoiceConnection extends EventEmitter {
    * Disconnects the Client from the Voice Channel
    * @param {string} [reason='user requested'] The reason of the disconnection
    */
-  disconnect(reason = 'user requested') {
+  disconnect(reason) {
     this.manager.client.ws.send({
       op: Constants.OPCodes.VOICE_STATE_UPDATE,
       d: {
@@ -98,7 +100,7 @@ class VoiceConnection extends EventEmitter {
         self_deaf: false,
       },
     });
-    this._shutdown(reason);
+    this._shutdown(reason || 'user requested');
   }
 
   _onClose(e) {
@@ -145,7 +147,7 @@ class VoiceConnection extends EventEmitter {
     });
     this.once('ready', () => {
       setImmediate(() => {
-        for (const item of this.queue) this.emit(...item);
+        for (const item of this.queue) this.emit.apply(null, item);
         this.queue = [];
       });
     });

--- a/src/client/voice/VoiceConnectionUDPClient.js
+++ b/src/client/voice/VoiceConnectionUDPClient.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const udp = require('dgram');
 const dns = require('dns');
 const Constants = require('../../util/Constants');

--- a/src/client/voice/VoiceConnectionWebSocket.js
+++ b/src/client/voice/VoiceConnectionWebSocket.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const WebSocket = require('ws');
 const Constants = require('../../util/Constants');
 const EventEmitter = require('events').EventEmitter;

--- a/src/client/voice/dispatcher/StreamDispatcher.js
+++ b/src/client/voice/dispatcher/StreamDispatcher.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const EventEmitter = require('events').EventEmitter;
 const NaCl = require('tweetnacl');
 

--- a/src/client/voice/opus/BaseOpusEngine.js
+++ b/src/client/voice/opus/BaseOpusEngine.js
@@ -1,3 +1,5 @@
+'use strict';
+
 class BaseOpus {
   constructor(player) {
     this.player = player;

--- a/src/client/voice/opus/NodeOpusEngine.js
+++ b/src/client/voice/opus/NodeOpusEngine.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const OpusEngine = require('./BaseOpusEngine');
 
 let opus;

--- a/src/client/voice/opus/OpusEngineList.js
+++ b/src/client/voice/opus/OpusEngineList.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const list = [
   require('./NodeOpusEngine'),
   require('./OpusScriptEngine'),

--- a/src/client/voice/opus/OpusScriptEngine.js
+++ b/src/client/voice/opus/OpusScriptEngine.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const OpusEngine = require('./BaseOpusEngine');
 
 let OpusScript;

--- a/src/client/voice/pcm/ConverterEngine.js
+++ b/src/client/voice/pcm/ConverterEngine.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const EventEmitter = require('events').EventEmitter;
 
 class ConverterEngine extends EventEmitter {

--- a/src/client/voice/pcm/FfmpegConverterEngine.js
+++ b/src/client/voice/pcm/FfmpegConverterEngine.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const ConverterEngine = require('./ConverterEngine');
 const ChildProcess = require('child_process');
 

--- a/src/client/voice/player/BasePlayer.js
+++ b/src/client/voice/player/BasePlayer.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const OpusEngines = require('../opus/OpusEngineList');
 const ConverterEngines = require('../pcm/ConverterEngineList');
 const Constants = require('../../../util/Constants');

--- a/src/client/voice/player/DefaultPlayer.js
+++ b/src/client/voice/player/DefaultPlayer.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const BasePlayer = require('./BasePlayer');
 const fs = require('fs');
 

--- a/src/client/voice/receiver/VoiceReadable.js
+++ b/src/client/voice/receiver/VoiceReadable.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Readable = require('stream').Readable;
 
 class VoiceReadable extends Readable {

--- a/src/client/voice/receiver/VoiceReceiver.js
+++ b/src/client/voice/receiver/VoiceReceiver.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const EventEmitter = require('events').EventEmitter;
 const NaCl = require('tweetnacl');
 const Readable = require('./VoiceReadable');

--- a/src/client/websocket/WebSocketManager.js
+++ b/src/client/websocket/WebSocketManager.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const WebSocket = require('ws');
 const Constants = require('../../util/Constants');
 const zlib = require('zlib');
@@ -73,7 +75,7 @@ class WebSocketManager {
    * @param {Object} data An object that can be JSON stringified
    * @param {boolean} force Whether or not to send the packet immediately
    */
-  send(data, force = false) {
+  send(data, force) {
     if (force) {
       this.ws.send(JSON.stringify(data));
       return;
@@ -190,11 +192,12 @@ class WebSocketManager {
     this.tryReconnect();
   }
 
-  _emitReady(normal = true) {
+  _emitReady(normal) {
     /**
      * Emitted when the Client becomes ready to start working
      * @event Client#ready
      */
+    if (typeof normal === 'undefined') normal = true;
     this.status = Constants.Status.READY;
     this.client.emit(Constants.Events.READY);
     this.packetManager.handleQueue();

--- a/src/client/websocket/packets/WebSocketPacketManager.js
+++ b/src/client/websocket/packets/WebSocketPacketManager.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Constants = require('../../../util/Constants');
 
 const BeforeReadyWhitelist = [

--- a/src/client/websocket/packets/handlers/AbstractHandler.js
+++ b/src/client/websocket/packets/handlers/AbstractHandler.js
@@ -1,3 +1,5 @@
+'use strict';
+
 class AbstractHandler {
   constructor(packetManager) {
     this.packetManager = packetManager;

--- a/src/client/websocket/packets/handlers/ChannelCreate.js
+++ b/src/client/websocket/packets/handlers/ChannelCreate.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const AbstractHandler = require('./AbstractHandler');
 
 const Constants = require('../../../../util/Constants');

--- a/src/client/websocket/packets/handlers/ChannelDelete.js
+++ b/src/client/websocket/packets/handlers/ChannelDelete.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const AbstractHandler = require('./AbstractHandler');
 
 const Constants = require('../../../../util/Constants');

--- a/src/client/websocket/packets/handlers/ChannelPinsUpdate.js
+++ b/src/client/websocket/packets/handlers/ChannelPinsUpdate.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const AbstractHandler = require('./AbstractHandler');
 const Constants = require('../../../../util/Constants');
 

--- a/src/client/websocket/packets/handlers/ChannelUpdate.js
+++ b/src/client/websocket/packets/handlers/ChannelUpdate.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const AbstractHandler = require('./AbstractHandler');
 
 class ChannelUpdateHandler extends AbstractHandler {

--- a/src/client/websocket/packets/handlers/GuildBanAdd.js
+++ b/src/client/websocket/packets/handlers/GuildBanAdd.js
@@ -1,3 +1,4 @@
+'use strict';
 // ##untested handler##
 
 const AbstractHandler = require('./AbstractHandler');

--- a/src/client/websocket/packets/handlers/GuildBanRemove.js
+++ b/src/client/websocket/packets/handlers/GuildBanRemove.js
@@ -1,3 +1,4 @@
+'use strict';
 // ##untested handler##
 
 const AbstractHandler = require('./AbstractHandler');

--- a/src/client/websocket/packets/handlers/GuildCreate.js
+++ b/src/client/websocket/packets/handlers/GuildCreate.js
@@ -1,3 +1,4 @@
+'use strict';
 const AbstractHandler = require('./AbstractHandler');
 
 class GuildCreateHandler extends AbstractHandler {

--- a/src/client/websocket/packets/handlers/GuildDelete.js
+++ b/src/client/websocket/packets/handlers/GuildDelete.js
@@ -1,3 +1,4 @@
+'use strict';
 const AbstractHandler = require('./AbstractHandler');
 const Constants = require('../../../../util/Constants');
 

--- a/src/client/websocket/packets/handlers/GuildMemberAdd.js
+++ b/src/client/websocket/packets/handlers/GuildMemberAdd.js
@@ -1,3 +1,4 @@
+'use strict';
 // ##untested handler##
 
 const AbstractHandler = require('./AbstractHandler');

--- a/src/client/websocket/packets/handlers/GuildMemberRemove.js
+++ b/src/client/websocket/packets/handlers/GuildMemberRemove.js
@@ -1,3 +1,4 @@
+'use strict';
 // ##untested handler##
 
 const AbstractHandler = require('./AbstractHandler');

--- a/src/client/websocket/packets/handlers/GuildMemberUpdate.js
+++ b/src/client/websocket/packets/handlers/GuildMemberUpdate.js
@@ -1,3 +1,4 @@
+'use strict';
 // ##untested handler##
 
 const AbstractHandler = require('./AbstractHandler');

--- a/src/client/websocket/packets/handlers/GuildMembersChunk.js
+++ b/src/client/websocket/packets/handlers/GuildMembersChunk.js
@@ -1,3 +1,4 @@
+'use strict';
 // ##untested##
 
 const AbstractHandler = require('./AbstractHandler');

--- a/src/client/websocket/packets/handlers/GuildRoleCreate.js
+++ b/src/client/websocket/packets/handlers/GuildRoleCreate.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const AbstractHandler = require('./AbstractHandler');
 
 class GuildRoleCreateHandler extends AbstractHandler {

--- a/src/client/websocket/packets/handlers/GuildRoleDelete.js
+++ b/src/client/websocket/packets/handlers/GuildRoleDelete.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const AbstractHandler = require('./AbstractHandler');
 
 class GuildRoleDeleteHandler extends AbstractHandler {

--- a/src/client/websocket/packets/handlers/GuildRoleUpdate.js
+++ b/src/client/websocket/packets/handlers/GuildRoleUpdate.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const AbstractHandler = require('./AbstractHandler');
 
 class GuildRoleUpdateHandler extends AbstractHandler {

--- a/src/client/websocket/packets/handlers/GuildSync.js
+++ b/src/client/websocket/packets/handlers/GuildSync.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const AbstractHandler = require('./AbstractHandler');
 
 class GuildSyncHandler extends AbstractHandler {

--- a/src/client/websocket/packets/handlers/GuildUpdate.js
+++ b/src/client/websocket/packets/handlers/GuildUpdate.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const AbstractHandler = require('./AbstractHandler');
 
 class GuildUpdateHandler extends AbstractHandler {

--- a/src/client/websocket/packets/handlers/MessageCreate.js
+++ b/src/client/websocket/packets/handlers/MessageCreate.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const AbstractHandler = require('./AbstractHandler');
 const Constants = require('../../../../util/Constants');
 

--- a/src/client/websocket/packets/handlers/MessageDelete.js
+++ b/src/client/websocket/packets/handlers/MessageDelete.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const AbstractHandler = require('./AbstractHandler');
 const Constants = require('../../../../util/Constants');
 

--- a/src/client/websocket/packets/handlers/MessageDeleteBulk.js
+++ b/src/client/websocket/packets/handlers/MessageDeleteBulk.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const AbstractHandler = require('./AbstractHandler');
 
 class MessageDeleteBulkHandler extends AbstractHandler {

--- a/src/client/websocket/packets/handlers/MessageUpdate.js
+++ b/src/client/websocket/packets/handlers/MessageUpdate.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const AbstractHandler = require('./AbstractHandler');
 
 class MessageUpdateHandler extends AbstractHandler {

--- a/src/client/websocket/packets/handlers/PresenceUpdate.js
+++ b/src/client/websocket/packets/handlers/PresenceUpdate.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const AbstractHandler = require('./AbstractHandler');
 const Constants = require('../../../../util/Constants');
 const cloneObject = require('../../../../util/CloneObject');

--- a/src/client/websocket/packets/handlers/Ready.js
+++ b/src/client/websocket/packets/handlers/Ready.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const AbstractHandler = require('./AbstractHandler');
 
 const getStructure = name => require(`../../../../structures/${name}`);

--- a/src/client/websocket/packets/handlers/TypingStart.js
+++ b/src/client/websocket/packets/handlers/TypingStart.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const AbstractHandler = require('./AbstractHandler');
 const Constants = require('../../../../util/Constants');
 

--- a/src/client/websocket/packets/handlers/UserUpdate.js
+++ b/src/client/websocket/packets/handlers/UserUpdate.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const AbstractHandler = require('./AbstractHandler');
 
 class UserUpdateHandler extends AbstractHandler {

--- a/src/client/websocket/packets/handlers/VoiceServerUpdate.js
+++ b/src/client/websocket/packets/handlers/VoiceServerUpdate.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const AbstractHandler = require('./AbstractHandler');
 
 /*

--- a/src/client/websocket/packets/handlers/VoiceStateUpdate.js
+++ b/src/client/websocket/packets/handlers/VoiceStateUpdate.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const AbstractHandler = require('./AbstractHandler');
 
 const Constants = require('../../../../util/Constants');

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Client = require('./client/Client');
 const Shard = require('./sharding/Shard');
 const ShardingManager = require('./sharding/ShardingManager');

--- a/src/sharding/Shard.js
+++ b/src/sharding/Shard.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const childProcess = require('child_process');
 const path = require('path');
 

--- a/src/sharding/ShardingManager.js
+++ b/src/sharding/ShardingManager.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const path = require('path');
 const fs = require('fs');
 const EventEmitter = require('events').EventEmitter;

--- a/src/structures/Channel.js
+++ b/src/structures/Channel.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Represents any Channel on Discord
  */

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const User = require('./User');
 
 /**
@@ -96,7 +98,7 @@ class ClientUser extends User {
    *  .then(user => console.log('Changed status!'))
    *  .catch(console.log);
    */
-  setStatus(status, game, url = null) {
+  setStatus(status, game, url) {
     return new Promise(resolve => {
       if (status === 'online' || status === 'here' || status === 'available') {
         this.idleStatus = null;
@@ -119,7 +121,7 @@ class ClientUser extends User {
       }
 
       if (url) {
-        this.userGame.url = url;
+        this.userGame.url = url || null;
         this.userGame.type = 1;
       }
 

--- a/src/structures/DMChannel.js
+++ b/src/structures/DMChannel.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const User = require('./User');
 const Channel = require('./Channel');
 const TextBasedChannel = require('./interface/TextBasedChannel');

--- a/src/structures/Emoji.js
+++ b/src/structures/Emoji.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Constants = require('../util/Constants');
 const Collection = require('../util/Collection');
 

--- a/src/structures/EvaluatedPermissions.js
+++ b/src/structures/EvaluatedPermissions.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Constants = require('../util/Constants');
 
 /**
@@ -38,7 +40,7 @@ class EvaluatedPermissions {
    * @param {boolean} [explicit=false] Whether to require the user to explicitly have the exact permission
    * @returns {boolean}
    */
-  hasPermission(permission, explicit = false) {
+  hasPermission(permission, explicit) {
     permission = this.member.client.resolver.resolvePermission(permission);
     if (!explicit && (this.permissions & Constants.PermissionFlags.ADMINISTRATOR) > 0) return true;
     return (this.permissions & permission) > 0;

--- a/src/structures/GroupDMChannel.js
+++ b/src/structures/GroupDMChannel.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Channel = require('./Channel');
 const TextBasedChannel = require('./interface/TextBasedChannel');
 const Collection = require('../util/Collection');

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const User = require('./User');
 const Role = require('./Role');
 const Emoji = require('./Emoji');
@@ -377,8 +379,8 @@ class Guild {
    * // ban a user
    * guild.ban('123123123123');
    */
-  ban(user, deleteDays = 0) {
-    return this.client.rest.methods.banGuildMember(this, user, deleteDays);
+  ban(user, deleteDays) {
+    return this.client.rest.methods.banGuildMember(this, user, deleteDays || 0);
   }
 
   /**
@@ -429,7 +431,7 @@ class Guild {
    * @param {string} [query=''] An optional query to provide when fetching members
    * @returns {Promise<Guild>}
    */
-  fetchMembers(query = '') {
+  fetchMembers(query) {
     return new Promise((resolve, reject) => {
       if (this._fetchWaiter) throw new Error('already fetching guild members');
       if (this.memberCount === this.members.size) {
@@ -441,7 +443,7 @@ class Guild {
         op: Constants.OPCodes.REQUEST_GUILD_MEMBERS,
         d: {
           guild_id: this.id,
-          query,
+          query: query || '',
           limit: 0,
         },
       });

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Channel = require('./Channel');
 const Role = require('./Role');
 const PermissionOverwrites = require('./PermissionOverwrites');
@@ -227,8 +229,8 @@ class GuildChannel extends Channel {
    * @param {InviteOptions} [options={}] The options for the invite
    * @returns {Promise<Invite>}
    */
-  createInvite(options = {}) {
-    return this.client.rest.methods.createChannelInvite(this, options);
+  createInvite(options) {
+    return this.client.rest.methods.createChannelInvite(this, options || {});
   }
 
   /**

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const TextBasedChannel = require('./interface/TextBasedChannel');
 const Role = require('./Role');
 const Collection = require('../util/Collection');
@@ -282,8 +284,8 @@ class GuildMember {
    * // ban a guild member
    * guildMember.ban(7);
    */
-  ban(deleteDays = 0) {
-    return this.client.rest.methods.banGuildMember(this.guild, this, deleteDays);
+  ban(deleteDays) {
+    return this.client.rest.methods.banGuildMember(this.guild, this, deleteDays || 0);
   }
 
   // These are here only for documentation purposes - they are implemented by TextBasedChannel

--- a/src/structures/Invite.js
+++ b/src/structures/Invite.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const PartialGuild = require('./PartialGuild');
 const PartialGuildChannel = require('./PartialGuildChannel');
 

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Attachment = require('./MessageAttachment');
 const Embed = require('./MessageEmbed');
 const Collection = require('../util/Collection');
@@ -230,13 +232,13 @@ class Message {
    *  .then(msg => console.log(`Deleted message from ${msg.author}`))
    *  .catch(console.log);
    */
-  delete(timeout = 0) {
+  delete(timeout) {
     return new Promise((resolve, reject) => {
       this.client.setTimeout(() => {
         this.client.rest.methods.deleteMessage(this)
           .then(resolve)
           .catch(reject);
-      }, timeout);
+      }, timeout || 0);
     });
   }
 
@@ -265,7 +267,8 @@ class Message {
    *  .then(msg => console.log(`Sent a reply to ${msg.author}`))
    *  .catch(console.log);
    */
-  reply(content, options = {}) {
+  reply(content, options) {
+    options = options || {};
     content = this.client.resolver.resolveString(content);
     const newContent = this.guild ? `${this.author}, ${content}` : content;
     return this.client.rest.methods.sendMessage(this.channel, newContent, options.tts);

--- a/src/structures/MessageAttachment.js
+++ b/src/structures/MessageAttachment.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Represents an Attachment in a Message
  */

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Represents an embed in an image - e.g. preview of image
  */

--- a/src/structures/PartialGuild.js
+++ b/src/structures/PartialGuild.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /*
 { splash: null,
      id: '123123123',

--- a/src/structures/PartialGuildChannel.js
+++ b/src/structures/PartialGuildChannel.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Constants = require('../util/Constants');
 
 /*

--- a/src/structures/PermissionOverwrites.js
+++ b/src/structures/PermissionOverwrites.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Represents a permission overwrite for a Role or Member in a Guild Channel.
  */

--- a/src/structures/Role.js
+++ b/src/structures/Role.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Constants = require('../util/Constants');
 
 /**
@@ -199,7 +201,7 @@ class Role {
    *   console.log('This role can\'t ban members');
    * }
    */
-  hasPermission(permission, explicit = false) {
+  hasPermission(permission, explicit) {
     permission = this.client.resolver.resolvePermission(permission);
     if (!explicit && (this.permissions & Constants.PermissionFlags.ADMINISTRATOR) > 0) return true;
     return (this.permissions & permission) > 0;

--- a/src/structures/TextChannel.js
+++ b/src/structures/TextChannel.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const GuildChannel = require('./GuildChannel');
 const TextBasedChannel = require('./interface/TextBasedChannel');
 const Collection = require('../util/Collection');

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const TextBasedChannel = require('./interface/TextBasedChannel');
 const Constants = require('../util/Constants');
 

--- a/src/structures/VoiceChannel.js
+++ b/src/structures/VoiceChannel.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const GuildChannel = require('./GuildChannel');
 const Collection = require('../util/Collection');
 

--- a/src/structures/interface/TextBasedChannel.js
+++ b/src/structures/interface/TextBasedChannel.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const path = require('path');
 const EventEmitter = require('events').EventEmitter;
 const Message = require('../Message');
@@ -45,7 +47,8 @@ class TextBasedChannel {
    *  .then(message => console.log(`Sent message: ${message.content}`))
    *  .catch(console.log);
    */
-  sendMessage(content, options = {}) {
+  sendMessage(content, options) {
+    options = options || {};
     return this.client.rest.methods.sendMessage(this, content, options.tts, options.nonce, options.disable_everyone);
   }
 
@@ -60,7 +63,8 @@ class TextBasedChannel {
    *  .then(message => console.log(`Sent tts message: ${message.content}`))
    *  .catch(console.log);
    */
-  sendTTSMessage(content, options = {}) {
+  sendTTSMessage(content, options) {
+    options = options || {};
     return this.client.rest.methods.sendMessage(this, content, true, options.nonce, options.disable_everyone);
   }
 
@@ -136,7 +140,8 @@ class TextBasedChannel {
    *  .then(messages => console.log(`Received ${messages.size} messages`))
    *  .catch(console.log);
    */
-  fetchMessages(options = {}) {
+  fetchMessages(options) {
+    options = options || {};
     return new Promise((resolve, reject) => {
       this.client.rest.methods.getChannelMessages(this, options).then(data => {
         const messages = new Collection();
@@ -203,7 +208,8 @@ class TextBasedChannel {
    * // force typing to fully stop in a channel
    * channel.stopTyping(true);
    */
-  stopTyping(force = false) {
+  stopTyping(force) {
+    force = force || false;
     if (this.client.user._typing.has(this.id)) {
       const entry = this.client.user._typing.get(this.id);
       entry.count--;
@@ -245,7 +251,8 @@ class TextBasedChannel {
    * collector.on('message', m => console.log(`Collected ${m.content}`));
    * collector.on('end', collected => console.log(`Collected ${collected.size} items`));
    */
-  createCollector(filter, options = {}) {
+  createCollector(filter, options) {
+    options = options || {};
     return new MessageCollector(this, filter, options);
   }
 
@@ -273,11 +280,12 @@ class TextBasedChannel {
    *  .then(collected => console.log(collected.size))
    *  .catch(collected => console.log(`After a minute, only ${collected.size} out of 4 voted.`));
    */
-  awaitMessages(filter, options = {}) {
+  awaitMessages(filter, options) {
+    options = options || {};
     return new Promise((resolve, reject) => {
       const collector = this.createCollector(filter, options);
       collector.on('end', (collection, reason) => {
-        if (options.errors && options.errors.includes(reason)) {
+        if (options.errors && options.errors.indexOf(reason) > -1) {
           reject(collection);
         } else {
           resolve(collection);
@@ -342,7 +350,7 @@ class MessageCollector extends EventEmitter {
    * @param {CollectorFilterFunction} filter The filter function
    * @param {CollectorOptions} [options] Options for the collector
    */
-  constructor(channel, filter, options = {}) {
+  constructor(channel, filter, options) {
     super();
 
     /**
@@ -361,7 +369,7 @@ class MessageCollector extends EventEmitter {
      * Options for the collecor.
      * @type {CollectorOptions}
      */
-    this.options = options;
+    this.options = options || {};
 
     /**
      * Whether this collector has stopped collecting Messages.
@@ -407,7 +415,7 @@ class MessageCollector extends EventEmitter {
    * Stops the collector and emits `end`.
    * @param {string} [reason='user'] An optional reason for stopping the collector
    */
-  stop(reason = 'user') {
+  stop(reason) {
     if (this.ended) return;
     this.ended = true;
     this.channel.client.removeListener('message', this.listener);
@@ -420,11 +428,11 @@ class MessageCollector extends EventEmitter {
      * ended because it reached its message limit, it will be `limit`.
      * @event MessageCollector#end
      */
-    this.emit('end', this.collected, reason);
+    this.emit('end', this.collected, reason || 'user');
   }
 }
 
-exports.applyToClass = (structure, full = false) => {
+exports.applyToClass = (structure, full) => {
   const props = ['sendMessage', 'sendTTSMessage', 'sendFile'];
   if (full) {
     props.push('_cacheMessage');

--- a/src/util/ArraysEqual.js
+++ b/src/util/ArraysEqual.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = function arraysEqual(a, b) {
   if (a === b) return true;
   if (a.length !== b.length) return false;

--- a/src/util/CloneObject.js
+++ b/src/util/CloneObject.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = function cloneObject(obj) {
   const cloned = Object.create(obj);
   Object.assign(cloned, obj);

--- a/src/util/Collection.js
+++ b/src/util/Collection.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * A utility class to help make it easier to access the data stores
  * @extends {Map}
@@ -115,8 +117,8 @@ class Collection extends Map {
    * @param {Object} [thisArg] Value to set as this when filtering
    * @returns {Collection}
    */
-  filter(...args) {
-    const newArray = this.array().filter(...args);
+  filter() {
+    const newArray = this.array().filter.apply(null, arguments);
     const collection = new Collection();
     for (const item of newArray) collection.set(item.id, item);
     return collection;
@@ -128,8 +130,8 @@ class Collection extends Map {
    * @param {*} [thisArg] Optional. Value to use as this when executing callback.
    * @returns {array}
    */
-  map(...args) {
-    return this.array().map(...args);
+  map() {
+    return this.array().map.apply(null, arguments);
   }
 }
 

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Options that can be passed to a client:
  * ```js

--- a/src/util/MergeDefault.js
+++ b/src/util/MergeDefault.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = function merge(def, given) {
   if (!given) return def;
   for (const key in def) {


### PR DESCRIPTION
There's still situations where node v6 isn't supported at the moment, such as meteor. Let alone endless requests for why they're getting the 'use strict' error. It's pretty easy to support.

Adds 'use strict';
Replaces rest/spread operators
Replaces default argument values
Replaces `.includes()` in a couple places