### PR TITLE
fix playConvertedStream

### DIFF
--- a/src/client/voice/VoiceConnection.js
+++ b/src/client/voice/VoiceConnection.js
@@ -253,7 +253,7 @@ class VoiceConnection extends EventEmitter {
    */
   playConvertedStream(stream, { seek = 0, volume = 1, passes = 1 } = {}) {
     const options = { seek, volume, passes };
-    return this.player.playPCMStream(stream, options);
+    return this.player.playPCMStream(stream, null, options);
   }
 
   /**


### PR DESCRIPTION
Incorrect number of arguments was provided to [`AudioPlayer.playPCMStream`](https://github.com/hydrabolt/discord.js/blob/indev/src/client/voice/player/AudioPlayer.js#L55) resulting in an error that [`AudioPlayer.currentConverter.destroy`](https://github.com/hydrabolt/discord.js/blob/indev/src/client/voice/player/AudioPlayer.js#L55) wasn't a function when trying to disconnect.