### PR TITLE
fix ClientManager.destroy promise bug

### DIFF
--- a/src/client/ClientManager.js
+++ b/src/client/ClientManager.js
@@ -58,10 +58,10 @@ class ClientManager {
   }
 
   destroy() {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       this.client.ws.destroy();
       if (!this.client.user.bot) {
-        this.client.rest.methods.logout().then(resolve);
+        this.client.rest.methods.logout().then(resolve, reject);
       } else {
         resolve();
       }


### PR DESCRIPTION
Relatedly, what was the reason #828 was reverted and a subset/rewritten version of it was recommitted? There wasn't any reason mentioned in #839.