### PR TITLE
Fixes guildMemberUpdate not triggering on nick change

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -612,7 +612,7 @@ class Guild {
   _updateMember(member, data) {
     const oldMember = cloneObject(member);
 
-    if (data.roles) member._roles = data.roles;
+    if (data.roles && data.roles.length > 0) member._roles = data.roles;
     else member.nickname = data.nick;
 
     const notSame = member.nickname !== oldMember.nickname || !arraysEqual(member._roles, oldMember._roles);


### PR DESCRIPTION
data.roles exists, but may be an empty array.

Example of nick change:
`{ user:
   { username: 'Clyde',
     id: '1234',
     discriminator: '1234',
     avatar: 'abc' },
  roles: [],
  nick: 'grtrhtrz',
  guild_id: '1234' }`