### PR TITLE
Fix for incorrect oldMember in guildMemberUpdate event after addRole

### DIFF
--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -410,6 +410,7 @@ class RESTMethods {
       };
 
       this.client.on('guildMemberUpdate', listener);
+      this.client.setTimeout(() => this.client.removeListener('guildMemberUpdate', listener), 10e3);
 
       this.rest.makeRequest(
         'put',
@@ -429,6 +430,7 @@ class RESTMethods {
       };
 
       this.client.on('guildMemberUpdate', listener);
+      this.client.setTimeout(() => this.client.removeListener('guildMemberUpdate', listener), 10e3);
 
       this.rest.makeRequest(
         'delete',

--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -6,7 +6,6 @@ const parseEmoji = require('../../util/ParseEmoji');
 const escapeMarkdown = require('../../util/EscapeMarkdown');
 const transformSearchOptions = require('../../util/TransformSearchOptions');
 const Snowflake = require('../../util/Snowflake');
-const cloneObject = require('../../util/CloneObject');
 
 const User = require('../../structures/User');
 const GuildMember = require('../../structures/GuildMember');
@@ -406,7 +405,7 @@ class RESTMethods {
       const listener = (oldMember, newMember) => {
         if (!oldMember._roles.includes(role.id) && newMember._roles.includes(role.id)) {
           this.client.removeListener('guildMemberUpdate', listener);
-          return resolve(newMember);
+          resolve(newMember);
         }
       };
 
@@ -425,7 +424,7 @@ class RESTMethods {
       const listener = (oldMember, newMember) => {
         if (oldMember._roles.includes(role.id) && !newMember._roles.includes(role.id)) {
           this.client.removeListener('guildMemberUpdate', listener);
-          return resolve(newMember);
+          resolve(newMember);
         }
       };
 

--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -402,10 +402,7 @@ class RESTMethods {
 
   addMemberRole(member, role) {
     return this.rest.makeRequest('put', Constants.Endpoints.guildMemberRole(member.guild.id, member.id, role.id), true)
-      .then(() => {
-        if (!member._roles.includes(role.id)) member._roles.push(role.id);
-        return member;
-      });
+      .then(() => member);
   }
 
   removeMemberRole(member, role) {
@@ -413,11 +410,7 @@ class RESTMethods {
       'delete',
       Constants.Endpoints.guildMemberRole(member.guild.id, member.id, role.id),
       true
-    ).then(() => {
-      const index = member._roles.indexOf(role.id);
-      if (index >= 0) member._roles.splice(index, 1);
-      return member;
-    });
+    ).then(() => member);
   }
 
   sendTyping(channelID) {

--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -6,6 +6,7 @@ const parseEmoji = require('../../util/ParseEmoji');
 const escapeMarkdown = require('../../util/EscapeMarkdown');
 const transformSearchOptions = require('../../util/TransformSearchOptions');
 const Snowflake = require('../../util/Snowflake');
+const cloneObject = require('../../util/CloneObject');
 
 const User = require('../../structures/User');
 const GuildMember = require('../../structures/GuildMember');
@@ -401,16 +402,25 @@ class RESTMethods {
   }
 
   addMemberRole(member, role) {
+    let clonedMember = cloneObject(member);
     return this.rest.makeRequest('put', Constants.Endpoints.guildMemberRole(member.guild.id, member.id, role.id), true)
-      .then(() => member);
+      .then(() => {
+        if (!clonedMember._roles.includes(role.id)) clonedMember._roles.push(role.id);
+        return clonedMember;
+      });
   }
 
   removeMemberRole(member, role) {
+    let clonedMember = cloneObject(member);
     return this.rest.makeRequest(
       'delete',
       Constants.Endpoints.guildMemberRole(member.guild.id, member.id, role.id),
       true
-    ).then(() => member);
+    ).then(() => {
+      const index = clonedMember._roles.indexOf(role.id);
+      if (index >= 0) clonedMember._roles.splice(index, 1);
+      return clonedMember;
+    });
   }
 
   sendTyping(channelID) {


### PR DESCRIPTION
`addRole` would modify the cached GuildMember rather than letting it be handled internally when a guild member update packet is received from Discord, leading to the `oldMember` and `newMember` being identical following a call to `addRole`

This is currently how `addRoles` does it, and a correct oldMember is passed to the `guildMemberUpdate` event following a call to `addRoles`