### PR TITLE
Cache array and keyArray in Collection

### DIFF
--- a/src/util/Collection.js
+++ b/src/util/Collection.js
@@ -3,6 +3,16 @@
  * @extends {Map}
  */
 class Collection extends Map {
+  set(key, value) {
+    super.set(key, value);
+    this.changed = true;
+  }
+
+  delete(key) {
+    super.delete(key);
+    this.changed = true;
+  }
+
   /**
    * Returns an ordered array of the values of this collection.
    * @returns {Array}
@@ -67,8 +77,12 @@ class Collection extends Map {
    * @returns {*}
    */
   random() {
-    const arr = this.array();
-    return arr[Math.floor(Math.random() * arr.length)];
+    if(!this.cachedArray || this.cachedArray.length !== this.size || this.changed) {
+      this.cachedArray = this.array();
+      this.changed = false;
+    }
+    
+    return this.cachedArray[Math.floor(Math.random() * this.cachedArray.length)];
   }
 
   /**
@@ -77,8 +91,12 @@ class Collection extends Map {
    * @returns {*}
    */
   randomKey() {
-    const arr = this.keyArray();
-    return arr[Math.floor(Math.random() * arr.length)];
+    if(!this.cachedKeyArray || this.cachedKeyArray.length !== this.size || this.changed) {
+      this.cachedKeyArray = this.keyArray();
+      this.changed = false;
+    }
+
+    return this.cachedKeyArray[Math.floor(Math.random() * this.cachedKeyArray.length)];
   }
 
   /**


### PR DESCRIPTION
Cache array and keyArray in the Collection class to improve consecutive
calls of collection.random/randomKey by around 400,000%, I think lel.

The speed decrease (I assume) compared to the previous version when
calling after it has changed is most likely negligible.

I didn't change the doc comment for random/randomKey though.