### PR TITLE
Fix proxyURL for attachments

### DIFF
--- a/src/structures/MessageAttachment.js
+++ b/src/structures/MessageAttachment.js
@@ -48,7 +48,7 @@ class MessageAttachment {
      * The Proxy URL to this attachment
      * @type {string}
      */
-    this.proxyURL = data.url;
+    this.proxyURL = data.proxy_url;
 
     /**
      * The height of this attachment (if an image)


### PR DESCRIPTION
Currently, it returns the same url for both the normal url, and the proxied url. This is obviously incorrect.

For reference, click [here](https://discordapp.com/developers/docs/resources/channel#attachment-object) to see appropriate discord documentation.