### PR TITLE
friendlier notification of an invalid token

### DIFF
--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -18,9 +18,9 @@ class RESTMethods {
 
   login(token = this.rest.client.token) {
     return new Promise((resolve, reject) => {
-      if(typeof token !== 'string') return reject('invalid token');
+      if (typeof token !== 'string') return reject(Constants.Errors.BAD_LOGIN);
       token = token.replace(/^Bot\s*/i, '');
-      this.rest.client.manager.connectToWebSocket(token, resolve, reject);
+      return this.rest.client.manager.connectToWebSocket(token, resolve, reject);
     });
   }
 

--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -18,6 +18,7 @@ class RESTMethods {
 
   login(token = this.rest.client.token) {
     return new Promise((resolve, reject) => {
+      if(typeof token !== 'string') return reject('invalid token');
       token = token.replace(/^Bot\s*/i, '');
       this.rest.client.manager.connectToWebSocket(token, resolve, reject);
     });

--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -18,7 +18,7 @@ class RESTMethods {
 
   login(token = this.rest.client.token) {
     return new Promise((resolve, reject) => {
-      if (typeof token !== 'string') return reject(Constants.Errors.BAD_LOGIN);
+      if (typeof token !== 'string') return reject(new Error(Constants.Errors.NO_TOKEN));
       token = token.replace(/^Bot\s*/i, '');
       return this.rest.client.manager.connectToWebSocket(token, resolve, reject);
     });

--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -18,9 +18,9 @@ class RESTMethods {
 
   login(token = this.rest.client.token) {
     return new Promise((resolve, reject) => {
-      if (typeof token !== 'string') return reject(new Error(Constants.Errors.INVALID_TOKEN));
+      if (typeof token !== 'string') throw new Error(Constants.Errors.INVALID_TOKEN);
       token = token.replace(/^Bot\s*/i, '');
-      return this.rest.client.manager.connectToWebSocket(token, resolve, reject);
+      this.rest.client.manager.connectToWebSocket(token, resolve, reject);
     });
   }
 

--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -18,7 +18,7 @@ class RESTMethods {
 
   login(token = this.rest.client.token) {
     return new Promise((resolve, reject) => {
-      if (typeof token !== 'string') return reject(new Error(Constants.Errors.NO_TOKEN));
+      if (typeof token !== 'string') return reject(new Error(Constants.Errors.INVALID_TOKEN));
       token = token.replace(/^Bot\s*/i, '');
       return this.rest.client.manager.connectToWebSocket(token, resolve, reject);
     });

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -68,7 +68,7 @@ exports.Errors = {
   INVALID_RATE_LIMIT_METHOD: 'Unknown rate limiting method.',
   BAD_LOGIN: 'Incorrect login details were provided.',
   INVALID_SHARD: 'Invalid shard settings were provided.',
-  INVALID_TOKEN: 'An invalid token was provided.'
+  INVALID_TOKEN: 'An invalid token was provided.',
 };
 
 const PROTOCOL_VERSION = exports.PROTOCOL_VERSION = 6;

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -68,6 +68,7 @@ exports.Errors = {
   INVALID_RATE_LIMIT_METHOD: 'Unknown rate limiting method.',
   BAD_LOGIN: 'Incorrect login details were provided.',
   INVALID_SHARD: 'Invalid shard settings were provided.',
+  INVALID_TOKEN: 'An invalid token was provided.'
 };
 
 const PROTOCOL_VERSION = exports.PROTOCOL_VERSION = 6;


### PR DESCRIPTION
Prompted by many questions asking what `cannot read property 'replace' of null` means.