### PR TITLE
Add more errors for RichEmbed builder char limits

### DIFF
--- a/src/structures/RichEmbed.js
+++ b/src/structures/RichEmbed.js
@@ -141,7 +141,7 @@ class RichEmbed {
    * @returns {RichEmbed} This embed
    */
   addField(name, value, inline = false) {
-    if (this.fields.length >= 25) throw new RangeError('A RichEmbed may only have a maximum of 25 fields.');
+    if (this.fields.length >= 25) throw new RangeError('RichEmbeds may only have a maximum of 25 fields.');
     if (name.length > 256) throw new RangeError('RichEmbed field names may not exceed 256 characters.');
     if (value.length > 1024) throw new RangeError('RichEmbed field values may not exceed 1024 characters.');
     this.fields.push({ name, value, inline });

--- a/src/structures/RichEmbed.js
+++ b/src/structures/RichEmbed.js
@@ -141,7 +141,7 @@ class RichEmbed {
    * @returns {RichEmbed} This embed
    */
   addField(name, value, inline = false) {
-    if (this.fields.length >= 25) throw new RangeError('RichEmbeds may only have a maximum of 25 fields.');
+    if (this.fields.length >= 25) throw new RangeError('RichEmbeds may not exceed 25 fields.');
     if (name.length > 256) throw new RangeError('RichEmbed field names may not exceed 256 characters.');
     if (value.length > 1024) throw new RangeError('RichEmbed field values may not exceed 1024 characters.');
     this.fields.push({ name, value, inline });

--- a/src/structures/RichEmbed.js
+++ b/src/structures/RichEmbed.js
@@ -71,6 +71,7 @@ class RichEmbed {
    * @returns {RichEmbed} This embed
    */
   setTitle(title) {
+    if (title.length > 256) throw new RangeError('RichEmbed titles may not exceed 256 characters.');
     this.title = title;
     return this;
   }
@@ -81,6 +82,7 @@ class RichEmbed {
    * @returns {RichEmbed} This embed
    */
   setDescription(description) {
+    if (description.length > 2048) throw new RangeError('RichEmbed descriptions may not exceed 2048 characters.');
     this.description = description;
     return this;
   }
@@ -140,6 +142,8 @@ class RichEmbed {
    */
   addField(name, value, inline = false) {
     if (this.fields.length >= 25) throw new RangeError('A RichEmbed may only have a maximum of 25 fields.');
+    if (name.length) throw new RangeError('RichEmbed field names may not exceed 256 characters.');
+    if (value.length > 1024) throw new RangeError('RichEmbed field values may not exceed 1024 characters.');
     this.fields.push({ name, value, inline });
     return this;
   }
@@ -171,6 +175,7 @@ class RichEmbed {
    * @returns {RichEmbed} This embed
    */
   setFooter(text, icon) {
+    if (text.length > 2048) throw new RangeError('RichEmbed footer text may not exceed 1024 characters.');
     this.footer = { text, icon_url: icon };
     return this;
   }

--- a/src/structures/RichEmbed.js
+++ b/src/structures/RichEmbed.js
@@ -142,7 +142,7 @@ class RichEmbed {
    */
   addField(name, value, inline = false) {
     if (this.fields.length >= 25) throw new RangeError('A RichEmbed may only have a maximum of 25 fields.');
-    if (name.length) throw new RangeError('RichEmbed field names may not exceed 256 characters.');
+    if (name.length > 256) throw new RangeError('RichEmbed field names may not exceed 256 characters.');
     if (value.length > 1024) throw new RangeError('RichEmbed field values may not exceed 1024 characters.');
     this.fields.push({ name, value, inline });
     return this;


### PR DESCRIPTION
Might as well if we're erroring on number of fields when that's the one limit that doesn't actually throw a bad request.