### PR TITLE
Revert error emit on Slow Stream Gen

### DIFF
--- a/src/client/voice/dispatcher/StreamDispatcher.js
+++ b/src/client/voice/dispatcher/StreamDispatcher.js
@@ -180,7 +180,7 @@ class StreamDispatcher extends EventEmitter {
       const data = this.streamingData;
 
       if (data.missed >= 5) {
-        this._triggerTerminalState('error', 'Stream is not generating quickly enough.');
+        this._triggerTerminalState('end', 'Stream is not generating quickly enough.');
         return;
       }
 


### PR DESCRIPTION
This seems to be a symptom of a larger issue....

It seems that streams aren't being properly ended, as this will emit after every song (effectively ruining queuing systems with this emitted as an error). This might account for some memory build up when playing many songs in a row. This PR is a band-aid fix, a real fix should be looked into.