### PR TITLE
Fix builds failing due to no changes in webpacks

### DIFF
--- a/docs/deploy/deploy.sh
+++ b/docs/deploy/deploy.sh
@@ -66,7 +66,7 @@ cd out
 git add .
 git config user.name "Travis CI"
 git config user.email "$COMMIT_AUTHOR_EMAIL"
-git commit -m "Docs build: ${SHA}"
+git commit -m "Docs build: ${SHA}" || true
 git push $SSH_REPO $TARGET_BRANCH
 
 # Clean up...
@@ -86,5 +86,5 @@ cd out
 git add .
 git config user.name "Travis CI"
 git config user.email "$COMMIT_AUTHOR_EMAIL"
-git commit -m "Webpack build: ${SHA}"
+git commit -m "Webpack build: ${SHA}" || true
 git push $SSH_REPO $TARGET_BRANCH


### PR DESCRIPTION
As reported by @Gawdl3y on the discord.js server. If I am correct only the commit commands should ever fail (I haven't seen errors on push when testing locally) - if necessary this can be amended by simply appending `|| true` to the particular failing lines.