### PR TITLE
Add ffmpeg-binaries as a possible source of ffmpeg

### DIFF
--- a/docs/general/faq.md
+++ b/docs/general/faq.md
@@ -12,6 +12,7 @@ Update to Node.js 6.0.0 or newer.
   node-opus is greatly preferred, due to it having significantly better performance.
 
 ## How do I install FFMPEG?
+- **npm:** `npm install --save ffmpeg-binaries`
 - **Ubuntu 16.04:** `sudo apt install ffmpeg`
 - **Ubuntu 14.04:** `sudo apt-get install libav-tools`
 - **Windows:** See the [FFMPEG section of AoDude's guide](https://github.com/bdistin/OhGodMusicBot/blob/master/README.md#download-ffmpeg).

--- a/src/client/voice/pcm/FfmpegConverterEngine.js
+++ b/src/client/voice/pcm/FfmpegConverterEngine.js
@@ -67,7 +67,14 @@ class FfmpegConverterEngine extends ConverterEngine {
 }
 
 function chooseCommand() {
-  for (const cmd of ['ffmpeg', 'avconv', './ffmpeg', './avconv']) {
+  for (const cmd of [
+    'ffmpeg',
+    'avconv',
+    './ffmpeg',
+    './avconv',
+    'node_modules\\ffmpeg-binaries\\bin\\ffmpeg',
+    'node_modules/ffmpeg-binaries/bin/ffmpeg',
+  ]) {
     if (!ChildProcess.spawnSync(cmd, ['-h']).error) return cmd;
   }
   throw new Error(


### PR DESCRIPTION
It will allow you to just do `npm i ffmpeg-binaries` to install and use ffmpeg.
I didn't add it as a peer dep because you can install ffmpeg through different methods