### PR TITLE
Fix empty search query parameters

### DIFF
--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -165,8 +165,9 @@ class RESTMethods {
 
   search(target, options) {
     options = transformSearchOptions(options, this.client);
+    for (const key in options) if (options[key] === undefined) delete options[key];
 
-    const queryString = querystring.stringify(options);
+    const queryString = (querystring.stringify(options).match(/[^=&?]+=[^=&?]+/g) || []).join('&');
 
     let type;
     if (target instanceof Channel) {


### PR DESCRIPTION
The search function was sending requests to stuff like:
`search?author_id=&content=&channel_id=135823828352838352`