### PR TITLE
Fixed highestRole to return the highest role

### DIFF
--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -119,7 +119,7 @@ class GuildMember {
    * @type {Role}
    */
   get highestRole() {
-    return this.roles.reduce((prev, role) => !prev || role.position > prev.position ? role : prev);
+    return this.roles.reduce((prev, role) => !prev || role.position > prev.position || (role.position === prev.position && role.id < prev.id) ? role : prev);
   }
 
   /**

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -119,7 +119,8 @@ class GuildMember {
    * @type {Role}
    */
   get highestRole() {
-    return this.roles.reduce((prev, role) => !prev || role.position > prev.position || (role.position === prev.position && role.id < prev.id) ? role : prev);
+    return this.roles.reduce((prev, role) => 
+    !prev || role.position > prev.position ||(role.position === prev.position && role.id < prev.id) ? role : prev);
   }
 
   /**

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -119,8 +119,8 @@ class GuildMember {
    * @type {Role}
    */
   get highestRole() {
-    return this.roles.reduce((prev, role) => 
-    !prev || role.position > prev.position ||(role.position === prev.position && role.id < prev.id) ? role : prev);
+    return this.roles.reduce((prev, role) =>
+    !prev || role.position > prev.position || (role.position === prev.position && role.id < prev.id) ? role : prev);
   }
 
   /**

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -120,7 +120,8 @@ class GuildMember {
    */
   get highestRole() {
     return this.roles.reduce((prev, role) =>
-    !prev || role.position > prev.position || (role.position === prev.position && role.id < prev.id) ? role : prev);
+      !prev || role.position > prev.position || (role.position === prev.position && role.id < prev.id) ? role : prev
+    );
   }
 
   /**


### PR DESCRIPTION
It now returns the users role that is higher than the other roles, as opposed to before, where it would sometimes return a role that was lower than some of the other roles.