### PR TITLE
Fix for wrongly formatted link being returned when generating invite for bot.

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -399,7 +399,7 @@ class Client extends EventEmitter {
    */
   generateInvite(permissions) {
     if (permissions) {
-      if (permissions instanceof Array) permissions = Permissions.resolve(permissions);
+      if (permissions instanceof Array) permissions = Permissions.resolve(permissions).reduce((a, b) => a + b, 0);
     } else {
       permissions = 0;
     }

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -399,7 +399,7 @@ class Client extends EventEmitter {
    */
   generateInvite(permissions) {
     if (permissions) {
-      if (permissions instanceof Array) permissions = Permissions.resolve(permissions).reduce((a, b) => a + b, 0);
+      if (permissions instanceof Array) permissions = Permissions.resolve(permissions).reduce((a, b) => a | b, 0);
     } else {
       permissions = 0;
     }


### PR DESCRIPTION
The link returned by client#generateInvite is wrongly containing a joined array of permission numbers.
Looking like this:
```
https://discordapp.com/oauth2/authorize?client_id=<ID>&permissions=2048,32,131072&scope=bot
```

Don't know if reduce is the best solution here, was the first thing that came to my mind.
Tested with various combinations and an empty array, everything working fine.

Result is looking like this
```
https://discordapp.com/oauth2/authorize?client_id=<ID>&permissions=133152&scope=bot
```