### PR TITLE
Implement 'Modify Guild Channel Positions' 

### DIFF
--- a/src/client/actions/ActionsManager.js
+++ b/src/client/actions/ActionsManager.js
@@ -28,6 +28,7 @@ class ActionsManager {
     this.register(require('./GuildEmojiDelete'));
     this.register(require('./GuildEmojiUpdate'));
     this.register(require('./GuildRolesPositionUpdate'));
+    this.register(require('./GuildChannelsPositionUpdate'));
   }
 
   register(Action) {

--- a/src/client/actions/GuildChannelsPositionUpdate.js
+++ b/src/client/actions/GuildChannelsPositionUpdate.js
@@ -1,0 +1,23 @@
+const Action = require('./Action');
+
+class GuildChannelsPositionUpdate extends Action {
+  handle(data) {
+    const client = this.client;
+
+    const guild = client.guilds.get(data.guild_id);
+    if (guild) {
+      for (const partialChannel of data.channels) {
+        const channel = guild.roles.get(partialChannel.id);
+        if (channel) {
+          channel.position = partialChannel.position;
+        }
+      }
+    }
+
+    return {
+      guild,
+    };
+  }
+}
+
+module.exports = GuildChannelsPositionUpdate;

--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -755,6 +755,15 @@ class RESTMethods {
       .then(() => user);
   }
 
+  updateChannelPositions(guildId, channels) {
+    return this.rest.makeRequest('patch', Constants.Endpoints.guildChannels(guildId), true, channels).then(() =>
+      this.client.actions.GuildChannelsPositionUpdate.handle({
+        guild_id: guildId,
+        channels,
+      }).guild
+    );
+  }
+
   setRolePositions(guildID, roles) {
     return this.rest.makeRequest('patch', Constants.Endpoints.guildRoles(guildID), true, roles).then(() =>
       this.client.actions.GuildRolesPositionUpdate.handle({

--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -755,10 +755,10 @@ class RESTMethods {
       .then(() => user);
   }
 
-  updateChannelPositions(guildId, channels) {
-    return this.rest.makeRequest('patch', Constants.Endpoints.guildChannels(guildId), true, channels).then(() =>
+  updateChannelPositions(guildID, channels) {
+    return this.rest.makeRequest('patch', Constants.Endpoints.guildChannels(guildID), true, channels).then(() =>
       this.client.actions.GuildChannelsPositionUpdate.handle({
-        guild_id: guildId,
+        guild_id: guildID,
         channels,
       }).guild
     );

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -642,19 +642,16 @@ class Guild {
    * Shuffles this guild's channel positions.
    * @returns {Promise<Guild>}
    * @example
-   * // create a new text channel
    * guild.shuffleChannels()
    *  .then(guild => console.log(`Shuffled all channels for ${guild.id}`))
    *  .catch(console.error);
    */
   shuffleChannels() {
     const newChannels = [];
-    console.log(this.channels.array());
     const shuffledChannels = Util.shuffleArray(this.channels.array());
     shuffledChannels.forEach((channel, index) => {
       newChannels.push({ id: channel.id, position: index });
     });
-    console.log(newChannels);
     return this.client.rest.methods.updateChannelPositions(this.id, newChannels);
   }
 

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -639,20 +639,17 @@ class Guild {
   }
 
   /**
-   * Shuffles this guild's channel positions.
+   * Updates this guild's channel positions as a batch.
+   * @param {Object[]} newChannelPositions Array of objects with an id and a position.
+   * Position should be an integer specifying the new position for the channel.
    * @returns {Promise<Guild>}
    * @example
-   * guild.shuffleChannels()
-   *  .then(guild => console.log(`Shuffled all channels for ${guild.id}`))
+   * guild.updateChannels([{ id: channelId, position: newChannelIndex }])
+   *  .then(guild => console.log(`Updated channels for ${guild.id}`))
    *  .catch(console.error);
    */
-  shuffleChannels() {
-    const newChannels = [];
-    const shuffledChannels = Util.shuffleArray(this.channels.array());
-    shuffledChannels.forEach((channel, index) => {
-      newChannels.push({ id: channel.id, position: index });
-    });
-    return this.client.rest.methods.updateChannelPositions(this.id, newChannels);
+  updateChannels(newChannelPositions) {
+    return this.client.rest.methods.updateChannelPositions(this.id, newChannelPositions);
   }
 
   /**

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -635,7 +635,27 @@ class Guild {
    *  .catch(console.error);
    */
   createChannel(name, type, overwrites) {
-    return this.client.rest.methods.createChannel(this, name, type, overwrites);
+    return this.client.rest.methods.updateChannel(this, name, type, overwrites);
+  }
+
+  /**
+   * Shuffles this guild's channel positions.
+   * @returns {Promise<Guild>}
+   * @example
+   * // create a new text channel
+   * guild.shuffleChannels()
+   *  .then(guild => console.log(`Shuffled all channels for ${guild.id}`))
+   *  .catch(console.error);
+   */
+  shuffleChannels() {
+    const newChannels = [];
+    console.log(this.channels.array());
+    const shuffledChannels = Util.shuffleArray(this.channels.array());
+    shuffledChannels.forEach((channel, index) => {
+      newChannels.push({ id: channel.id, position: index });
+    });
+    console.log(newChannels);
+    return this.client.rest.methods.updateChannelPositions(this.id, newChannels);
   }
 
   /**

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -644,7 +644,7 @@ class Guild {
    * Position should be an integer specifying the new position for the channel.
    * @returns {Promise<Guild>}
    * @example
-   * guild.updateChannels([{ id: channelId, position: newChannelIndex }])
+   * guild.updateChannels([{ id: channelID, position: newChannelIndex }])
    *  .then(guild => console.log(`Updated channels for ${guild.id}`))
    *  .catch(console.error);
    */

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -648,7 +648,7 @@ class Guild {
    *  .then(guild => console.log(`Updated channels for ${guild.id}`))
    *  .catch(console.error);
    */
-  updateChannels(newChannelPositions) {
+  updateChannelPositions(newChannelPositions) {
     return this.client.rest.methods.updateChannelPositions(this.id, newChannelPositions);
   }
 

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -639,17 +639,23 @@ class Guild {
   }
 
   /**
+   * The data needed for updating a channel's position.
+   * @typedef {Object} ChannelPosition
+   * @property {string} id The channel being updated's unique id.
+   * @property {number} position The new position of the channel.
+   */
+
+  /**
    * Updates this guild's channel positions as a batch.
-   * @param {Object[]} newChannelPositions Array of objects with an id and a position.
-   * Position should be an integer specifying the new position for the channel.
+   * @param {Array<ChannelPosition>} channelPositions Array of objects that defines which channel is going where.
    * @returns {Promise<Guild>}
    * @example
    * guild.updateChannels([{ id: channelID, position: newChannelIndex }])
    *  .then(guild => console.log(`Updated channels for ${guild.id}`))
    *  .catch(console.error);
    */
-  updateChannelPositions(newChannelPositions) {
-    return this.client.rest.methods.updateChannelPositions(this.id, newChannelPositions);
+  updateChannelPositions(channelPositions) {
+    return this.client.rest.methods.updateChannelPositions(this.id, channelPositions);
   }
 
   /**

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -208,26 +208,6 @@ class Util {
     }
     return array;
   }
-
-  /**
-   * Shuffles an array using the Knuth-Fisher-Yates shuffle
-   * @param {Array<*>} array Array to shuffle
-   * @returns {Array<*>}
-   * @private
-   */
-  static shuffleArray(array) {
-    let currentIndex = array.length;
-    let temp;
-    let randomIndex;
-    while (currentIndex !== 0) {
-      randomIndex = Math.floor(Math.random() * currentIndex);
-      currentIndex -= 1;
-      temp = array[currentIndex];
-      array[currentIndex] = array[randomIndex];
-      array[randomIndex] = temp;
-    }
-    return array;
-  }
 }
 
 module.exports = Util;

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -208,6 +208,26 @@ class Util {
     }
     return array;
   }
+
+  /**
+   * Shuffles an array using the Knuth-Fisher-Yates shuffle
+   * @param {Array<*>} array Array to shuffle
+   * @returns {Array<*>}
+   * @private
+   */
+  static shuffleArray(array) {
+    let currentIndex = array.length;
+    let temp;
+    let randomIndex;
+    while (currentIndex !== 0) {
+      randomIndex = Math.floor(Math.random() * currentIndex);
+      currentIndex -= 1;
+      temp = array[currentIndex];
+      array[currentIndex] = array[randomIndex];
+      array[randomIndex] = temp;
+    }
+    return array;
+  }
 }
 
 module.exports = Util;


### PR DESCRIPTION
Currently the library implements the ['Create Channels' endpoint via POST to /guilds/{guild.id}/channels](https://discordapp.com/developers/docs/resources/guild#create-guild-channel), but doesn't implement the ['Modify Guild Channel Positions' endpoint](https://discordapp.com/developers/docs/resources/guild#modify-guild-channel-positions) at all.

This change adds that support as well as a method on Guild which will shuffle all existing channels using a new utility method for shuffling arrays.