### PR TITLE
Added support for adding users to guild 2

### DIFF
--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -378,9 +378,19 @@ class RESTMethods {
   }
 
   putGuildMember(guild, user, options) {
-    return this.rest.makeRequest('put', Constants.Endpoints.guildMember(guild.id, user.id), true, options).then(data =>
-      this.client.actions.GuildMemberGet.handle(guild, data).member
-    );
+    if (options.roles) {
+      var roles = options.roles;
+      if (roles instanceof Collection || (roles instanceof Array && roles[0] instanceof Role)) {
+        options.roles = roles.map(role => role.id);
+      }
+    }
+    if (options.accessToken) {
+      options.access_token = options.accessToken;
+    } else {
+      return Promise.reject(new Error('OAuth2 access token was not specified.'));
+    }
+    return this.rest.makeRequest('put', Constants.Endpoints.guildMember(guild.id, user.id), true, options)
+      .then(data => this.client.actions.GuildMemberGet.handle(guild, data).member);
   }
 
   getGuildMember(guild, user, cache) {

--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -377,6 +377,12 @@ class RESTMethods {
     return this.rest.makeRequest('get', Constants.Endpoints.channelMessage(channel.id, messageID), true);
   }
 
+  putGuildMember(guild, user, options) {
+    return this.rest.makeRequest('put', Constants.Endpoints.guildMember(guild.id, user.id), true, options).then(data =>
+      this.client.actions.GuildMemberGet.handle(guild, data).member
+    );
+  }
+
   getGuildMember(guild, user, cache) {
     return this.rest.makeRequest('get', Constants.Endpoints.guildMember(guild.id, user.id), true).then(data => {
       if (cache) {

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -349,18 +349,6 @@ class Guild {
    * @returns {Promise<GuildMember>}
    */
   addMember(user, options) {
-    if (options.roles) {
-      var roles = options.roles;
-      if (roles instanceof Collection || (roles instanceof Array && roles[0] instanceof Role)) {
-        options.roles = roles.map(role => role.id);
-      }
-    }
-    if (options.accessToken) {
-      options.access_token = options.accessToken;
-      delete options.accessToken;
-    } else {
-      return Promise.reject(new Error('OAuth2 access token was not specified.'));
-    }
     if (this.members.has(user.id)) return Promise.resolve(this.members.get(user.id));
     return this.client.rest.methods.putGuildMember(this, user, options);
   }

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -334,7 +334,7 @@ class Guild {
   /**
    * The data for a role
    * @typedef {Object} AddGuildMemberOptions
-   * @property {string} access_token An oauth2 access token granted with the guilds.join to the bot's application
+   * @property {string} accessToken An oauth2 access token granted with the guilds.join to the bot's application
    * for the user you want to add to the guild
    * @property {string} [nick] Value to set users nickname to
    * @property {Collection<Snowflake, Role>|Role[]|string[]} [roles] The roles or role IDs to add
@@ -343,7 +343,7 @@ class Guild {
    */
 
   /**
-   * Adds user to guild using his oauth2 access token
+   * Add a user to this guild using OAuth2
    * @param {UserResolvable|string} user The user or ID of the user to add to guild
    * @param {AddGuildMemberOptions} options Options object containing the access_token
    * @returns {Promise<GuildMember>}
@@ -354,6 +354,10 @@ class Guild {
       if (roles instanceof Collection || (roles instanceof Array && roles[0] instanceof Role)) {
         options.roles = roles.map(role => role.id);
       }
+    }
+    if (options.accessToken) {
+      options.access_token = options.accessToken;
+      delete options.accessToken;
     }
     if (!options.access_token) return Promise.reject(new Error('User oauth2 access_token was not specified.'));
     if (this.members.has(user.id)) return Promise.resolve(this.members.get(user.id));

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -358,8 +358,9 @@ class Guild {
     if (options.accessToken) {
       options.access_token = options.accessToken;
       delete options.accessToken;
+    } else {
+      return Promise.reject(new Error('OAuth2 access token was not specified.'));
     }
-    if (!options.access_token) return Promise.reject(new Error('User oauth2 access_token was not specified.'));
     if (this.members.has(user.id)) return Promise.resolve(this.members.get(user.id));
     return this.client.rest.methods.putGuildMember(this, user, options);
   }

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -332,6 +332,34 @@ class Guild {
   }
 
   /**
+   * The data for a role
+   * @typedef {Object} AddGuildMemberOptions
+   * @property {string} access_token An oauth2 access token granted with the guilds.join to the bot's application for the user you want to add to the guild
+   * @property {string} [nick] Value to set users nickname to
+   * @property {Collection<Snowflake, Role>|Role[]|string[]} [roles] The roles or role IDs to add
+   * @property {boolean} [mute] If the user is muted
+   * @property {boolean} [deaf] If the user is deafened
+   */
+
+  /**
+   * Adds user to guild using his oauth2 access token
+   * @param {UserResolvable|string} user The user or ID of the user to add to guild
+   * @param {AddGuildMemberOptions} options Options object containing the access_token
+   * @returns {Promise<GuildMember>}
+   */
+  addMember(user, options) {
+    if (options.roles) {
+      var roles = options.roles
+      if (roles instanceof Collection || (roles instanceof Array && roles[0] instanceof Role)) {
+        options.roles = roles.map(role => role.id)
+      }
+    }
+    if (!options.access_token) return Promise.reject(new Error('User oauth2 access_token was not specified in options.'));
+    if (this.members.has(user.id)) return Promise.resolve(this.members.get(user.id));
+    return this.client.rest.methods.putGuildMember(this, user, options);
+  }
+
+  /**
    * Fetch a single guild member from a user.
    * @param {UserResolvable} user The user to fetch the member for
    * @param {boolean} [cache=true] Insert the user into the users cache

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -334,7 +334,8 @@ class Guild {
   /**
    * The data for a role
    * @typedef {Object} AddGuildMemberOptions
-   * @property {string} access_token An oauth2 access token granted with the guilds.join to the bot's application for the user you want to add to the guild
+   * @property {string} access_token An oauth2 access token granted with the guilds.join to the bot's application
+   * for the user you want to add to the guild
    * @property {string} [nick] Value to set users nickname to
    * @property {Collection<Snowflake, Role>|Role[]|string[]} [roles] The roles or role IDs to add
    * @property {boolean} [mute] If the user is muted
@@ -349,12 +350,12 @@ class Guild {
    */
   addMember(user, options) {
     if (options.roles) {
-      var roles = options.roles
+      var roles = options.roles;
       if (roles instanceof Collection || (roles instanceof Array && roles[0] instanceof Role)) {
-        options.roles = roles.map(role => role.id)
+        options.roles = roles.map(role => role.id);
       }
     }
-    if (!options.access_token) return Promise.reject(new Error('User oauth2 access_token was not specified in options.'));
+    if (!options.access_token) return Promise.reject(new Error('User oauth2 access_token was not specified.'));
     if (this.members.has(user.id)) return Promise.resolve(this.members.get(user.id));
     return this.client.rest.methods.putGuildMember(this, user, options);
   }


### PR DESCRIPTION
added RESTMethods#AddGuildMemberOptions and Guild#addMember with typedef AddGuildMemberOptions to be able to add user to guild as a member through `PUT/guilds/{guild.id}/members/{user.id}` https://discordapp.com/developers/docs/resources/guild#add-guild-member