### PR TITLE
Fixes typo in GuildRoleUpdate's documentation

### DIFF
--- a/src/client/actions/GuildRoleUpdate.js
+++ b/src/client/actions/GuildRoleUpdate.js
@@ -33,7 +33,7 @@ class GuildRoleUpdateAction extends Action {
 
 /**
  * Emitted whenever a guild role is updated.
- * @event Client#guildRoleUpdated
+ * @event Client#guildRoleUpdate
  * @param {Guild} guild The guild that the role was updated in.
  * @param {Role} oldRole The role before the update.
  * @param {Role} newRole The role after the update.


### PR DESCRIPTION
See https://github.com/hydrabolt/discord.js/blob/7fe032c785/src/util/Constants.js#L156