### PR TITLE
Update default permissions

### DIFF
--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -238,4 +238,4 @@ for (const key in PermissionFlags) _ALL_PERMISSIONS |= PermissionFlags[key];
 
 exports.ALL_PERMISSIONS = _ALL_PERMISSIONS;
 
-exports.DEFAULT_PERMISSIONS = 36953089;
+exports.DEFAULT_PERMISSIONS = 104324097;


### PR DESCRIPTION
The default value on Discord's side was changed from 36953089 to 104324097 a while ago to include the `USE_EXTERNAL_EMOJIS` and `CHANGE_NICKNAME` permissions.
