### PR TITLE
Grammar cleanup

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -90,25 +90,25 @@ class Client extends EventEmitter {
     this.shard = process.send ? ShardClientUtil.singleton(this) : null;
 
     /**
-     * A Collection of the Client's stored users
+     * A collection of the Client's stored users
      * @type {Collection<string, User>}
      */
     this.users = new Collection();
 
     /**
-     * A Collection of the Client's stored guilds
+     * A collection of the Client's stored guilds
      * @type {Collection<string, Guild>}
      */
     this.guilds = new Collection();
 
     /**
-     * A Collection of the Client's stored channels
+     * A collection of the Client's stored channels
      * @type {Collection<string, Channel>}
      */
     this.channels = new Collection();
 
     /**
-     * A Collection of presences for friends of the logged in user.
+     * A collection of presences for friends of the logged in user.
      * <warn>This is only filled for user accounts, not bot accounts.</warn>
      * @type {Collection<string, Presence>}
      */
@@ -175,7 +175,7 @@ class Client extends EventEmitter {
   }
 
   /**
-   * Returns a Collection, mapping Guild ID to Voice Connections.
+   * Returns a collection, mapping guild ID to voice connections.
    * @type {Collection<string, VoiceConnection>}
    * @readonly
    */
@@ -246,7 +246,7 @@ class Client extends EventEmitter {
 
   /**
    * This shouldn't really be necessary to most developers as it is automatically invoked every 30 seconds, however
-   * if you wish to force a sync of Guild data, you can use this.
+   * if you wish to force a sync of guild data, you can use this.
    * <warn>This is only applicable to user accounts.</warn>
    * @param {Guild[]|Collection<string, Guild>} [guilds=this.guilds] An array or collection of guilds to sync
    */

--- a/src/client/ClientDataManager.js
+++ b/src/client/ClientDataManager.js
@@ -24,7 +24,7 @@ class ClientDataManager {
     this.client.guilds.set(guild.id, guild);
     if (this.pastReady && !already) {
       /**
-       * Emitted whenever the client joins a Guild.
+       * Emitted whenever the client joins a guild.
        * @event Client#guildCreate
        * @param {Guild} guild The created guild
        */

--- a/src/client/ClientDataResolver.js
+++ b/src/client/ClientDataResolver.js
@@ -25,10 +25,10 @@ class ClientDataResolver {
   /**
    * Data that resolves to give a User object. This can be:
    * * A User object
-   * * A User ID
-   * * A Message (resolves to the message author)
-   * * A Guild (owner of the guild)
-   * * A Guild Member
+   * * A user ID
+   * * A Message object (resolves to the message author)
+   * * A Guild object (owner of the guild)
+   * * A GuildMember object
    * @typedef {User|string|Message|Guild|GuildMember} UserResolvable
    */
 
@@ -99,10 +99,10 @@ class ClientDataResolver {
 
   /**
    * Data that can be resolved to give a Channel. This can be:
-   * * An instance of a Channel
-   * * An instance of a Message (the channel the message was sent in)
-   * * An instance of a Guild (the #general channel)
-   * * An ID of a Channel
+   * * A Channel object
+   * * A Message object (the channel the message was sent in)
+   * * A Guild object (the #general channel)
+   * * A channel ID
    * @typedef {Channel|Guild|Message|string} ChannelResolvable
    */
 
@@ -190,7 +190,7 @@ class ClientDataResolver {
   /**
    * Data that can be resolved to give a string. This can be:
    * * A string
-   * * An Array (joined with a new line delimiter to give a string)
+   * * An array (joined with a new line delimiter to give a string)
    * * Any value
    * @typedef {string|Array|*} StringResolvable
    */
@@ -209,7 +209,7 @@ class ClientDataResolver {
   /**
    * Data that resolves to give a Base64 string, typically for image uploading. This can be:
    * * A Buffer
-   * * A Base64 string
+   * * A base64 string
    * @typedef {Buffer|string} Base64Resolvable
    */
 

--- a/src/client/voice/ClientVoiceManager.js
+++ b/src/client/voice/ClientVoiceManager.js
@@ -23,7 +23,7 @@ class ClientVoiceManager {
     this.connections = new Collection();
 
     /**
-     * Pending connection attempts, maps Guild ID to VoiceChannel
+     * Pending connection attempts, maps guild ID to VoiceChannel
      * @type {Collection<string, VoiceChannel>}
      */
     this.pending = new Collection();

--- a/src/client/voice/VoiceConnection.js
+++ b/src/client/voice/VoiceConnection.js
@@ -7,7 +7,7 @@ const EventEmitter = require('events').EventEmitter;
 const fs = require('fs');
 
 /**
- * Represents a connection to a Voice Channel in Discord.
+ * Represents a connection to a voice channel in Discord.
  * ```js
  * // obtained using:
  * voiceChannel.join().then(connection => {

--- a/src/client/websocket/packets/handlers/ChannelCreate.js
+++ b/src/client/websocket/packets/handlers/ChannelCreate.js
@@ -9,7 +9,7 @@ class ChannelCreateHandler extends AbstractHandler {
 }
 
 /**
- * Emitted whenever a Channel is created.
+ * Emitted whenever a channel is created.
  * @event Client#channelCreate
  * @param {Channel} channel The channel that was created
  */

--- a/src/client/websocket/packets/handlers/ChannelDelete.js
+++ b/src/client/websocket/packets/handlers/ChannelDelete.js
@@ -12,7 +12,7 @@ class ChannelDeleteHandler extends AbstractHandler {
 }
 
 /**
- * Emitted whenever a Channel is deleted.
+ * Emitted whenever a channel is deleted.
  * @event Client#channelDelete
  * @param {Channel} channel The channel that was deleted
  */

--- a/src/client/websocket/packets/handlers/ChannelPinsUpdate.js
+++ b/src/client/websocket/packets/handlers/ChannelPinsUpdate.js
@@ -21,7 +21,7 @@ class ChannelPinsUpdate extends AbstractHandler {
 }
 
 /**
- * Emitted whenever the pins of a Channel are updated. Due to the nature of the WebSocket event, not much information
+ * Emitted whenever the pins of a channel are updated. Due to the nature of the WebSocket event, not much information
  * can be provided easily here - you need to manually check the pins yourself.
  * @event Client#channelPinsUpdate
  * @param {Channel} channel The channel that the pins update occured in

--- a/src/client/websocket/packets/handlers/GuildDelete.js
+++ b/src/client/websocket/packets/handlers/GuildDelete.js
@@ -11,7 +11,7 @@ class GuildDeleteHandler extends AbstractHandler {
 }
 
 /**
- * Emitted whenever a Guild is deleted/left.
+ * Emitted whenever a guild is deleted/left.
  * @event Client#guildDelete
  * @param {Guild} guild The guild that was deleted
  */

--- a/src/client/websocket/packets/handlers/GuildMembersChunk.js
+++ b/src/client/websocket/packets/handlers/GuildMembersChunk.js
@@ -20,7 +20,7 @@ class GuildMembersChunkHandler extends AbstractHandler {
 }
 
 /**
- * Emitted whenever a chunk of Guild members is received (all members come from the same guild)
+ * Emitted whenever a chunk of guild members is received (all members come from the same guild)
  * @event Client#guildMembersChunk
  * @param {GuildMember[]} members The members in the chunk
  */

--- a/src/client/websocket/packets/handlers/PresenceUpdate.js
+++ b/src/client/websocket/packets/handlers/PresenceUpdate.js
@@ -64,7 +64,7 @@ class PresenceUpdateHandler extends AbstractHandler {
  */
 
 /**
- * Emitted whenever a member becomes available in a large Guild
+ * Emitted whenever a member becomes available in a large guild
  * @event Client#guildMemberAvailable
  * @param {GuildMember} member The member that became available
  */

--- a/src/structures/Channel.js
+++ b/src/structures/Channel.js
@@ -1,5 +1,5 @@
 /**
- * Represents any Channel on Discord
+ * Represents any channel on Discord
  */
 class Channel {
   constructor(client, data) {

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -2,7 +2,7 @@ const User = require('./User');
 const Collection = require('../util/Collection');
 
 /**
- * Represents the logged in client's Discord User
+ * Represents the logged in client's Discord user
  * @extends {User}
  */
 class ClientUser extends User {

--- a/src/structures/DMChannel.js
+++ b/src/structures/DMChannel.js
@@ -3,7 +3,7 @@ const TextBasedChannel = require('./interface/TextBasedChannel');
 const Collection = require('../util/Collection');
 
 /**
- * Represents a Direct Message Channel between two users.
+ * Represents a direct message channel between two users.
  * @extends {Channel}
  * @implements {TextBasedChannel}
  */

--- a/src/structures/Emoji.js
+++ b/src/structures/Emoji.js
@@ -2,7 +2,7 @@ const Constants = require('../util/Constants');
 const Collection = require('../util/Collection');
 
 /**
- * Represents a Custom Emoji
+ * Represents a custom emoji
  */
 class Emoji {
   constructor(guild, data) {
@@ -14,7 +14,7 @@ class Emoji {
     Object.defineProperty(this, 'client', { enumerable: false, configurable: false });
 
     /**
-     * The Guild this emoji is part of
+     * The guild this emoji is part of
      * @type {Guild}
      */
     this.guild = guild;
@@ -24,13 +24,13 @@ class Emoji {
 
   setup(data) {
     /**
-     * The ID of the Emoji
+     * The ID of the emoji
      * @type {string}
      */
     this.id = data.id;
 
     /**
-     * The name of the Emoji
+     * The name of the emoji
      * @type {string}
      */
     this.name = data.name;

--- a/src/structures/GroupDMChannel.js
+++ b/src/structures/GroupDMChannel.js
@@ -110,7 +110,7 @@ class GroupDMChannel extends Channel {
   }
 
   /**
-   * When concatenated with a string, this automatically concatenates the Channel's name instead of the Channel object.
+   * When concatenated with a string, this automatically concatenates the channel's name instead of the Channel object.
    * @returns {string}
    * @example
    * // logs: Hello from My Group DM!

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -9,7 +9,7 @@ const cloneObject = require('../util/CloneObject');
 const arraysEqual = require('../util/ArraysEqual');
 
 /**
- * Represents a Guild (or a Server) on Discord.
+ * Represents a guild (or a server) on Discord.
  * <info>It's recommended to see if a guild is available before performing operations or reading data from it. You can
  * check this with `guild.available`.</info>
  */
@@ -23,19 +23,19 @@ class Guild {
     Object.defineProperty(this, 'client', { enumerable: false, configurable: false });
 
     /**
-     * A Collection of members that are in this Guild. The key is the member's ID, the value is the member.
+     * A collection of members that are in this guild. The key is the member's ID, the value is the member.
      * @type {Collection<string, GuildMember>}
      */
     this.members = new Collection();
 
     /**
-     * A Collection of channels that are in this Guild. The key is the channel's ID, the value is the channel.
+     * A collection of channels that are in this guild. The key is the channel's ID, the value is the channel.
      * @type {Collection<string, GuildChannel>}
      */
     this.channels = new Collection();
 
     /**
-     * A Collection of roles that are in this Guild. The key is the role's ID, the value is the role.
+     * A collection of roles that are in this guild. The key is the role's ID, the value is the role.
      * @type {Collection<string, Role>}
      */
     this.roles = new Collection();
@@ -43,7 +43,7 @@ class Guild {
     if (!data) return;
     if (data.unavailable) {
       /**
-       * Whether the Guild is available to access. If it is not available, it indicates a server outage.
+       * Whether the guild is available to access. If it is not available, it indicates a server outage.
        * @type {boolean}
        */
       this.available = false;
@@ -90,7 +90,7 @@ class Guild {
     this.region = data.region;
 
     /**
-     * The full amount of members in this Guild as of `READY`
+     * The full amount of members in this guild as of `READY`
      * @type {number}
      */
     this.memberCount = data.member_count || this.memberCount;
@@ -102,7 +102,7 @@ class Guild {
     this.large = data.large || this.large;
 
     /**
-     * A collection of presences in this Guild
+     * A collection of presences in this guild
      * @type {Collection<string, Presence>}
      */
     this.presences = new Collection();
@@ -114,7 +114,7 @@ class Guild {
     this.features = data.features;
 
     /**
-     * A Collection of emojis that are in this Guild. The key is the emoji's ID, the value is the emoji.
+     * A collection of emojis that are in this guild. The key is the emoji's ID, the value is the emoji.
      * @type {Collection<string, Emoji>}
      */
     this.emojis = new Collection();
@@ -242,7 +242,7 @@ class Guild {
   }
 
   /**
-   * The owner of the Guild
+   * The owner of the guild
    * @type {GuildMember}
    * @readonly
    */
@@ -269,7 +269,7 @@ class Guild {
   }
 
   /**
-   * Returns the GuildMember form of a User object, if the User is present in the guild.
+   * Returns the GuildMember form of a User object, if the user is present in the guild.
    * @param {UserResolvable} user The user that you want to obtain the GuildMember of
    * @returns {?GuildMember}
    * @example
@@ -281,7 +281,7 @@ class Guild {
   }
 
   /**
-   * Fetch a Collection of banned users in this Guild.
+   * Fetch a collection of banned users in this guild.
    * @returns {Promise<Collection<string, User>>}
    */
   fetchBans() {
@@ -289,7 +289,7 @@ class Guild {
   }
 
   /**
-   * Fetch a Collection of invites to this Guild. Resolves with a Collection mapping invites by their codes.
+   * Fetch a collection of invites to this guild. Resolves with a collection mapping invites by their codes.
    * @returns {Promise<Collection<string, Invite>>}
    */
   fetchInvites() {
@@ -318,7 +318,7 @@ class Guild {
   }
 
   /**
-   * Fetches all the members in the Guild, even if they are offline. If the Guild has less than 250 members,
+   * Fetches all the members in the guild, even if they are offline. If the guild has less than 250 members,
    * this should not be necessary.
    * @param {string} [query=''] An optional query to provide when fetching members
    * @returns {Promise<Guild>}
@@ -375,8 +375,8 @@ class Guild {
   }
 
   /**
-   * Edit the name of the Guild.
-   * @param {string} name The new name of the Guild
+   * Edit the name of the guild.
+   * @param {string} name The new name of the guild
    * @returns {Promise<Guild>}
    * @example
    * // edit the guild name
@@ -389,7 +389,7 @@ class Guild {
   }
 
   /**
-   * Edit the region of the Guild.
+   * Edit the region of the guild.
    * @param {string} region The new region of the guild.
    * @returns {Promise<Guild>}
    * @example
@@ -403,7 +403,7 @@ class Guild {
   }
 
   /**
-   * Edit the verification level of the Guild.
+   * Edit the verification level of the guild.
    * @param {number} verificationLevel The new verification level of the guild
    * @returns {Promise<Guild>}
    * @example
@@ -417,7 +417,7 @@ class Guild {
   }
 
   /**
-   * Edit the AFK channel of the Guild.
+   * Edit the AFK channel of the guild.
    * @param {GuildChannelResolvable} afkChannel The new AFK channel
    * @returns {Promise<Guild>}
    * @example
@@ -431,7 +431,7 @@ class Guild {
   }
 
   /**
-   * Edit the AFK timeout of the Guild.
+   * Edit the AFK timeout of the guild.
    * @param {number} afkTimeout The time in seconds that a user must be idle to be considered AFK
    * @returns {Promise<Guild>}
    * @example
@@ -445,7 +445,7 @@ class Guild {
   }
 
   /**
-   * Set a new Guild Icon.
+   * Set a new guild icon.
    * @param {Base64Resolvable} icon The new icon of the guild
    * @returns {Promise<Guild>}
    * @example
@@ -459,8 +459,8 @@ class Guild {
   }
 
   /**
-   * Sets a new owner of the Guild.
-   * @param {GuildMemberResolvable} owner The new owner of the Guild
+   * Sets a new owner of the guild.
+   * @param {GuildMemberResolvable} owner The new owner of the guild
    * @returns {Promise<Guild>}
    * @example
    * // edit the guild owner
@@ -473,7 +473,7 @@ class Guild {
   }
 
   /**
-   * Set a new Guild Splash Logo.
+   * Set a new guild splash screen.
    * @param {Base64Resolvable} splash The new splash screen of the guild
    * @returns {Promise<Guild>}
    * @example
@@ -503,7 +503,7 @@ class Guild {
   }
 
   /**
-   * Unbans a user from the Guild.
+   * Unbans a user from the guild.
    * @param {UserResolvable} user The user to unban
    * @returns {Promise<User>}
    * @example
@@ -546,7 +546,7 @@ class Guild {
   }
 
   /**
-   * Creates a new Channel in the Guild.
+   * Creates a new channel in the guild.
    * @param {string} name The name of the new channel
    * @param {string} type The type of the new channel, either `text` or `voice`
    * @returns {Promise<TextChannel|VoiceChannel>}
@@ -702,7 +702,7 @@ class Guild {
   }
 
   /**
-   * When concatenated with a string, this automatically concatenates the Guild's name instead of the Guild object.
+   * When concatenated with a string, this automatically concatenates the guild's name instead of the Guild object.
    * @returns {string}
    * @example
    * // logs: Hello from My Guild!
@@ -757,7 +757,7 @@ class Guild {
 
     if (this.client.ws.status === Constants.Status.READY && notSame) {
       /**
-       * Emitted whenever a Guild Member changes - i.e. new role, removed role, nickname
+       * Emitted whenever a guild member changes - i.e. new role, removed role, nickname
        * @event Client#guildMemberUpdate
        * @param {GuildMember} oldMember The member before the update
        * @param {GuildMember} newMember The member after the update
@@ -781,7 +781,7 @@ class Guild {
     if (member && member.speaking !== speaking) {
       member.speaking = speaking;
       /**
-       * Emitted once a Guild Member starts/stops speaking
+       * Emitted once a guild member starts/stops speaking
        * @event Client#guildMemberSpeaking
        * @param {GuildMember} member The member that started/stopped speaking
        * @param {boolean} speaking Whether or not the member is speaking

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -7,7 +7,7 @@ const Collection = require('../util/Collection');
 const arraysEqual = require('../util/ArraysEqual');
 
 /**
- * Represents a Guild Channel (i.e. Text Channels and Voice Channels)
+ * Represents a guild channel (i.e. text channels and voice channels)
  * @extends {Channel}
  */
 class GuildChannel extends Channel {
@@ -25,7 +25,7 @@ class GuildChannel extends Channel {
     super.setup(data);
 
     /**
-     * The name of the Guild Channel
+     * The name of the guild channel
      * @type {string}
      */
     this.name = data.name;
@@ -186,7 +186,7 @@ class GuildChannel extends Channel {
   }
 
   /**
-   * Set a new name for the Guild Channel
+   * Set a new name for the guild channel
    * @param {string} name The new name for the guild channel
    * @returns {Promise<GuildChannel>}
    * @example
@@ -200,7 +200,7 @@ class GuildChannel extends Channel {
   }
 
   /**
-   * Set a new position for the Guild Channel
+   * Set a new position for the guild channel
    * @param {number} position The new position for the guild channel
    * @returns {Promise<GuildChannel>}
    * @example
@@ -214,7 +214,7 @@ class GuildChannel extends Channel {
   }
 
   /**
-   * Set a new topic for the Guild Channel
+   * Set a new topic for the guild channel
    * @param {string} topic The new topic for the guild channel
    * @returns {Promise<GuildChannel>}
    * @example
@@ -228,7 +228,7 @@ class GuildChannel extends Channel {
   }
 
   /**
-   * Options given when creating a Guild Channel Invite
+   * Options given when creating a guild channel invite
    * @typedef {Object} InviteOptions
    * @property {boolean} [temporary=false] Whether the invite should kick users after 24hrs if they are not given a role
    * @property {number} [maxAge=0] Time in seconds the invite expires in
@@ -236,7 +236,7 @@ class GuildChannel extends Channel {
    */
 
   /**
-   * Create an invite to this Guild Channel
+   * Create an invite to this guild channel
    * @param {InviteOptions} [options={}] The options for the invite
    * @returns {Promise<Invite>}
    */
@@ -272,7 +272,7 @@ class GuildChannel extends Channel {
   }
 
   /**
-   * When concatenated with a string, this automatically returns the Channel's mention instead of the Channel object.
+   * When concatenated with a string, this automatically returns the channel's mention instead of the Channel object.
    * @returns {string}
    * @example
    * // Outputs: Hello from #general

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -6,13 +6,13 @@ const Collection = require('../util/Collection');
 const Presence = require('./Presence').Presence;
 
 /**
- * Represents a Member of a Guild on Discord
+ * Represents a member of a guild on Discord
  * @implements {TextBasedChannel}
  */
 class GuildMember {
   constructor(guild, data) {
     /**
-     * The client that instantiated this GuildMember
+     * The Client that instantiated this GuildMember
      * @type {Client}
      */
     this.client = guild.client;
@@ -78,7 +78,7 @@ class GuildMember {
     this.speaking = false;
 
     /**
-     * The nickname of this Guild Member, if they have one
+     * The nickname of this guild member, if they have one
      * @type {?string}
      */
     this.nickname = data.nick || null;
@@ -103,7 +103,7 @@ class GuildMember {
   }
 
   /**
-   * The presence of this Guild Member
+   * The presence of this guild member
    * @type {Presence}
    * @readonly
    */
@@ -167,7 +167,7 @@ class GuildMember {
   }
 
   /**
-   * The ID of this User
+   * The ID of this user
    * @type {string}
    * @readonly
    */
@@ -263,7 +263,7 @@ class GuildMember {
   }
 
   /**
-   * Edit a Guild Member
+   * Edit a guild member
    * @param {GuildmemberEditData} data The data to edit the member with
    * @returns {Promise<GuildMember>}
    */
@@ -290,7 +290,7 @@ class GuildMember {
   }
 
   /**
-   * Moves the Guild Member to the given channel.
+   * Moves the guild member to the given channel.
    * @param {ChannelResolvable} channel The channel to move the member to
    * @returns {Promise<GuildMember>}
    */
@@ -299,7 +299,7 @@ class GuildMember {
   }
 
   /**
-   * Sets the Roles applied to the member.
+   * Sets the roles applied to the member.
    * @param {Collection<string, Role>|Role[]|string[]} roles The roles or role IDs to apply
    * @returns {Promise<GuildMember>}
    */
@@ -308,7 +308,7 @@ class GuildMember {
   }
 
   /**
-   * Adds a single Role to the member.
+   * Adds a single role to the member.
    * @param {Role|string} role The role or ID of the role to add
    * @returns {Promise<GuildMember>}
    */
@@ -333,7 +333,7 @@ class GuildMember {
   }
 
   /**
-   * Removes a single Role from the member.
+   * Removes a single role from the member.
    * @param {Role|string} role The role or ID of the role to remove
    * @returns {Promise<GuildMember>}
    */
@@ -363,8 +363,8 @@ class GuildMember {
   }
 
   /**
-   * Set the nickname for the Guild Member
-   * @param {string} nick The nickname for the Guild Member
+   * Set the nickname for the guild member
+   * @param {string} nick The nickname for the guild member
    * @returns {Promise<GuildMember>}
    */
   setNickname(nick) {
@@ -372,7 +372,7 @@ class GuildMember {
   }
 
   /**
-   * Deletes any DMs with this Guild Member
+   * Deletes any DMs with this guild member
    * @returns {Promise<DMChannel>}
    */
   deleteDM() {
@@ -380,7 +380,7 @@ class GuildMember {
   }
 
   /**
-   * Kick this member from the Guild
+   * Kick this member from the guild
    * @returns {Promise<GuildMember>}
    */
   kick() {
@@ -388,7 +388,7 @@ class GuildMember {
   }
 
   /**
-   * Ban this Guild Member
+   * Ban this guild member
    * @param {number} [deleteDays=0] The amount of days worth of messages from this member that should
    * also be deleted. Between `0` and `7`.
    * @returns {Promise<GuildMember>}
@@ -401,7 +401,7 @@ class GuildMember {
   }
 
   /**
-   * When concatenated with a string, this automatically concatenates the User's mention instead of the Member object.
+   * When concatenated with a string, this automatically concatenates the user's mention instead of the Member object.
    * @returns {string}
    * @example
    * // logs: Hello from <@123456789>!

--- a/src/structures/Invite.js
+++ b/src/structures/Invite.js
@@ -24,7 +24,7 @@ const Constants = require('../util/Constants');
 */
 
 /**
- * Represents an Invitation to a Guild Channel.
+ * Represents an invitation to a guild channel.
  * <warn>The only guaranteed properties are `code`, `guild` and `channel`. Other properties can be missing.</warn>
  */
 class Invite {
@@ -41,8 +41,8 @@ class Invite {
 
   setup(data) {
     /**
-     * The Guild the invite is for. If this Guild is already known, this will be a Guild object. If the Guild is
-     * unknown, this will be a Partial Guild.
+     * The guild the invite is for. If this guild is already known, this will be a Guild object. If the guild is
+     * unknown, this will be a PartialGuild object.
      * @type {Guild|PartialGuild}
      */
     this.guild = this.client.guilds.get(data.guild.id) || new PartialGuild(this.client, data.guild);
@@ -86,8 +86,8 @@ class Invite {
     }
 
     /**
-     * The Channel the invite is for. If this Channel is already known, this will be a GuildChannel object.
-     * If the Channel is unknown, this will be a Partial Guild Channel.
+     * The channel the invite is for. If this channel is already known, this will be a GuildChannel object.
+     * If the channel is unknown, this will be a PartialGuildChannel object.
      * @type {GuildChannel|PartialGuildChannel}
      */
     this.channel = this.client.channels.get(data.channel.id) || new PartialGuildChannel(this.client, data.channel);
@@ -144,7 +144,7 @@ class Invite {
   }
 
   /**
-   * When concatenated with a string, this automatically concatenates the Invite's URL instead of the object.
+   * When concatenated with a string, this automatically concatenates the invite's URL instead of the object.
    * @returns {string}
    * @example
    * // logs: Invite: https://discord.gg/A1b2C3

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -6,12 +6,12 @@ const escapeMarkdown = require('../util/EscapeMarkdown');
 const MessageReaction = require('./MessageReaction');
 
 /**
- * Represents a Message on Discord
+ * Represents a message on Discord
  */
 class Message {
   constructor(channel, data, client) {
     /**
-     * The client that instantiated the Message
+     * The Client that instantiated the Message
      * @type {Client}
      */
     this.client = client;
@@ -52,7 +52,7 @@ class Message {
     this.author = this.client.dataManager.newUser(data.author);
 
     /**
-     * Represents the Author of the message as a Guild Member. Only available if the message comes from a Guild
+     * Represents the author of the message as a guild member. Only available if the message comes from a guild
      * where the author is still a member.
      * @type {GuildMember}
      */
@@ -151,7 +151,7 @@ class Message {
     this._edits = [];
 
     /**
-     * A collection of Reactions to this Message, mapped by the reaction "id".
+     * A collection of reactions to this message, mapped by the reaction "id".
      * @type {Collection<string, MessageReaction>}
      */
     this.reactions = new Collection();
@@ -504,7 +504,7 @@ class Message {
   }
 
   /**
-   * When concatenated with a string, this automatically concatenates the Message's content instead of the object.
+   * When concatenated with a string, this automatically concatenates the message's content instead of the object.
    * @returns {string}
    * @example
    * // logs: Message: This is a message!

--- a/src/structures/MessageAttachment.js
+++ b/src/structures/MessageAttachment.js
@@ -1,10 +1,10 @@
 /**
- * Represents an Attachment in a Message
+ * Represents an attachment in a message
  */
 class MessageAttachment {
   constructor(message, data) {
     /**
-     * The Client that instantiated this Message.
+     * The Client that instantiated this MessageAttachment.
      * @type {Client}
      */
     this.client = message.client;

--- a/src/structures/MessageCollector.js
+++ b/src/structures/MessageCollector.js
@@ -54,7 +54,7 @@ class MessageCollector extends EventEmitter {
     this.options = options;
 
     /**
-     * Whether this collector has stopped collecting Messages.
+     * Whether this collector has stopped collecting messages.
      * @type {boolean}
      */
     this.ended = false;
@@ -81,7 +81,7 @@ class MessageCollector extends EventEmitter {
     if (this.filter(message, this)) {
       this.collected.set(message.id, message);
       /**
-       * Emitted whenever the Collector receives a Message that passes the filter test.
+       * Emitted whenever the collector receives a message that passes the filter test.
        * @param {Message} message The received message
        * @param {MessageCollector} collector The collector the message passed through
        * @event MessageCollector#message
@@ -138,7 +138,7 @@ class MessageCollector extends EventEmitter {
     /**
      * Emitted when the Collector stops collecting.
      * @param {Collection<string, Message>} collection A collection of messages collected
-     * during the lifetime of the Collector, mapped by the ID of the Messages.
+     * during the lifetime of the collector, mapped by the ID of the messages.
      * @param {string} reason The reason for the end of the collector. If it ended because it reached the specified time
      * limit, this would be `time`. If you invoke `.stop()` without specifying a reason, this would be `user`. If it
      * ended because it reached its message limit, it will be `limit`.

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -65,7 +65,7 @@ class MessageEmbed {
 }
 
 /**
- * Represents a thumbnail for a Message embed
+ * Represents a thumbnail for a message embed
  */
 class MessageEmbedThumbnail {
   constructor(embed, data) {
@@ -106,7 +106,7 @@ class MessageEmbedThumbnail {
 }
 
 /**
- * Represents a Provider for a Message embed
+ * Represents a provider for a message embed
  */
 class MessageEmbedProvider {
   constructor(embed, data) {
@@ -135,7 +135,7 @@ class MessageEmbedProvider {
 }
 
 /**
- * Represents a Author for a Message embed
+ * Represents a author for a message embed
  */
 class MessageEmbedAuthor {
   constructor(embed, data) {

--- a/src/structures/MessageReaction.js
+++ b/src/structures/MessageReaction.js
@@ -35,8 +35,9 @@ class MessageReaction {
   }
 
   /**
-   * The emoji of this reaction, either an Emoji object for known custom emojis, or a ReactionEmoji which has fewer
-   * properties. Whatever the prototype of the emoji, it will still have `name`, `id`, `identifier` and `toString()`
+   * The emoji of this reaction, either an Emoji object for known custom emojis, or a ReactionEmoji
+   * object which has fewer properties. Whatever the prototype of the emoji, it will still have
+   * `name`, `id`, `identifier` and `toString()`
    * @type {Emoji|ReactionEmoji}
    */
   get emoji() {

--- a/src/structures/PartialGuild.js
+++ b/src/structures/PartialGuild.js
@@ -6,12 +6,12 @@
 */
 
 /**
- * Represents a Guild that the client only has limited information for - e.g. from invites.
+ * Represents a guild that the client only has limited information for - e.g. from invites.
  */
 class PartialGuild {
   constructor(client, data) {
     /**
-     * The client that instantiated this PartialGuild
+     * The Client that instantiated this PartialGuild
      * @type {Client}
      */
     this.client = client;

--- a/src/structures/PartialGuildChannel.js
+++ b/src/structures/PartialGuildChannel.js
@@ -5,12 +5,12 @@ const Constants = require('../util/Constants');
 */
 
 /**
- * Represents a Guild Channel that the client only has limited information for - e.g. from invites.
+ * Represents a guild channel that the client only has limited information for - e.g. from invites.
  */
 class PartialGuildChannel {
   constructor(client, data) {
     /**
-     * The client that instantiated this PartialGuildChannel
+     * The Client that instantiated this PartialGuildChannel
      * @type {Client}
      */
     this.client = client;
@@ -21,19 +21,19 @@ class PartialGuildChannel {
 
   setup(data) {
     /**
-     * The ID of this Guild Channel
+     * The ID of this guild channel
      * @type {string}
      */
     this.id = data.id;
 
     /**
-     * The name of this Guild Channel
+     * The name of this guild channel
      * @type {string}
      */
     this.name = data.name;
 
     /**
-     * The type of this Guild Channel - `text` or `voice`
+     * The type of this guild channel - `text` or `voice`
      * @type {string}
      */
     this.type = Constants.ChannelTypes.text === data.type ? 'text' : 'voice';

--- a/src/structures/PermissionOverwrites.js
+++ b/src/structures/PermissionOverwrites.js
@@ -1,5 +1,5 @@
 /**
- * Represents a permission overwrite for a Role or Member in a Guild Channel.
+ * Represents a permission overwrite for a role or member in a guild channel.
  */
 class PermissionOverwrites {
   constructor(guildChannel, data) {
@@ -14,7 +14,7 @@ class PermissionOverwrites {
 
   setup(data) {
     /**
-     * The ID of this overwrite, either a User ID or a Role ID
+     * The ID of this overwrite, either a user ID or a role ID
      * @type {string}
      */
     this.id = data.id;

--- a/src/structures/Presence.js
+++ b/src/structures/Presence.js
@@ -1,5 +1,5 @@
 /**
- * Represents a User's presence
+ * Represents a user's presence
  */
 class Presence {
   constructor(data) {
@@ -44,7 +44,7 @@ class Presence {
 }
 
 /**
- * Represents a Game that is part of a User's presence.
+ * Represents a game that is part of a user's presence.
  */
 class Game {
   constructor(data) {

--- a/src/structures/Role.js
+++ b/src/structures/Role.js
@@ -1,7 +1,7 @@
 const Constants = require('../util/Constants');
 
 /**
- * Represents a Role on Discord
+ * Represents a role on Discord
  */
 class Role {
   constructor(guild, data) {
@@ -304,7 +304,7 @@ class Role {
   }
 
   /**
-   * When concatenated with a string, this automatically concatenates the Role mention rather than the Role object.
+   * When concatenated with a string, this automatically concatenates the role mention rather than the Role object.
    * @returns {string}
    */
   toString() {

--- a/src/structures/TextChannel.js
+++ b/src/structures/TextChannel.js
@@ -3,7 +3,7 @@ const TextBasedChannel = require('./interface/TextBasedChannel');
 const Collection = require('../util/Collection');
 
 /**
- * Represents a Server Text Channel on Discord.
+ * Represents a guild text channel on Discord.
  * @extends {GuildChannel}
  * @implements {TextBasedChannel}
  */
@@ -19,7 +19,7 @@ class TextChannel extends GuildChannel {
     super.setup(data);
 
     /**
-     * The topic of the Text Channel, if there is one.
+     * The topic of the text channel, if there is one.
      * @type {?string}
      */
     this.topic = data.topic;

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -3,7 +3,7 @@ const Constants = require('../util/Constants');
 const Presence = require('./Presence').Presence;
 
 /**
- * Represents a User on Discord.
+ * Represents a user on Discord.
  * @implements {TextBasedChannel}
  */
 class User {
@@ -20,19 +20,19 @@ class User {
 
   setup(data) {
     /**
-     * The ID of the User
+     * The ID of the user
      * @type {string}
      */
     this.id = data.id;
 
     /**
-     * The username of the User
+     * The username of the user
      * @type {string}
      */
     this.username = data.username;
 
     /**
-     * A discriminator based on username for the User
+     * A discriminator based on username for the user
      * @type {string}
      */
     this.discriminator = data.discriminator;
@@ -44,7 +44,7 @@ class User {
     this.avatar = data.avatar;
 
     /**
-     * Whether or not the User is a Bot.
+     * Whether or not the user is a bot.
      * @type {boolean}
      */
     this.bot = Boolean(data.bot);
@@ -138,7 +138,7 @@ class User {
   }
 
   /**
-   * Deletes a DM Channel (if one exists) between the Client and the User. Resolves with the Channel if successful.
+   * Deletes a DM channel (if one exists) between the client and the user. Resolves with the channel if successful.
    * @returns {Promise<DMChannel>}
    */
   deleteDM() {
@@ -217,7 +217,7 @@ class User {
   }
 
   /**
-   * When concatenated with a string, this automatically concatenates the User's mention instead of the User object.
+   * When concatenated with a string, this automatically concatenates the user's mention instead of the User object.
    * @returns {string}
    * @example
    * // logs: Hello from <@123456789>!

--- a/src/structures/UserConnection.js
+++ b/src/structures/UserConnection.js
@@ -1,5 +1,5 @@
 /**
- * Represents a User Connection object (or "platform identity")
+ * Represents a user connection (or "platform identity")
  */
 class UserConnection {
   constructor(user, data) {

--- a/src/structures/UserProfile.js
+++ b/src/structures/UserProfile.js
@@ -13,14 +13,14 @@ class UserProfile {
     this.user = user;
 
     /**
-     * The Client that created the instance of the the User.
+     * The Client that created the instance of the the UserProfile.
      * @type {Client}
      */
     this.client = this.user.client;
     Object.defineProperty(this, 'client', { enumerable: false, configurable: false });
 
     /**
-     * Guilds that the ClientUser and the User share
+     * Guilds that the client user and the user share
      * @type {Collection<Guild>}
      */
     this.mutualGuilds = new Collection();

--- a/src/structures/VoiceChannel.js
+++ b/src/structures/VoiceChannel.js
@@ -2,7 +2,7 @@ const GuildChannel = require('./GuildChannel');
 const Collection = require('../util/Collection');
 
 /**
- * Represents a Server Voice Channel on Discord.
+ * Represents a guild voice channel on Discord.
  * @extends {GuildChannel}
  */
 class VoiceChannel extends GuildChannel {
@@ -10,7 +10,7 @@ class VoiceChannel extends GuildChannel {
     super(guild, data);
 
     /**
-     * The members in this Voice Channel.
+     * The members in this voice channel.
      * @type {Collection<string, GuildMember>}
      */
     this.members = new Collection();
@@ -90,7 +90,7 @@ class VoiceChannel extends GuildChannel {
   }
 
   /**
-   * Attempts to join this Voice Channel
+   * Attempts to join this voice channel
    * @returns {Promise<VoiceConnection>}
    * @example
    * // join a voice channel

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -2,13 +2,13 @@ const path = require('path');
 const escapeMarkdown = require('../util/EscapeMarkdown');
 
 /**
- * Represents a Webhook
+ * Represents a webhook
  */
 class Webhook {
   constructor(client, dataOrID, token) {
     if (client) {
       /**
-       * The client that instantiated the Channel
+       * The Client that instantiated the Webhook
        * @type {Client}
        */
       this.client = client;
@@ -23,43 +23,43 @@ class Webhook {
 
   setup(data) {
     /**
-     * The name of the Webhook
+     * The name of the webhook
      * @type {string}
      */
     this.name = data.name;
 
     /**
-     * The token for the Webhook
+     * The token for the webhook
      * @type {string}
      */
     this.token = data.token;
 
     /**
-     * The avatar for the Webhook
+     * The avatar for the webhook
      * @type {string}
      */
     this.avatar = data.avatar;
 
     /**
-     * The ID of the Webhook
+     * The ID of the webhook
      * @type {string}
      */
     this.id = data.id;
 
     /**
-     * The guild the Webhook belongs to
+     * The guild the webhook belongs to
      * @type {string}
      */
     this.guildID = data.guild_id;
 
     /**
-     * The channel the Webhook belongs to
+     * The channel the webhook belongs to
      * @type {string}
      */
     this.channelID = data.channel_id;
 
     /**
-     * The owner of the Webhook
+     * The owner of the webhook
      * @type {User}
      */
     if (data.user) this.owner = data.user;
@@ -169,7 +169,7 @@ class Webhook {
   }
 
   /**
-   * Edit the Webhook.
+   * Edit the webhook.
    * @param {string} name The new name for the Webhook
    * @param {BufferResolvable} avatar The new avatar for the Webhook.
    * @returns {Promise<Webhook>}
@@ -188,7 +188,7 @@ class Webhook {
   }
 
   /**
-   * Delete the Webhook
+   * Delete the webhook
    * @returns {Promise}
    */
   delete() {

--- a/src/structures/interface/TextBasedChannel.js
+++ b/src/structures/interface/TextBasedChannel.js
@@ -11,7 +11,7 @@ const escapeMarkdown = require('../../util/EscapeMarkdown');
 class TextBasedChannel {
   constructor() {
     /**
-     * A Collection containing the messages sent to this channel.
+     * A collection containing the messages sent to this channel.
      * @type {Collection<string, Message>}
      */
     this.messages = new Collection();
@@ -147,7 +147,7 @@ class TextBasedChannel {
    */
 
   /**
-   * Gets the past messages sent in this channel. Resolves with a Collection mapping message ID's to Message objects.
+   * Gets the past messages sent in this channel. Resolves with a collection mapping message ID's to Message objects.
    * @param {ChannelLogsQueryOptions} [options={}] The query parameters to pass in
    * @returns {Promise<Collection<string, Message>>}
    * @example
@@ -169,7 +169,7 @@ class TextBasedChannel {
   }
 
   /**
-   * Fetches the pinned messages of this Channel and returns a Collection of them.
+   * Fetches the pinned messages of this channel and returns a collection of them.
    * @returns {Promise<Collection<string, Message>>}
    */
   fetchPinnedMessages() {
@@ -210,7 +210,7 @@ class TextBasedChannel {
   /**
    * Stops the typing indicator in the channel.
    * The indicator will only stop if this is called as many times as startTyping().
-   * <info>It can take a few seconds for the Client User to stop typing.</info>
+   * <info>It can take a few seconds for the client user to stop typing.</info>
    * @param {boolean} [force=false] Whether or not to reset the call count and force the indicator to stop
    * @example
    * // stop typing in a channel
@@ -274,7 +274,7 @@ class TextBasedChannel {
    */
 
   /**
-   * Similar to createCollector but in Promise form. Resolves with a Collection of messages that pass the specified
+   * Similar to createCollector but in promise form. Resolves with a collection of messages that pass the specified
    * filter.
    * @param {CollectorFilterFunction} filter The filter function to use
    * @param {AwaitMessagesOptions} [options={}] Optional options to pass to the internal collector


### PR DESCRIPTION
This commit:
* fixes inconsistencies (primarily regarding capitalization)
* fixes non-proper nouns that were improperly capitalized
* fixes reminents from not-so-meticulous copy+paste jobs