### PR TITLE
fix Client.destroy

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -236,8 +236,8 @@ class Client extends EventEmitter {
   destroy() {
     for (const t of this._timeouts) clearTimeout(t);
     for (const i of this._intervals) clearInterval(i);
-    this._timeouts = [];
-    this._intervals = [];
+    this._timeouts.clear();
+    this._intervals.clear();
     this.token = null;
     this.email = null;
     this.password = null;


### PR DESCRIPTION
_timeouts and _intervals were changed to Set objects in
commit 6ede7a32fd29bd44e65e344e1f102332d30c2129 a month ago.

Like #844, this fix was reverted in 7d04863b66177c105a92b39ffc990be3b6bfe84f (#839)
without explanation and was never included in the followup rewrite in
commit 5e2ee2398ea5f7b30d8c1783be5cde05803e54fd.