### PR TITLE
fix remove reactions return

### DIFF
--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -630,7 +630,7 @@ class RESTMethods {
   }
 
   removeMessageReactions(message) {
-    this.rest.makeRequest('delete', Constants.Endpoints.messageReactions(message.channel.id, message.id), true)
+    return this.rest.makeRequest('delete', Constants.Endpoints.messageReactions(message.channel.id, message.id), true)
       .then(() => message);
   }
 


### PR DESCRIPTION
As per an issue brought up in Discord, the `clearReactions` method was returning `undefined`.  This was the solution.