### PR TITLE
Add FEC and PLP support for Opus encoding

### DIFF
--- a/src/client/voice/opus/BaseOpusEngine.js
+++ b/src/client/voice/opus/BaseOpusEngine.js
@@ -9,11 +9,15 @@ class BaseOpus {
   }
 
   init() {
-    // enable FEC (forward error correction)
-    this.setFEC(true);
+    try {
+      // enable FEC (forward error correction)
+      this.setFEC(true);
 
-    // set PLP (expected packet loss percentage) to 15%
-    this.setPLP(0.15);
+      // set PLP (expected packet loss percentage) to 15%
+      this.setPLP(0.15);
+    } catch (err) {
+      // Opus engine likely has no support for libopus CTL
+    }
   }
 
   encode(buffer) {

--- a/src/client/voice/opus/BaseOpusEngine.js
+++ b/src/client/voice/opus/BaseOpusEngine.js
@@ -1,6 +1,19 @@
 class BaseOpus {
   constructor(player) {
     this.player = player;
+
+    this.ctl = {
+      FEC: 4012,
+      PLP: 4014,
+    };
+  }
+
+  init() {
+    // enable FEC (forward error correction)
+    this.setFEC(true);
+
+    // set PLP (expected packet loss percentage) to 15%
+    this.setPLP(0.15);
   }
 
   encode(buffer) {

--- a/src/client/voice/opus/NodeOpusEngine.js
+++ b/src/client/voice/opus/NodeOpusEngine.js
@@ -19,7 +19,7 @@ class NodeOpusEngine extends OpusEngine {
   }
 
   setPLP(percent) {
-    this.encoder.applyEncoderCTL(this.ctl.PLP, Math.max(100, Math.min(0, percent * 100)));
+    this.encoder.applyEncoderCTL(this.ctl.PLP, Math.min(100, Math.max(0, percent * 100)));
   }
 
   encode(buffer) {

--- a/src/client/voice/opus/NodeOpusEngine.js
+++ b/src/client/voice/opus/NodeOpusEngine.js
@@ -11,6 +11,15 @@ class NodeOpusEngine extends OpusEngine {
       throw err;
     }
     this.encoder = new opus.OpusEncoder(48000, 2);
+    super.init();
+  }
+
+  setFEC(enabled) {
+    this.encoder.applyEncoderCTL(this.ctl.FEC, enabled ? 1 : 0);
+  }
+
+  setPLP(percent) {
+    this.encoder.applyEncoderCTL(this.ctl.PLP, Math.max(100, Math.min(0, percent * 100)));
   }
 
   encode(buffer) {

--- a/src/client/voice/opus/OpusScriptEngine.js
+++ b/src/client/voice/opus/OpusScriptEngine.js
@@ -19,7 +19,7 @@ class OpusScriptEngine extends OpusEngine {
   }
 
   setPLP(percent) {
-    this.encoder.encoderCTL(this.ctl.PLP, Math.max(100, Math.min(0, percent * 100)));
+    this.encoder.encoderCTL(this.ctl.PLP, Math.min(100, Math.max(0, percent * 100)));
   }
 
   encode(buffer) {

--- a/src/client/voice/opus/OpusScriptEngine.js
+++ b/src/client/voice/opus/OpusScriptEngine.js
@@ -11,6 +11,15 @@ class OpusScriptEngine extends OpusEngine {
       throw err;
     }
     this.encoder = new OpusScript(48000, 2);
+    super.init();
+  }
+
+  setFEC(enabled) {
+    this.encoder.encoderCTL(this.ctl.FEC, enabled ? 1 : 0);
+  }
+
+  setPLP(percent) {
+    this.encoder.encoderCTL(this.ctl.PLP, Math.max(100, Math.min(0, percent * 100)));
   }
 
   encode(buffer) {


### PR DESCRIPTION
Enables FEC (forward error correction) and PLP (expected packet loss percentage) settings for Opus encoding.

See Jake's PR to discord.py that adds this:
https://github.com/Rapptz/discord.py/commit/7efabce4b2a1ddc0193f9d544cd90185d4740042