### PR TITLE
Fix VoiceConnection.playConvertedStream not playing any audio

### DIFF
--- a/src/client/voice/VoiceConnection.js
+++ b/src/client/voice/VoiceConnection.js
@@ -255,7 +255,7 @@ class VoiceConnection extends EventEmitter {
    */
   playConvertedStream(stream, { seek = 0, volume = 1, passes = 1 } = {}) {
     const options = { seek, volume, passes };
-    this._shutdown();
+    this.player._shutdown();
     const dispatcher = this.player.playPCMStream(stream, options);
     return dispatcher;
   }


### PR DESCRIPTION
When using VoiceConnection.playConvertedStream no audio is played. This seems to fix it