### PR TITLE
Fix createEmoji/deleteEmoji action name.

### DIFF
--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -549,12 +549,12 @@ class RESTMethods {
 
   createEmoji(guild, image, name) {
     return this.rest.makeRequest('post', `${Constants.Endpoints.guildEmojis(guild.id)}`, true, { name, image })
-      .then(data => this.client.actions.EmojiCreate.handle(data, guild).emoji);
+      .then(data => this.client.actions.GuildEmojiCreate.handle(data, guild).emoji);
   }
 
   deleteEmoji(emoji) {
     return this.rest.makeRequest('delete', `${Constants.Endpoints.guildEmojis(emoji.guild.id)}/${emoji.id}`, true)
-      .then(() => this.client.actions.EmojiDelete.handle(emoji).data);
+      .then(() => this.client.actions.GuildEmojiDelete.handle(emoji).data);
   }
 
   getWebhook(id, token) {


### PR DESCRIPTION
The class names were renamed in cd657be8beaf852e969d660ec40c02130242578f, this fixes two places where references weren't renamed.