### PR TITLE
Fix _removeReaction's reaction lookup

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -529,7 +529,7 @@ class Message {
   }
 
   _addReaction(emoji, user) {
-    const emojiID = buildEmojiID(emoji);
+    const emojiID = emoji.identifier;
     let reaction;
     if (this.reactions.has(emojiID)) {
       reaction = this.reactions.get(emojiID);
@@ -547,7 +547,7 @@ class Message {
   }
 
   _removeReaction(emoji, user) {
-    const emojiID = buildEmojiID(emoji);
+    const emojiID = emoji.identifier;
     if (this.reactions.has(emojiID)) {
       const reaction = this.reactions.get(emojiID);
       if (reaction.users.has(user.id)) {
@@ -563,10 +563,6 @@ class Message {
   _clearReactions() {
     this.reactions.clear();
   }
-}
-
-function buildEmojiID(emoji) {
-  return emoji.id ? `${emoji.name}:${emoji.id}` : emoji.name;
 }
 
 module.exports = Message;

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -529,7 +529,7 @@ class Message {
   }
 
   _addReaction(emoji, user) {
-    const emojiID = emoji.id ? `${emoji.name}:${emoji.id}` : emoji.name;
+    const emojiID = buildEmojiID(emoji);
     let reaction;
     if (this.reactions.has(emojiID)) {
       reaction = this.reactions.get(emojiID);
@@ -547,7 +547,7 @@ class Message {
   }
 
   _removeReaction(emoji, user) {
-    const emojiID = emoji.id || emoji;
+    const emojiID = buildEmojiID(emoji);
     if (this.reactions.has(emojiID)) {
       const reaction = this.reactions.get(emojiID);
       if (reaction.users.has(user.id)) {
@@ -563,6 +563,10 @@ class Message {
   _clearReactions() {
     this.reactions.clear();
   }
+}
+
+function buildEmojiID(emoji) {
+  return emoji.id ? `${emoji.name}:${emoji.id}` : emoji.name;
 }
 
 module.exports = Message;


### PR DESCRIPTION
The `emojiID` that was used to remove a reaction from `this.reactions` was different from the `emojiID` that's used to add one.

`_removeReaction` would always return `null`, so the `messageReactionRemove` event could never get emitted. No more.