### PR TITLE
Changed return type of Guild.defaultChannel

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -278,8 +278,8 @@ class Guild {
   }
 
   /**
-   * The `#general` GuildChannel of the server.
-   * @type {GuildChannel}
+   * The `#general` TextChannel of the server.
+   * @type {TextChannel}
    * @readonly
    */
   get defaultChannel() {


### PR DESCRIPTION
The default channel for a Guild is always the first TextChannel in the Guild, it can't be a VoiceChannel.
I know this might come off as petty, and I'm sorry if it does, just came across this today and wanted to make it a bit more specific.