### PR TITLE
Improve the docs building process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ node_modules
 test/auth.json
 examples/auth.json
 docs/_build
+
+# Secret keys
+docs/deploy/deploy_key
+docs/deploy/deploy_key.pub

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ cache:
   directories:
     - node_modules
 install: npm install
+script: bash ./docs/deploy/deploy.sh

--- a/docs/deploy/deploy.sh
+++ b/docs/deploy/deploy.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Adapted from https://gist.github.com/domenic/ec8b0fc8ab45f39403dd.
+
+set -e
+
+function build {
+  node docs/generator/generator.js
+}
+
+# Ignore Travis checking PRs
+if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+  echo "deploy.sh: Ignoring PR build"
+  build
+  exit 0
+fi
+
+# Ignore travis checking other branches irrelevant to users
+if [ "$TRAVIS_BRANCH" != "master" -a "$TRAVIS_BRANCH" != "indev" ]; then
+  echo "deploy.sh: Ignoring push to another branch than master/indev"
+  build
+  exit 0
+fi
+
+SOURCE=$TRAVIS_BRANCH
+
+# Make sure tag pushes are handled
+if [ -n "$TRAVIS_TAG" ]; then
+  echo "deploy.sh: This is a tag build, proceeding accordingly"
+  SOURCE=$TRAVIS_TAG
+fi
+
+REPO=`git config remote.origin.url`
+SSH_REPO=${REPO/https:\/\/github.com\//git@github.com:}
+SHA=`git rev-parse --verify HEAD`
+
+TARGET_BRANCH="docs"
+
+# Checkout the repo in the target branch so we can build docs and push to it
+git clone $REPO out -b $TARGET_BRANCH
+cd out
+cd ..
+
+# Build the docs
+build
+
+# Move the generated JSON file to the newly-checked-out repo, to be committed
+# and pushed
+mv docs/docs.json out/$SOURCE.json
+
+# Commit and push
+cd out
+git config user.name "Travis CI"
+git config user.email "$COMMIT_AUTHOR_EMAIL"
+
+git add .
+git commit -m "Docs build: ${SHA}"
+
+ENCRYPTED_KEY_VAR="encrypted_${ENCRYPTION_LABEL}_key"
+ENCRYPTED_IV_VAR="encrypted_${ENCRYPTION_LABEL}_iv"
+ENCRYPTED_KEY=${!ENCRYPTED_KEY_VAR}
+ENCRYPTED_IV=${!ENCRYPTED_IV_VAR}
+openssl aes-256-cbc -K $ENCRYPTED_KEY -iv $ENCRYPTED_IV -in ../docs/deploy/deploy_key.enc -out deploy_key -d
+chmod 600 deploy_key
+eval `ssh-agent -s`
+ssh-add deploy_key
+
+# Now that we're all set up, we can push.
+git push $SSH_REPO $TARGET_BRANCH


### PR DESCRIPTION
Currently building the docs is handled by committing the `docs.json` file along with any changes. Frankly, this system is clunky at best and this proposed Travis-based solution is a more streamlined alternative.

The `deploy.sh` script invoked by Travis builds the docs on every push to `master` or `indev`, clones this repo in a separate `docs` branch, copies the built docs there, commits and pushes using encrypted deploy keys. This means that not only is the docs file not unnecessarily attached to every commit, it is also in a separate branch so we have more freedom with having separate sets of docs.

Currently, a `master.json` and an `indev.json` for regular pushes, as well as a `<tagname>.json` for every tag build, will be built. This can easily be extended to other branches by modifying the script.

Since this PR makes a more fundamental change in the repo than the content PRs there are usually, a couple other things need to be done before this can be merged. Things that need to be done in general:

- [ ] An orphan `docs` branch needs to be generated with at least one initial commit ([example](https://github.com/meew0/discord.js/blob/docs/README.md)).
- [ ] The `gh-pages` branch needs to be updated to read its files from there instead.

Things that you need to do specifically, @hydrabolt:

- [ ] Generate a new SSH key pair and add the public key to the repo settings with push access:
  - `ssh-keygen -t rsa -b 4096 -C "email@example.com"` (replace the email with your normal push email)
  - Set the path to something other than the default.
  - Use no passphrase (just press enter for both the passphrase prompts) 
  - Add the contents from the `<key_name>.pub` file to the repo settings under "Deploy keys".
- [ ] Encrypt the private key using the Travis client and push it to the repo.
  - Use [Travis' file encryption support](https://docs.travis-ci.com/user/encrypting-files/) to encrypt the private key file (if the public file is called `keyname.pub`, the private file will simply be called `keyname`) to `<filename>.enc`. You don't need to do any of the other stuff the Travis client tells you to do, simply having the encrypted file is enough.
  - Take note of the encryption label, it is a part of the output the Travis client gives. It will contain a line that looks like `openssl aes-256-cbc -K $encrypted_0a6446eb3ae3_key -iv $encrypted_0a6446eb3ae3_key -in super_secret.txt.enc -out super_secret.txt -d`. In this case the encryption label would be `0a6446eb3ae3`.
  - Commit the encrypted file (should end with `.enc`) to the repo as `docs/deploy/deploy_key.enc`. Make sure not to commit any unencrypted files.
- [ ] Add the following section, with things in angle brackets appropriately replaced, to the end of the `.travis.yml`:
```yml
env:
  global:
    - ENCRYPTION_LABEL: "<encryption label from Travis encryption step>"
    - COMMIT_AUTHOR_EMAIL: "<email used for the SSH key generation>"

I've opened this PR to edits from maintainers, so the last two steps can be done before merging if necessary. If @hydrabolt trusts me enough to give me the generated SSH key added to the repo, I can also do the last two steps myself, since as a collaborator Travis gives me access to build settings.

I've tested the scripts extensively using my fork, if all the other steps are done correctly it should work fine.