### PR TITLE
Add RichEmbed#attachFile

### DIFF
--- a/src/structures/RichEmbed.js
+++ b/src/structures/RichEmbed.js
@@ -201,7 +201,7 @@ class RichEmbed {
   /**
    * Sets the file to upload alongside the embed. This file can be accessed via `attachment://fileName.extension` when
    * setting an embed image or author/footer icons. Only one file may be attached.
-   * @param {FileOptions|string} file Local path or Url to the file to attach, or valid FileOptions for a file to attach
+   * @param {FileOptions|string} file Local path or URL to the file to attach, or valid FileOptions for a file to attach
    * @returns {RichEmbed} This embed
    */
   attachFile(file) {

--- a/src/structures/RichEmbed.js
+++ b/src/structures/RichEmbed.js
@@ -65,6 +65,12 @@ class RichEmbed {
      * @type {Object}
      */
     this.footer = data.footer;
+
+    /**
+     * File to upload alongside this Embed
+     * @type {string}
+     */
+    this.file = data.file;
   }
 
   /**
@@ -189,6 +195,19 @@ class RichEmbed {
     text = resolveString(text);
     if (text.length > 2048) throw new RangeError('RichEmbed footer text may not exceed 2048 characters.');
     this.footer = { text, icon_url: icon };
+    return this;
+  }
+
+  /**
+   * Sets the file to upload alongside this embed that can
+   * be accessed via `attachment://fileName.extension` when
+   * setting an embed image, or author/footer icons
+   * @param {string} file Path or Url to the file to attach
+   * @returns {RichEmbed} This embed
+   */
+  attachFile(file) {
+    if (this.file) throw new RangeError('You may not upload more than one file at once.');
+    this.file = file;
     return this;
   }
 }

--- a/src/structures/RichEmbed.js
+++ b/src/structures/RichEmbed.js
@@ -202,7 +202,7 @@ class RichEmbed {
    * Sets the file to upload alongside this embed that can
    * be accessed via `attachment://fileName.extension` when
    * setting an embed image, or author/footer icons
-   * @param {string} file Path or Url to the file to attach
+   * @param {FileOptions|string} file Local path or Url to the file to attach, or valid FileOptions for a file to attach
    * @returns {RichEmbed} This embed
    */
   attachFile(file) {

--- a/src/structures/RichEmbed.js
+++ b/src/structures/RichEmbed.js
@@ -199,9 +199,8 @@ class RichEmbed {
   }
 
   /**
-   * Sets the file to upload alongside this embed that can
-   * be accessed via `attachment://fileName.extension` when
-   * setting an embed image, or author/footer icons
+   * Sets the file to upload alongside the embed. This file can be accessed via `attachment://fileName.extension` when
+   * setting an embed image or author/footer icons. Only one file may be attached.
    * @param {FileOptions|string} file Local path or Url to the file to attach, or valid FileOptions for a file to attach
    * @returns {RichEmbed} This embed
    */

--- a/src/structures/interface/TextBasedChannel.js
+++ b/src/structures/interface/TextBasedChannel.js
@@ -78,9 +78,7 @@ class TextBasedChannel {
       options = {};
     }
 
-    if (options.embed && options.embed.file) {
-      options.file = options.embed.file;
-    }
+    if (options.embed && options.embed.file) options.file = options.embed.file;
 
     if (options.file) {
       if (typeof options.file === 'string') options.file = { attachment: options.file };

--- a/src/structures/interface/TextBasedChannel.js
+++ b/src/structures/interface/TextBasedChannel.js
@@ -78,6 +78,10 @@ class TextBasedChannel {
       options = {};
     }
 
+    if (options.embed && options.embed.file) {
+      options.file = options.embed.file;
+    }
+
     if (options.file) {
       if (typeof options.file === 'string') options.file = { attachment: options.file };
       if (!options.file.name) {


### PR DESCRIPTION
Mostly for attaching local images that can be accessed within the embed image/author icon/footer icon via `attachment//filename.png` and the like.