### PR TITLE
Add RichEmbed fields error handling

### DIFF
--- a/src/structures/RichEmbed.js
+++ b/src/structures/RichEmbed.js
@@ -154,7 +154,7 @@ class RichEmbed {
     value = resolveString(value);
     if (value.length > 1024) throw new RangeError('RichEmbed field values may not exceed 1024 characters.');
     if (!/\S/.test(value)) throw new RangeError('RichEmbed field values may not be blank.');
-    this.fields.push({ name: name, value: value, inline });
+    this.fields.push({ name, value, inline });
     return this;
   }
 

--- a/src/structures/RichEmbed.js
+++ b/src/structures/RichEmbed.js
@@ -150,9 +150,11 @@ class RichEmbed {
     if (this.fields.length >= 25) throw new RangeError('RichEmbeds may not exceed 25 fields.');
     name = resolveString(name);
     if (name.length > 256) throw new RangeError('RichEmbed field names may not exceed 256 characters.');
+    if (!/\S/.test(name)) throw new RangeError('RichEmbed field names may not be blank.');
     value = resolveString(value);
     if (value.length > 1024) throw new RangeError('RichEmbed field values may not exceed 1024 characters.');
-    this.fields.push({ name: String(name), value: value, inline });
+    if (!/\S/.test(value)) throw new RangeError('RichEmbed field values may not be blank.');
+    this.fields.push({ name: name, value: value, inline });
     return this;
   }
 

--- a/src/structures/RichEmbed.js
+++ b/src/structures/RichEmbed.js
@@ -150,10 +150,10 @@ class RichEmbed {
     if (this.fields.length >= 25) throw new RangeError('RichEmbeds may not exceed 25 fields.');
     name = resolveString(name);
     if (name.length > 256) throw new RangeError('RichEmbed field names may not exceed 256 characters.');
-    if (!/\S/.test(name)) throw new RangeError('RichEmbed field names may not be blank.');
+    if (!/\S/.test(name)) throw new RangeError('RichEmbed field names may not be empty.');
     value = resolveString(value);
     if (value.length > 1024) throw new RangeError('RichEmbed field values may not exceed 1024 characters.');
-    if (!/\S/.test(value)) throw new RangeError('RichEmbed field values may not be blank.');
+    if (!/\S/.test(value)) throw new RangeError('RichEmbed field values may not be empty.');
     this.fields.push({ name, value, inline });
     return this;
   }


### PR DESCRIPTION
See issue #1190.
Also removed `String(name)` because `name` is already a string.