### PR TITLE
added UserProfile.partner

### DIFF
--- a/src/structures/UserProfile.js
+++ b/src/structures/UserProfile.js
@@ -41,6 +41,12 @@ class UserProfile {
      * @type {boolean}
      */
     this.premium = data.premium;
+    
+    /**
+     * If the user is a Discord Partner
+     * @type {boolean}
+     */
+    this.partner = data.premium_since == null && data.premium == True
 
     for (const guild of data.mutual_guilds) {
       if (this.client.guilds.has(guild.id)) {


### PR DESCRIPTION
Boolean based on if user is a discord partner or not.
Added as some projects like to utilise the information, and I feel, any information is good information...
(except for cloudbleed)