### PR TITLE
Properly export constants using named exports - v8

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -4,8 +4,10 @@ exports.__esModule = true;
 var Constants = {};
 
 var API = Constants.API = "https://discordapp.com/api";
+exports.API = API;
 var CDN = Constants.CDN = "https://cdn.discordapp.com";
 
+exports.CDN = CDN;
 var Endpoints = Constants.Endpoints = {
 	// general endpoints
 	LOGIN: API + "/auth/login",
@@ -117,7 +119,8 @@ var Endpoints = Constants.Endpoints = {
 	FRIENDS: API + "/users/@me/relationships"
 };
 
-Constants.Permissions = {
+exports.Endpoints = Endpoints;
+var Permissions = Constants.Permissions = {
 	// general
 	createInstantInvite: 1 << 0,
 	kickMembers: 1 << 1,
@@ -149,7 +152,8 @@ Constants.Permissions = {
 
 };
 
-Constants.PacketType = {
+exports.Permissions = Permissions;
+var PacketType = Constants.PacketType = {
 	CHANNEL_CREATE: "CHANNEL_CREATE",
 	CHANNEL_DELETE: "CHANNEL_DELETE",
 	CHANNEL_UPDATE: "CHANNEL_UPDATE",
@@ -181,5 +185,5 @@ Constants.PacketType = {
 	FRIEND_REMOVE: "RELATIONSHIP_REMOVE"
 };
 
+exports.PacketType = PacketType;
 exports["default"] = Constants;
-module.exports = exports["default"];

--- a/src/Constants.js
+++ b/src/Constants.js
@@ -2,10 +2,10 @@
 
 const Constants = {};
 
-const API = Constants.API = "https://discordapp.com/api";
-const CDN = Constants.CDN = "https://cdn.discordapp.com";
+export const API = Constants.API = "https://discordapp.com/api";
+export const CDN = Constants.CDN = "https://cdn.discordapp.com";
 
-const Endpoints = Constants.Endpoints = {
+export const Endpoints = Constants.Endpoints = {
 	// general endpoints
 	LOGIN: `${API}/auth/login`,
 	LOGOUT: `${API}/auth/logout`,
@@ -59,7 +59,7 @@ const Endpoints = Constants.Endpoints = {
 	FRIENDS: `${API}/users/@me/relationships`
 };
 
-Constants.Permissions = {
+export const Permissions = Constants.Permissions = {
 	// general
 	createInstantInvite: 1 << 0,
 	kickMembers: 1 << 1,
@@ -91,7 +91,7 @@ Constants.Permissions = {
 
 };
 
-Constants.PacketType = {
+export const PacketType = Constants.PacketType = {
 	CHANNEL_CREATE : "CHANNEL_CREATE",
 	CHANNEL_DELETE : "CHANNEL_DELETE",
 	CHANNEL_UPDATE : "CHANNEL_UPDATE",


### PR DESCRIPTION
Export the constants from /lib/Constants using named exports so they can be imported using named imports. 

The reason why the current state of the library does not break is caused by named destructing acting on the default export but as of latest versions of babel and possibly the official spec this will and may not work respectively