### PR TITLE
Fixed resolveChannel when using a string

### DIFF
--- a/src/client/ClientDataResolver.js
+++ b/src/client/ClientDataResolver.js
@@ -117,7 +117,7 @@ class ClientDataResolver {
     if (channel instanceof Channel) return channel;
     if (channel instanceof Message) return channel.channel;
     if (channel instanceof Guild) return channel.channels.get(channel.id) || null;
-    if (typeof channel === 'string') return this.client.channels.get(channel.id) || null;
+    if (typeof channel === 'string') return this.client.channels.get(channel) || null;
     return null;
   }
 


### PR DESCRIPTION
`resolveChannel` was actually trying to look for the ìd`attribute even when a string was passed.
(That was unluckily my first experience with the new version and almost drove me crazy haha).