### PR TITLE
UnhandledPromiseRejectionWarning caused by resolveBuffer on empty resource body

### DIFF
--- a/src/client/ClientDataResolver.js
+++ b/src/client/ClientDataResolver.js
@@ -244,15 +244,7 @@ class ClientDataResolver {
         if (/^https?:\/\//.test(resource)) {
           request.get(resource)
             .set('Content-Type', 'blob')
-            .end((err, res) => {
-              if (err) {
-                reject(err);
-              } else if (res.body instanceof Buffer) {
-                resolve(res.body);
-              } else {
-                resolve();
-              }
-            });
+            .end((err, res) => err ? reject(err) : resolve(res.body instanceof Buffer ? res.body : null));
         } else {
           const file = path.resolve(resource);
           fs.stat(file, (err, stats) => {

--- a/src/client/ClientDataResolver.js
+++ b/src/client/ClientDataResolver.js
@@ -244,7 +244,15 @@ class ClientDataResolver {
         if (/^https?:\/\//.test(resource)) {
           request.get(resource)
             .set('Content-Type', 'blob')
-            .end((err, res) => err ? reject(err) : resolve(res.body));
+            .end((err, res) => {
+              if (err) {
+                reject(err);
+              } else if (res.body instanceof Buffer) {
+                resolve(res.body);
+              } else {
+                resolve();
+              }
+            });
         } else {
           const file = path.resolve(resource);
           fs.stat(file, (err, stats) => {

--- a/src/client/ClientDataResolver.js
+++ b/src/client/ClientDataResolver.js
@@ -244,7 +244,11 @@ class ClientDataResolver {
         if (/^https?:\/\//.test(resource)) {
           request.get(resource)
             .set('Content-Type', 'blob')
-            .end((err, res) => err ? reject(err) : resolve(res.body instanceof Buffer ? res.body : null));
+            .end((err, res) => {
+              if (err) return reject(err);
+              if (!(res.body instanceof Buffer)) return reject(new TypeError('Body is not a Buffer'));
+              return resolve(res.body);
+            });
         } else {
           const file = path.resolve(resource);
           fs.stat(file, (err, stats) => {


### PR DESCRIPTION
Hi,

I'd like to propose a fix for an `UnhandledPromiseRejectionWarning` caused by `resolveBuffer`:
```
(node:4) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 9): TypeError: source.on is not a function
```

When calling `sendFile()` with an attachment URL that returns an empty page (ie. content-length=0), `resolveBuffer` in ClientDataResolver will return `res.body` as an empty object instead of a Buffer. This causes an UnhandledPromiseRejectionWarning further along the way, so my suggested fix would be to simply check if the `resource` actually returned a Buffer. 

Example:
```js
msg.channel.sendFile('http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=242500&type=broken', 'image.jpg', 'look at this cool image');
```

