### PR TITLE
hotfix ReferenceError when built using Webpack

### DIFF
--- a/src/client/rest/APIRequest.js
+++ b/src/client/rest/APIRequest.js
@@ -1,16 +1,6 @@
 const request = require('superagent');
 const Constants = require('../../util/Constants');
 
-function getRoute(url) {
-  let route = url.split('?')[0];
-  if (route.includes('/channels/') || route.includes('/guilds/')) {
-    const startInd = route.includes('/channels/') ? route.indexOf('/channels/') : route.indexOf('/guilds/');
-    const majorID = route.substring(startInd).split('/')[2];
-    route = route.replace(/(\d{8,})/g, ':id').replace(':id', majorID);
-  }
-  return route;
-}
-
 class APIRequest {
   constructor(rest, method, url, auth, data, file) {
     this.rest = rest;
@@ -19,7 +9,17 @@ class APIRequest {
     this.auth = auth;
     this.data = data;
     this.file = file;
-    this.route = getRoute(this.url);
+    this.route = this.getRoute(this.url);
+  }
+
+  getRoute(url) {
+    let route = url.split('?')[0];
+    if (route.includes('/channels/') || route.includes('/guilds/')) {
+      const startInd = route.includes('/channels/') ? route.indexOf('/channels/') : route.indexOf('/guilds/');
+      const majorID = route.substring(startInd).split('/')[2];
+      route = route.replace(/(\d{8,})/g, ':id').replace(':id', majorID);
+    }
+    return route;
   }
 
   getAuth() {


### PR DESCRIPTION
**move function getRoute(url) into class APIRequest**

this.route = getRoute(this.url);   `>>>`   this.route = this.getRoute(this.url);


#Error Console 
————————
Uncaught (in promise) ReferenceError: getRoute is not defined.    _[APIRequest.js]_