### PR TITLE
Adding resetGame functionality

### DIFF
--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -226,7 +226,7 @@ class ClientUser extends User {
 
   /**
    * Sets the game the client user is playing.
-   * @param {string|null} game Game being played
+   * @param {?string} game Game being played
    * @param {string} [streamingURL] Twitch stream URL
    * @returns {Promise<ClientUser>}
    */

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -185,6 +185,10 @@ class ClientUser extends User {
         game = data.game;
         if (game.url) game.type = 1;
       }
+      
+      if(data.game ===  null){
+        game = null
+      }
 
       if (typeof data.afk !== 'undefined') afk = data.afk;
       afk = Boolean(afk);
@@ -234,7 +238,17 @@ class ClientUser extends User {
       url: streamingURL,
     } });
   }
-
+  
+  /**
+   * Resets the game the client user is playing.
+   * @returns {Promise<ClientUser>}
+   */
+  resetGame(){
+    return this.setPresence({
+      game: null
+    })
+  }
+  
   /**
    * Sets/removes the AFK flag for the client user.
    * @param {boolean} afk Whether or not the user is AFK

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -187,7 +187,7 @@ class ClientUser extends User {
       }
       
       if(data.game ===  null){
-        game = null
+        game = null;
       }
 
       if (typeof data.afk !== 'undefined') afk = data.afk;
@@ -246,7 +246,7 @@ class ClientUser extends User {
   resetGame(){
     return this.setPresence({
       game: null
-    })
+    });
   }
   
   /**

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -185,8 +185,8 @@ class ClientUser extends User {
         game = data.game;
         if (game.url) game.type = 1;
       }
-      
-      if(data.game ===  null){
+
+      if (data.game === null) {
         game = null;
       }
 
@@ -238,17 +238,17 @@ class ClientUser extends User {
       url: streamingURL,
     } });
   }
-  
+
   /**
    * Resets the game the client user is playing.
    * @returns {Promise<ClientUser>}
    */
-  resetGame(){
+  resetGame() {
     return this.setPresence({
-      game: null
+      game: null,
     });
   }
-  
+
   /**
    * Sets/removes the AFK flag for the client user.
    * @param {boolean} afk Whether or not the user is AFK

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -231,7 +231,7 @@ class ClientUser extends User {
    * @returns {Promise<ClientUser>}
    */
   setGame(game, streamingURL) {
-    if(game === null) return this.setPresence({ game });
+    if (game === null) return this.setPresence({ game });
     return this.setPresence({ game: {
       name: game,
       url: streamingURL,

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -186,9 +186,7 @@ class ClientUser extends User {
         if (game.url) game.type = 1;
       }
 
-      if (data.game === null) {
-        game = null;
-      }
+      if (data.game === null) game = null;
 
       if (typeof data.afk !== 'undefined') afk = data.afk;
       afk = Boolean(afk);
@@ -228,25 +226,16 @@ class ClientUser extends User {
 
   /**
    * Sets the game the client user is playing.
-   * @param {string} game Game being played
+   * @param {string|null} game Game being played
    * @param {string} [streamingURL] Twitch stream URL
    * @returns {Promise<ClientUser>}
    */
   setGame(game, streamingURL) {
+    if(game === null) return this.setPresence({ game });
     return this.setPresence({ game: {
       name: game,
       url: streamingURL,
     } });
-  }
-
-  /**
-   * Resets the game the client user is playing.
-   * @returns {Promise<ClientUser>}
-   */
-  resetGame() {
-    return this.setPresence({
-      game: null,
-    });
   }
 
   /**


### PR DESCRIPTION
`setGame` method would always result in an Object passed to `setPresence`.
Passing { game: null } (supported by discords WebSocket gateway to reset the current Game) to `setPresence` would still result in a Game Object sent to the endpoint.
Explicitly setting `game` to null should overwrite the `game` object provided by `localPresence` or `client.presence`.
This was neither supported by `setGame` or `setPresence`.

[Discord Documentation: Gateway#gateway-status-update](https://discordapp.com/developers/docs/topics/gateway#gateway-status-update)