### PR TITLE
Fix for #1219 (sodium methods)

### DIFF
--- a/src/client/voice/util/Secretbox.js
+++ b/src/client/voice/util/Secretbox.js
@@ -1,8 +1,8 @@
 try {
   const sodium = require('sodium');
   module.exports = {
-    open: sodium.api.crypto_secretbox_xsalsa20poly1305_open,
-    close: sodium.api.crypto_secretbox_xsalsa20poly1305,
+    open: sodium.api.crypto_secretbox_easy_open,
+    close: sodium.api.crypto_secretbox_easy,
   };
 } catch (err) {
   const tweetnacl = require('tweetnacl');

--- a/src/client/voice/util/Secretbox.js
+++ b/src/client/voice/util/Secretbox.js
@@ -1,7 +1,7 @@
 try {
   const sodium = require('sodium');
   module.exports = {
-    open: sodium.api.crypto_secretbox_easy_open,
+    open: sodium.api.crypto_secretbox_open_easy,
     close: sodium.api.crypto_secretbox_easy,
   };
 } catch (err) {

--- a/src/client/voice/util/Secretbox.js
+++ b/src/client/voice/util/Secretbox.js
@@ -1,8 +1,8 @@
 try {
   const sodium = require('sodium');
   module.exports = {
-    open: sodium.api.crypto_secretbox_open,
-    close: sodium.api.crypto_secretbox,
+    open: sodium.api.crypto_secretbox_xsalsa20poly1305_open,
+    close: sodium.api.crypto_secretbox_xsalsa20poly1305,
   };
 } catch (err) {
   const tweetnacl = require('tweetnacl');


### PR DESCRIPTION
Looking through the source of node-sodium, it looks like libsodium exposes a separate method for xsalsa20poly1305 encryption. If you look at the documentation for `crypto_secretbox(_open)` it shows that it requires four args: the text, the nonce, and two public keys from the sender and receiver. However, `crypto_secretbox_xsalsa20poly1305(_open)` takes just three args, as tweetnacl does: the text, the nonce, and the secret key.