### PR TITLE
Change _updateMember's notSame check from && to ||

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -105,7 +105,7 @@ class Guild {
     if (data.roles) member._roles = data.roles;
     else member.nickname = data.nick;
 
-    const notSame = member.nickname !== oldMember.nickname && !arraysEqual(member._roles, oldMember._roles);
+    const notSame = member.nickname !== oldMember.nickname || !arraysEqual(member._roles, oldMember._roles);
 
     if (this.client.ws.status === Constants.Status.READY && notSame) {
       /**


### PR DESCRIPTION
Currently, the event will only be emitted if the member's nickname AND roles change.

This fixes that issue.