### PR TITLE
Added mentions.members

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -123,7 +123,6 @@ class Message {
      */
     this.mentions = {
       users: new Collection(),
-      members: new Collection(),
       roles: new Collection(),
       channels: new Collection(),
       everyone: data.mention_everyone,
@@ -135,8 +134,11 @@ class Message {
         user = this.client.dataManager.newUser(mention);
       }
       this.mentions.users.set(user.id, user);
+    }
 
-      if (this.channel.guild) {
+    if (this.guild) {
+      this.mentions.members = new Collection();
+      for (const mention of data.mentions) {
         const member = this.channel.guild.members.get(mention.id);
         if (member) this.mentions.members.set(member.id, member);
       }

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -130,14 +130,13 @@ class Message {
 
     for (const mention of data.mentions) {
       let user = this.client.users.get(mention.id);
-      if (!user) {
-        user = this.client.dataManager.newUser(mention);
-      }
+      if (!user) user = this.client.dataManager.newUser(mention);
       this.mentions.users.set(user.id, user);
     }
 
     Object.defineProperty(this.mentions, 'members', {
       get: () => {
+        if (this.channel.type !== 'text') return null;
         const memberMentions = new Collection();
         for (const mention of this.mentions.users.values()) {
           const member = this.client.resolver.resolveGuildMember(this.guild, mention);

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -136,13 +136,16 @@ class Message {
       this.mentions.users.set(user.id, user);
     }
 
-    if (this.guild) {
-      this.mentions.members = new Collection();
-      for (const mention of data.mentions) {
-        const member = this.channel.guild.members.get(mention.id);
-        if (member) this.mentions.members.set(member.id, member);
-      }
-    }
+    Object.defineProperty(this.mentions, 'members', {
+      get: () => {
+        const memberMentions = new Collection();
+        for (const mention of this.mentions.users.values()) {
+          const member = this.client.resolver.resolveGuildMember(this.guild, mention);
+          if (member) memberMentions.set(member.id, member);
+        }
+        return memberMentions;
+      },
+    });
 
     if (data.mention_roles) {
       for (const mention of data.mention_roles) {

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -114,6 +114,8 @@ class Message {
      * An object containing a further users, roles or channels collections
      * @type {Object}
      * @property {Collection<Snowflake, User>} mentions.users Mentioned users, maps their ID to the user object.
+     * @property {Collection<Snowflake, GuildMember>} mentions.members Mentioned members, maps their ID
+     * to the member object.
      * @property {Collection<Snowflake, Role>} mentions.roles Mentioned roles, maps their ID to the role object.
      * @property {Collection<Snowflake, GuildChannel>} mentions.channels Mentioned channels,
      * maps their ID to the channel object.
@@ -121,6 +123,7 @@ class Message {
      */
     this.mentions = {
       users: new Collection(),
+      members: new Collection(),
       roles: new Collection(),
       channels: new Collection(),
       everyone: data.mention_everyone,
@@ -128,11 +131,14 @@ class Message {
 
     for (const mention of data.mentions) {
       let user = this.client.users.get(mention.id);
-      if (user) {
-        this.mentions.users.set(user.id, user);
-      } else {
+      if (!user) {
         user = this.client.dataManager.newUser(mention);
-        this.mentions.users.set(user.id, user);
+      }
+      this.mentions.users.set(user.id, user);
+
+      if (this.channel.guild) {
+        const member = this.channel.guild.members.get(mention.id);
+        if (member) this.mentions.members.set(member.id, member);
       }
     }
 


### PR DESCRIPTION
## Description
I have added a convenience field to mentions that maps guild members to their respective mentions, provided they already exist in the cache.
I also changed the users code to be a bit neater, but the functionality is exactly the same.

## Use Cases
### Case 1
Frequently when doing operations on mentions, we need to map them to the member get function.
```js
if (message.mentions.users.size) {
	const x = message.mentions.users.map(u => message.guild.members.get(u.id).displayName);
	message.reply(`Members: ${x}`);
}
```
Using the convenience property, we can shorten this to:
```js
if (message.mentions.members.size) {
	const x = message.mentions.members.map(m => m.displayName);
	message.reply(`Members: ${x}`);
}
```
### Case 2
For moderation purposes such as checking for kickable:
```js
message.guild.members.get(message.mentions.users.first().id).kickable;
```
Would become:
```js
message.mentions.members.first().kickable;
```

## Things to note

- If a member is not in the cache, the members list will not be populated with their entry. This can lead to strange behaviour such as where the `users.first()` and `members.first()` may not be the same entry.
- ~~In a DM, this field will be an empty collection.~~ ~~Amended to be undefined for non-guild channels.~~ Further amended to return empty collection again
