### PR TITLE
MessageEmbed to convert to RichEmbed and vice-versa

### DIFF
--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -1,3 +1,5 @@
+const RichEmbed = require("./RichEmbed.js");
+
 /**
  * Represents an embed in a message (image/video preview, rich embed, etc.)
  * <info>This class is only used for *recieved* embeds. If you wish to send one, use the {@link RichEmbed} class.</info>
@@ -107,6 +109,36 @@ class MessageEmbed {
     let col = this.color.toString(16);
     while (col.length < 6) col = `0${col}`;
     return `#${col}`;
+  }
+
+  /**
+   * The RichEmbed representation of this MessageEmbed.
+   * @type {RichEmbed}
+   * @readonly
+   */
+  get richEmbed() {
+    const result = {};
+    for (const prop of Object.keys(this)) {
+      let thing = this[prop];
+      if (typeof thing === 'object' && !(thing instanceof Array)) {
+        result[prop] = {};
+        for (const key in thing) {
+          if (key !== 'embed' && key !== 'height' && key !== 'width') result[prop][key] = thing[key];
+        }
+      } else if (thing instanceof Array) {
+        result[prop] = [];
+        thing.map(field => {
+          const addedField = result[prop][result[prop].push({}) - 1];
+          for (const key of Object.keys(field)) {
+            if (key !== 'embed') addedField[key] = field[key];
+          }
+          return addedField;
+        });
+      } else {
+        result[prop] = thing;
+      }
+    }
+    return new RichEmbed(result);
   }
 }
 

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -1,4 +1,4 @@
-const RichEmbed = require('./RichEmbed');
+let RichEmbed;
 
 /**
  * Represents an embed in a message (image/video preview, rich embed, etc.)
@@ -118,8 +118,11 @@ class MessageEmbed {
    */
   get richEmbed() {
     const result = {};
+    // circular dependency stuff
+    if (!RichEmbed) RichEmbed = require('./RichEmbed');
     for (const key of Object.keys(this)) {
       const value = this[key];
+      if (key === 'message') continue;
       if (value && typeof value === 'object') {
         const resultObj = value instanceof Array ? [] : {};
         for (const key2 of Object.keys(value)) {

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -118,14 +118,15 @@ class MessageEmbed {
    */
   get richEmbed() {
     const result = {};
-    Object.entries(this).map(([key, value]) => {
+    const entries = object => Object.keys(object).map(key => [key, object[key]]);
+    entries(this).map(([key, value]) => {
       if (value && typeof value === 'object') {
         const resultObj = value instanceof Array ? [] : {};
-        Object.entries(value).map(([key2, value2]) => {
+        entries(value).map(([key2, value2]) => {
           if (/^(?:embed|height|width|proxyURL|proxyIconUrl)$/i.test(key2)) return true;
           if (typeof value2 === 'object') {
             const resultObj2 = value2 instanceof Array ? [] : {};
-            Object.entries(value2).map(([key3, value3]) => {
+            entries(value2).map(([key3, value3]) => {
               if (key3 !== 'embed') resultObj2[key3] = value3;
               return true;
             });

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -119,15 +119,16 @@ class MessageEmbed {
   get richEmbed() {
     const result = {};
     for (const prop of Object.keys(this)) {
-      let thing = this[prop];
-      if (typeof thing === 'object' && !(thing instanceof Array)) {
+      let item = this[prop];
+      if (typeof item === 'object' && !(item instanceof Array)) {
         result[prop] = {};
-        for (const key in thing) {
-          if (key !== 'embed' && key !== 'height' && key !== 'width') result[prop][key] = thing[key];
+        for (const key in item) {
+          if (!/^(?:embed|height|width|proxyURL|proxyIconUrl)$/i.test(key))// eslint-disable-line curly
+            result[prop][key === 'iconURL' ? 'icon_url' : key] = item[key];
         }
-      } else if (thing instanceof Array) {
+      } else if (item instanceof Array) {
         result[prop] = [];
-        thing.map(field => {
+        item.map(field => {
           const addedField = result[prop][result[prop].push({}) - 1];
           for (const key of Object.keys(field)) {
             if (key !== 'embed') addedField[key] = field[key];
@@ -135,7 +136,7 @@ class MessageEmbed {
           return addedField;
         });
       } else {
-        result[prop] = thing;
+        result[prop] = item;
       }
     }
     return new RichEmbed(result);

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -118,7 +118,7 @@ class MessageEmbed {
    */
   get richEmbed() {
     const result = {};
-    // circular dependency stuff
+    // Circular dependency stuff
     if (!RichEmbed) RichEmbed = require('./RichEmbed');
     for (const key of Object.keys(this)) {
       const value = this[key];

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -118,30 +118,29 @@ class MessageEmbed {
    */
   get richEmbed() {
     const result = {};
-    const entries = object => Object.keys(object).map(key => [key, object[key]]);
-    entries(this).forEach(([key, value]) => {
+    for (const key of Object.keys(this)) {
+      const value = this[key];
       if (value && typeof value === 'object') {
         const resultObj = value instanceof Array ? [] : {};
-        entries(value).forEach(([key2, value2]) => {
-          if (/^(?:embed|height|width|proxyURL|proxyIconUrl)$/i.test(key2)) return true;
+        for (const key2 of Object.keys(value)) {
+          const value2 = value[key2];
+          if (/^(?:embed|height|width|proxyURL|proxyIconUrl)$/i.test(key2)) continue;
           if (typeof value2 === 'object') {
             const resultObj2 = value2 instanceof Array ? [] : {};
-            entries(value2).forEach(([key3, value3]) => {
-              if (key3 !== 'embed') resultObj2[key3] = value3;
-              return true;
-            });
+            for (const key3 of Object.keys(value2)) { // eslint-disable-line max-depth
+              const value3 = value2[key3];
+              if (key3 !== 'embed') resultObj2[key3] = value3; // eslint-disable-line max-depth
+            }
             resultObj[key2] = resultObj2;
           } else {
             resultObj[key2] = value2;
           }
-          return true;
-        });
+        }
         result[key] = resultObj;
       } else {
         result[key] = value;
       }
-      return result;
-    });
+    }
     return new RichEmbed(result);
   }
 }

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -119,14 +119,14 @@ class MessageEmbed {
   get richEmbed() {
     const result = {};
     const entries = object => Object.keys(object).map(key => [key, object[key]]);
-    entries(this).map(([key, value]) => {
+    entries(this).forEach(([key, value]) => {
       if (value && typeof value === 'object') {
         const resultObj = value instanceof Array ? [] : {};
-        entries(value).map(([key2, value2]) => {
+        entries(value).forEach(([key2, value2]) => {
           if (/^(?:embed|height|width|proxyURL|proxyIconUrl)$/i.test(key2)) return true;
           if (typeof value2 === 'object') {
             const resultObj2 = value2 instanceof Array ? [] : {};
-            entries(value2).map(([key3, value3]) => {
+            entries(value2).forEach(([key3, value3]) => {
               if (key3 !== 'embed') resultObj2[key3] = value3;
               return true;
             });

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -1,4 +1,4 @@
-const RichEmbed = require("./RichEmbed.js");
+const RichEmbed = require('./RichEmbed.js');
 
 /**
  * Represents an embed in a message (image/video preview, rich embed, etc.)

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -117,33 +117,30 @@ class MessageEmbed {
    * @readonly
    */
   get richEmbed() {
-    const handler = {
-      set: (target, name, value) => {
-        if (typeof value === 'object') {
-          target[name] = new Proxy(value, {
-            set: (target2, name2, value2) => {
-              if (/^(?:embed|height|width|proxyURL|proxyIconUrl)$/i.test(name2)) return true;
-              if (typeof value2 === 'object') {
-                target2[name2] = new Proxy(value2, {
-                  set: (target3, name3, value3) => {
-                    if (name3 === 'embed') return true;
-                    target3[name3] = value3;
-                    return true;
-                  },
-                });
-              } else {
-                target2[name2] = value2;
-              }
+    const result = {};
+    Object.entries(this).map(([key, value]) => {
+      if (value && typeof value === 'object') {
+        const resultObj = value instanceof Array ? [] : {};
+        Object.entries(value).map(([key2, value2]) => {
+          if (/^(?:embed|height|width|proxyURL|proxyIconUrl)$/i.test(key2)) return true;
+          if (typeof value2 === 'object') {
+            const resultObj2 = value2 instanceof Array ? [] : {};
+            Object.entries(value2).map(([key3, value3]) => {
+              if (key3 !== 'embed') resultObj2[key3] = value3;
               return true;
-            },
-          });
-        } else {
-          target[name] = value;
-        }
-        return true;
-      },
-    };
-    const result = new Proxy(this, handler);
+            });
+            resultObj[key2] = resultObj2;
+          } else {
+            resultObj[key2] = value2;
+          }
+          return true;
+        });
+        result[key] = resultObj;
+      } else {
+        result[key] = value;
+      }
+      return result;
+    });
     return new RichEmbed(result);
   }
 }

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -117,32 +117,33 @@ class MessageEmbed {
    * @readonly
    */
   get richEmbed() {
-    const result = Object.assign(new Proxy({}, {
+    const handler = {
       set: (target, name, value) => {
         if (typeof value === 'object') {
-          target[name] = Object.assign(new Proxy(value instanceof Array ? [] : {}, {
+          target[name] = new Proxy(value, {
             set: (target2, name2, value2) => {
               if (/^(?:embed|height|width|proxyURL|proxyIconUrl)$/i.test(name2)) return true;
               if (typeof value2 === 'object') {
-                target2[name2] = Object.assign(new Proxy({}, {
+                target2[name2] = new Proxy(value2, {
                   set: (target3, name3, value3) => {
                     if (name3 === 'embed') return true;
                     target3[name3] = value3;
                     return true;
                   },
-                }), value2);
+                });
               } else {
                 target2[name2] = value2;
               }
               return true;
             },
-          }), value);
+          });
         } else {
           target[name] = value;
         }
         return true;
       },
-    }), this);
+    };
+    const result = new Proxy(this, handler);
     return new RichEmbed(result);
   }
 }

--- a/src/structures/RichEmbed.js
+++ b/src/structures/RichEmbed.js
@@ -226,6 +226,7 @@ class RichEmbed {
         Object.entries(value).map(([key2, value2]) => {
           if (key2 === 'icon_url') key2 = 'iconURL';
           resultObj[key2] = value2;
+          return true;
         });
         result[key] = resultObj;
       } else {

--- a/src/structures/RichEmbed.js
+++ b/src/structures/RichEmbed.js
@@ -220,21 +220,20 @@ class RichEmbed {
    */
   get messageEmbed() {
     const result = {};
-    const entries = object => Object.keys(object).map(key => [key, object[key]]);
-    entries(this).forEach(([key, value]) => {
+    for (const key of Object.keys(this)) {
+      const value = this[key];
       if (value && typeof value === 'object') {
         const resultObj = Object.create(value);
-        entries(value).forEach(([key2, value2]) => {
+        for (let key2 of Object.keys(value)) {
+          const value2 = value[key2];
           if (key2 === 'icon_url') key2 = 'iconURL';
           resultObj[key2] = value2;
-          return true;
-        });
+        }
         result[key] = resultObj;
       } else {
         result[key] = value;
       }
-      return result;
-    });
+    }
     return new MessageEmbed({}, result);
   }
 }

--- a/src/structures/RichEmbed.js
+++ b/src/structures/RichEmbed.js
@@ -232,7 +232,7 @@ class RichEmbed {
       }
       result[prop] = item;
     }
-    return new MessageEmbed({}, this);
+    return new MessageEmbed({}, result);
   }
 }
 

--- a/src/structures/RichEmbed.js
+++ b/src/structures/RichEmbed.js
@@ -1,5 +1,5 @@
 const ClientDataResolver = require('../client/ClientDataResolver');
-const MessageEmbed = require('./MessageEmbed');
+let MessageEmbed;
 
 /**
  * A rich embed to be sent with a message with a fluent interface for creation
@@ -220,6 +220,8 @@ class RichEmbed {
    */
   get messageEmbed() {
     const result = {};
+    // no circular stuff this time
+    if (!MessageEmbed) MessageEmbed = require('./MessageEmbed');
     for (const key of Object.keys(this)) {
       const value = this[key];
       if (value && typeof value === 'object') {

--- a/src/structures/RichEmbed.js
+++ b/src/structures/RichEmbed.js
@@ -1,5 +1,5 @@
 const ClientDataResolver = require('../client/ClientDataResolver');
-const MessageEmbed = require('./MessageEmbed.js');
+const MessageEmbed = require('./MessageEmbed');
 
 /**
  * A rich embed to be sent with a message with a fluent interface for creation
@@ -219,19 +219,22 @@ class RichEmbed {
    * @readonly
    */
   get messageEmbed() {
-    const result = {};
-    for (const prop of Object.keys(this)) {
-      let item = this[prop];
-      if (typeof item === 'object' && !(item instanceof Array)) {
-        const oldItem = item;
-        item = {};
-        for (const anotherprop of Object.keys(oldItem)) {
-          if (anotherprop === 'icon_url') item.iconURL = oldItem[anotherprop];
-          else item[anotherprop] = oldItem[anotherprop];
+    const result = Object.assign(new Proxy({}, {
+      set: (target, name, value) => {
+        if (typeof value === 'object') {
+          target[name] = Object.assign(new Proxy(value instanceof Array ? [] : {}, {
+            set: (target2, name2, value2) => {
+              if (name2 === 'icon_url') name2 = 'iconURL';
+              target2[name2] = value2;
+              return true;
+            },
+          }), value);
+        } else {
+          target[name] = value;
         }
-      }
-      result[prop] = item;
-    }
+        return true;
+      },
+    }), this);
     return new MessageEmbed({}, result);
   }
 }

--- a/src/structures/RichEmbed.js
+++ b/src/structures/RichEmbed.js
@@ -220,10 +220,11 @@ class RichEmbed {
    */
   get messageEmbed() {
     const result = {};
-    Object.entries(this).map(([key, value]) => {
+    const entries = object => Object.keys(object).map(key => [key, object[key]]);
+    entries(this).map(([key, value]) => {
       if (value && typeof value === 'object') {
         const resultObj = Object.create(value);
-        Object.entries(value).map(([key2, value2]) => {
+        entries(value).map(([key2, value2]) => {
           if (key2 === 'icon_url') key2 = 'iconURL';
           resultObj[key2] = value2;
           return true;

--- a/src/structures/RichEmbed.js
+++ b/src/structures/RichEmbed.js
@@ -219,12 +219,20 @@ class RichEmbed {
    * @readonly
    */
   get messageEmbed() {
-    if (!(this instanceof RichEmbed)) throw new TypeError('Embed must be an instance of the RichEmbed class.');
     const result = {};
     for (const prop of Object.keys(this)) {
-      result[prop] = this[prop];
+      let item = this[prop];
+      if (typeof item === 'object' && !(item instanceof Array)) {
+        const oldItem = item;
+        item = {};
+        for (const anotherprop of Object.keys(oldItem)) {
+          if (anotherprop === 'icon_url') item.iconURL = oldItem[anotherprop];
+          else item[anotherprop] = oldItem[anotherprop];
+        }
+      }
+      result[prop] = item;
     }
-    return new MessageEmbed({ client: null }, result);
+    return new MessageEmbed({}, this);
   }
 }
 

--- a/src/structures/RichEmbed.js
+++ b/src/structures/RichEmbed.js
@@ -219,22 +219,23 @@ class RichEmbed {
    * @readonly
    */
   get messageEmbed() {
-    const result = Object.assign(new Proxy({}, {
+    const handler = {
       set: (target, name, value) => {
         if (typeof value === 'object') {
-          target[name] = Object.assign(new Proxy(value instanceof Array ? [] : {}, {
+          target[name] = new Proxy(value, {
             set: (target2, name2, value2) => {
               if (name2 === 'icon_url') name2 = 'iconURL';
               target2[name2] = value2;
               return true;
             },
-          }), value);
+          });
         } else {
           target[name] = value;
         }
         return true;
       },
-    }), this);
+    };
+    const result = new Proxy(this, handler);
     return new MessageEmbed({}, result);
   }
 }

--- a/src/structures/RichEmbed.js
+++ b/src/structures/RichEmbed.js
@@ -1,4 +1,5 @@
 const ClientDataResolver = require('../client/ClientDataResolver');
+const MessageEmbed = require('./MessageEmbed.js');
 
 /**
  * A rich embed to be sent with a message with a fluent interface for creation
@@ -210,6 +211,20 @@ class RichEmbed {
     if (this.file) throw new RangeError('You may not upload more than one file at once.');
     this.file = file;
     return this;
+  }
+
+  /**
+   * The MessageEmbed representation of this RichEmbed.
+   * @type {MessageEmbed}
+   * @readonly
+   */
+  get messageEmbed() {
+    if (!(this instanceof RichEmbed)) throw new TypeError('Embed must be an instance of the RichEmbed class.');
+    const result = {};
+    for (const prop of Object.keys(this)) {
+      result[prop] = this[prop];
+    }
+    return new MessageEmbed({ client: null }, result);
   }
 }
 

--- a/src/structures/RichEmbed.js
+++ b/src/structures/RichEmbed.js
@@ -220,7 +220,7 @@ class RichEmbed {
    */
   get messageEmbed() {
     const result = {};
-    // no circular stuff this time
+    // No circular stuff this time
     if (!MessageEmbed) MessageEmbed = require('./MessageEmbed');
     for (const key of Object.keys(this)) {
       const value = this[key];

--- a/src/structures/RichEmbed.js
+++ b/src/structures/RichEmbed.js
@@ -219,23 +219,20 @@ class RichEmbed {
    * @readonly
    */
   get messageEmbed() {
-    const handler = {
-      set: (target, name, value) => {
-        if (typeof value === 'object') {
-          target[name] = new Proxy(value, {
-            set: (target2, name2, value2) => {
-              if (name2 === 'icon_url') name2 = 'iconURL';
-              target2[name2] = value2;
-              return true;
-            },
-          });
-        } else {
-          target[name] = value;
-        }
-        return true;
-      },
-    };
-    const result = new Proxy(this, handler);
+    const result = {};
+    Object.entries(this).map(([key, value]) => {
+      if (value && typeof value === 'object') {
+        const resultObj = Object.create(value);
+        Object.entries(value).map(([key2, value2]) => {
+          if (key2 === 'icon_url') key2 = 'iconURL';
+          resultObj[key2] = value2;
+        });
+        result[key] = resultObj;
+      } else {
+        result[key] = value;
+      }
+      return result;
+    });
     return new MessageEmbed({}, result);
   }
 }

--- a/src/structures/RichEmbed.js
+++ b/src/structures/RichEmbed.js
@@ -221,10 +221,10 @@ class RichEmbed {
   get messageEmbed() {
     const result = {};
     const entries = object => Object.keys(object).map(key => [key, object[key]]);
-    entries(this).map(([key, value]) => {
+    entries(this).forEach(([key, value]) => {
       if (value && typeof value === 'object') {
         const resultObj = Object.create(value);
-        entries(value).map(([key2, value2]) => {
+        entries(value).forEach(([key2, value2]) => {
           if (key2 === 'icon_url') key2 = 'iconURL';
           resultObj[key2] = value2;
           return true;


### PR DESCRIPTION
I made the MessageEmbed initializer have `{ client: null }` so MessageEmbed doesn't complain.

EDIT: Set it to `{}` instead.

This could be used, for example, for a bot that does moderation logs in embeds and needs to edit the reason field: It fetches the message and then does edits, and edits the message to the new embed.
This could also be used for logging bots, that want to capture the embeds in messages, or something.
It could **also** be used for cloning embeds, by converting e.g. RichEmbed -> MessageEmbed -> RichEmbed.