### PR TITLE
Fixed unset field of VoiceConnection

### DIFF
--- a/src/client/voice/VoiceConnection.js
+++ b/src/client/voice/VoiceConnection.js
@@ -33,7 +33,7 @@ class VoiceConnection extends EventEmitter {
     this.channel = pendingConnection.channel;
 
     /**
-     * Indicates whether the voice connection emits a voice signal
+     * Whether we're currently transmitting audio
      * @type {boolean}
      */
     this.speaking = false;

--- a/src/client/voice/VoiceConnection.js
+++ b/src/client/voice/VoiceConnection.js
@@ -33,6 +33,12 @@ class VoiceConnection extends EventEmitter {
     this.channel = pendingConnection.channel;
 
     /**
+     * Indicates whether the voice connection emits a voice signal
+     * @type {boolean}
+     */
+    this.speaking = false;
+
+    /**
      * An array of Voice Receivers that have been created for this connection
      * @type {VoiceReceiver[]}
      */


### PR DESCRIPTION
In v8 a field called [`playing`](http://discordjs.readthedocs.io/en/8.2.0/docs_voiceconnection.html?highlight=playing#playing) existed on VoiceConnection. When trying to migrate to v10, I realized it was missing from the docs. It turns out it is still present, but was renamed to `speaking` and is not set in the constructor. This keeps it from being documented. This PR fixes this.