### PR TITLE
[untested] Fix for #1281: memberUpdate Roles are Identical

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -863,12 +863,16 @@ class Guild {
   }
 
   _updateMember(member, data) {
-    const oldMember = Util.cloneObject(member);
+    data.joined_at = member.joinedAt.toString();
+    data.deaf = member.serverDeaf;
+    data.mute = member.serverMute;
+    data.self_deaf = member.selfDeaf;
+    data.self_mute = member.selfMute;
+    data.session_id = member.voiceSessionID;
+    data.channel_id = member.voiceChannelID;
+    const newMember = new GuildMember(member.guild, data);
 
-    if (data.roles) member._roles = data.roles;
-    if (typeof data.nick !== 'undefined') member.nickname = data.nick;
-
-    const notSame = member.nickname !== oldMember.nickname || !Util.arraysEqual(member._roles, oldMember._roles);
+    const notSame = member.nickname !== newMember.nickname || !Util.arraysEqual(member._roles, newMember._roles);
 
     if (this.client.ws.status === Constants.Status.READY && notSame) {
       /**
@@ -877,12 +881,12 @@ class Guild {
        * @param {GuildMember} oldMember The member before the update
        * @param {GuildMember} newMember The member after the update
        */
-      this.client.emit(Constants.Events.GUILD_MEMBER_UPDATE, oldMember, member);
+      this.client.emit(Constants.Events.GUILD_MEMBER_UPDATE, member, newMember);
     }
 
     return {
-      old: oldMember,
-      mem: member,
+      old: member,
+      mem: newMember,
     };
   }
 

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -882,6 +882,7 @@ class Guild {
        * @param {GuildMember} newMember The member after the update
        */
       this.client.emit(Constants.Events.GUILD_MEMBER_UPDATE, member, newMember);
+      this.members.set(newMember.id, newMember);
     }
 
     return {


### PR DESCRIPTION
Similar fix to collections being overwritten because of references. The array is being referenced in the object assign, so when the member was being patched, the arrays being linked was causing both oldMember and newMember's arrays to be overwritten.