### PR TITLE
fix Client.destroy bugs

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -235,13 +235,13 @@ class Client extends EventEmitter {
    */
   destroy() {
     return this.manager.destroy().then(() => {
-        for (const t of this._timeouts) clearTimeout(t);
-        for (const i of this._intervals) clearInterval(i);
-        this._timeouts.clear();
-        this._intervals.clear();
-        this.token = null;
-        this.email = null;
-        this.password = null;
+      for (const t of this._timeouts) clearTimeout(t);
+      for (const i of this._intervals) clearInterval(i);
+      this._timeouts.clear();
+      this._intervals.clear();
+      this.token = null;
+      this.email = null;
+      this.password = null;
     });
   }
 

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -234,17 +234,14 @@ class Client extends EventEmitter {
    * @returns {Promise}
    */
   destroy() {
-    return new Promise((resolve, reject) => {
-      this.manager.destroy().then(() => {
+    return this.manager.destroy().then(() => {
         for (const t of this._timeouts) clearTimeout(t);
         for (const i of this._intervals) clearInterval(i);
-        this._timeouts = [];
-        this._intervals = [];
+        this._timeouts.clear();
+        this._intervals.clear();
         this.token = null;
         this.email = null;
         this.password = null;
-        resolve();
-      }).catch(reject);
     });
   }
 

--- a/src/client/ClientManager.js
+++ b/src/client/ClientManager.js
@@ -58,12 +58,11 @@ class ClientManager {
   }
 
   destroy() {
-      if (!this.client.user.bot) {
-        return this.client.rest.methods.logout();
-      } else {
-        this.client.ws.destroy();
-        return Promise.resolve();
-      }
+    let p = Promise.resolve();
+    if (!this.client.user.bot) {
+      p = this.client.rest.methods.logout();
+    }
+    return p.then(() => this.client.ws.destroy());
   }
 }
 

--- a/src/client/ClientManager.js
+++ b/src/client/ClientManager.js
@@ -58,14 +58,12 @@ class ClientManager {
   }
 
   destroy() {
-    return new Promise((resolve) => {
       if (!this.client.user.bot) {
-        this.client.rest.methods.logout().then(resolve);
+        return this.client.rest.methods.logout();
       } else {
         this.client.ws.destroy();
-        resolve();
+        return Promise.resolve();
       }
-    });
   }
 }
 

--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -35,7 +35,7 @@ class RESTMethods {
   }
 
   logout() {
-    return this.rest.makeRequest('post', Constants.Endpoints.logout, true);
+    return this.rest.makeRequest('post', Constants.Endpoints.logout, true, {});
   }
 
   getGateway() {

--- a/test/destroy.js
+++ b/test/destroy.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const Discord = require('../');
+
+const client = new Discord.Client({ fetch_all_members: false, api_request_method: 'sequential' });
+
+const { email, password, token } = require('./auth.json');
+
+let p = client.login(token);
+p = p.then(() => client.destroy());
+p = p.then(() => client.login(token));
+p = p.then(() => client.destroy());


### PR DESCRIPTION
There were a bunch of them. the ClientManager promise bug hid the fact that the logout() call was always failing, and the logout call failing made sure the faulty timeout-clearing code in Client.destroy never got called.