### PR TITLE
Fix setBitrate typo in VoiceChannel.js

### DIFF
--- a/src/structures/VoiceChannel.js
+++ b/src/structures/VoiceChannel.js
@@ -72,7 +72,7 @@ class VoiceChannel extends GuildChannel {
    *  .catch(console.error);
    */
   setBitrate(bitrate) {
-    return this.rest.client.rest.methods.updateChannel(this, { bitrate });
+    return this.client.rest.methods.updateChannel(this, { bitrate });
   }
 
   /**


### PR DESCRIPTION
Fixed simple typo that prevented setBitrate method from working.