### PR TITLE
Make the optional arguments for TextBasedChannel#sendFiles optional

### DIFF
--- a/src/structures/interface/TextBasedChannel.js
+++ b/src/structures/interface/TextBasedChannel.js
@@ -151,7 +151,7 @@ class TextBasedChannel {
    * @param {MessageOptions} [options] Options for the message
    * @returns {Promise<Message>}
    */
-  sendFiles(files, content, options) {
+  sendFiles(files, content, options = {}) {
     return this.send(content, Object.assign(options, { files }));
   }
 


### PR DESCRIPTION
When using sendFiles, only the first argument (array of BufferResolvable or FileOptions) should be required.

Currently omitting the last argument results in 
```js
TypeError: Cannot convert undefined or null to object
```
Just a small fix for this.
It's tested.