### PR TITLE
Make _array & _keyArray non-enumerable

### DIFF
--- a/src/util/Collection.js
+++ b/src/util/Collection.js
@@ -9,17 +9,19 @@ class Collection extends Map {
 
     /**
      * Cached array for the `array()` method - will be reset to `null` whenever `set()` or `delete()` are called.
+     * @name Collection#_array
      * @type {?Array}
      * @private
      */
-    this._array = null;
+    Object.defineProperty(this, '_array', { value: null, writable: true, configurable: true });
 
     /**
      * Cached array for the `keyArray()` method - will be reset to `null` whenever `set()` or `delete()` are called.
+     * @name Collection#_keyArray
      * @type {?Array}
      * @private
      */
-    this._keyArray = null;
+    Object.defineProperty(this, '_keyArray', { value: null, writable: true, configurable: true });
   }
 
   set(key, val) {


### PR DESCRIPTION
Because Map has no enumerable properties and I got tired of seeing these when logging Collections