### PR TITLE
Fix issues with messageReaction map getting broken by message updates

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -231,11 +231,22 @@ class Message {
       }
     }
     if (data.reactions) {
+      const reactionUsers = new Collection();
+      this.reactions.forEach(reaction => {
+        const id = reaction.emoji.id ? `${reaction.emoji.name}:${reaction.emoji.id}` :
+          encodeURIComponent(reaction.emoji.name);
+        reactionUsers.set(id, reaction.users);
+      });
       this.reactions.clear();
       if (data.reactions.length > 0) {
         for (const reaction of data.reactions) {
-          const id = reaction.emoji.id ? `${reaction.emoji.name}:${reaction.emoji.id}` : reaction.emoji.name;
-          this.reactions.set(id, new MessageReaction(this, reaction.emoji, reaction.count, reaction.me));
+          const id = reaction.emoji.id ? `${reaction.emoji.name}:${reaction.emoji.id}` :
+            encodeURIComponent(reaction.emoji.name);
+          const newReaction = new MessageReaction(this, reaction.emoji, reaction.count, reaction.me);
+          if (reactionUsers.has(id)) {
+            newReaction.users = reactionUsers.get(id);
+          }
+          this.reactions.set(id, newReaction);
         }
       }
     }


### PR DESCRIPTION
Fixes:

1. Message.patch method was setting incorrect id for emoji reactions (non encoded name)
2. UpdateMessage data did not contain full information on message reactions, so the patched messageReaction map did not contain users, and therefore could not be removed by messageReactionRemove events.

This pull request properly encodes emoji names in the patched reaction list, and copies over user lists from the original message into the patched message.