### PR TITLE
Fix #1253: Permission Overwrites Resolution

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -64,8 +64,10 @@ class GuildChannel extends Channel {
 
     const overwrites = this.overwritesFor(member, true, roles);
 
-    permissions &= ~overwrites.everyone.deny;
-    permissions |= overwrites.everyone.allow;
+    if (overwrites.everyone) {
+      permissions &= ~overwrites.everyone.deny;
+      permissions |= overwrites.everyone.allow;
+    }
 
     let allow = 0;
     for (const overwrite of overwrites.roles) {

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -97,11 +97,11 @@ class GuildChannel extends Channel {
     let everyoneOverwrites;
 
     for (const overwrite of this.permissionOverwrites.values()) {
-      if (overwrite.id === member.id) {
-        memberOverwrites = overwrite;
-      } else if (roles.has(overwrite.id) && roles.get(overwrite.id).name !== '@everyone') {
+      if (roles.has(overwrite.id) && overwrite.id !== this.guild.id) {
         roleOverwrites.push(overwrite);
-      } else if (roles.has(overwrite.id) && roles.get(overwrite.id).name === '@everyone') {
+      } else if (overwrite.id === member.id) {
+        memberOverwrites = overwrite;
+      } else if (overwrite.id === this.guild.id) {
         everyoneOverwrites = overwrite;
       }
     }

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -101,7 +101,7 @@ class GuildChannel extends Channel {
         memberOverwrites = overwrite;
       } else if (roles.has(overwrite.id) && roles.get(overwrite.id).name !== '@everyone') {
         roleOverwrites.push(overwrite);
-      } else {
+      } else if (roles.has(overwrite.id) && roles.get(overwrite.id).name === '@everyone') {
         everyoneOverwrites = overwrite;
       }
     }

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -97,12 +97,12 @@ class GuildChannel extends Channel {
     let everyoneOverwrites;
 
     for (const overwrite of this.permissionOverwrites.values()) {
-      if (roles.has(overwrite.id) && overwrite.id !== this.guild.id) {
+      if (overwrite.id === this.guild.id) {
+        everyoneOverwrites = overwrite;
+      } else if (roles.has(overwrite.id)) {
         roleOverwrites.push(overwrite);
       } else if (overwrite.id === member.id) {
         memberOverwrites = overwrite;
-      } else if (overwrite.id === this.guild.id) {
-        everyoneOverwrites = overwrite;
       }
     }
 


### PR DESCRIPTION
Everyone, Roles, and Member overwrites were all resolving in the same loop, instead of Separate application of Everyone -> Roles -> Member overwrites according to https://support.discordapp.com/hc/en-us/articles/206141927-How-is-the-permission-hierarchy-structured-

This means, if Everyone had allow on something a Role had deny on it, it would incorrectly resolve allow. And the same for if a Role had an allow, when a member would have a deny.