### PR TITLE
Create channel accidentally changed to update channel

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -633,7 +633,7 @@ class Guild {
    *  .catch(console.error);
    */
   createChannel(name, type, overwrites) {
-    return this.client.rest.methods.updateChannel(this, name, type, overwrites);
+    return this.client.rest.methods.createChannel(this, name, type, overwrites);
   }
 
   /**


### PR DESCRIPTION
In my last commit it looks like I changed 'createChannel' to 'updateChannel' at some point and never changed it back before committing, this flips it back to createChannel.

Sorry for the trouble.