### PR TITLE
Make FetchMessage work for non-bot users

### DIFF
--- a/src/structures/interface/TextBasedChannel.js
+++ b/src/structures/interface/TextBasedChannel.js
@@ -191,7 +191,9 @@ class TextBasedChannel {
    *   .catch(console.error);
    */
   fetchMessage(messageID) {
-    if (!this.client.user.bot) return this.fetchMessages({ limit: 1, around: messageID });
+    if (!this.client.user.bot) {
+      return this.fetchMessages({ limit: 1, around: messageID }).then(messageCol => messageCol.first());
+    }
     return this.client.rest.methods.getChannelMessage(this, messageID).then(data => {
       const msg = data instanceof Message ? data : new Message(this, data, this.client);
       this._cacheMessage(msg);

--- a/src/structures/interface/TextBasedChannel.js
+++ b/src/structures/interface/TextBasedChannel.js
@@ -181,7 +181,8 @@ class TextBasedChannel {
 
   /**
    * Gets a single message from this channel, regardless of it being cached or not.
-   * When using a user account, this abstracts {@link #fetchMessages} to obtain the single message.
+   * Since the single message fetching endpoint is reserved for bot accounts, this abstracts
+   * the `fetchMessages` method to obtain the single message when using a user account.
    * @param {Snowflake} messageID ID of the message to get
    * @returns {Promise<Message>}
    * @example

--- a/src/structures/interface/TextBasedChannel.js
+++ b/src/structures/interface/TextBasedChannel.js
@@ -181,7 +181,7 @@ class TextBasedChannel {
 
   /**
    * Gets a single message from this channel, regardless of it being cached or not.
-   * When not using a bot account, it will use fetchMessages instead.
+   * When not using a bot account, it will use fetchMessages to fetch the message ID instead.
    * @param {Snowflake} messageID ID of the message to get
    * @returns {Promise<Message>}
    * @example

--- a/src/structures/interface/TextBasedChannel.js
+++ b/src/structures/interface/TextBasedChannel.js
@@ -182,7 +182,7 @@ class TextBasedChannel {
   /**
    * Gets a single message from this channel, regardless of it being cached or not.
    * Since the single message fetching endpoint is reserved for bot accounts, this abstracts
-   * the `fetchMessages` method to obtain the single message when using a user account.
+   * {@link #fetchMessages} to obtain the single message when using a user account.
    * @param {Snowflake} messageID ID of the message to get
    * @returns {Promise<Message>}
    * @example

--- a/src/structures/interface/TextBasedChannel.js
+++ b/src/structures/interface/TextBasedChannel.js
@@ -181,7 +181,7 @@ class TextBasedChannel {
 
   /**
    * Gets a single message from this channel, regardless of it being cached or not.
-   * <warn>This is only available when using a bot account.</warn>
+   * When not using a bot account, it will use fetchMessages instead.
    * @param {Snowflake} messageID ID of the message to get
    * @returns {Promise<Message>}
    * @example
@@ -191,7 +191,8 @@ class TextBasedChannel {
    *   .catch(console.error);
    */
   fetchMessage(messageID) {
-    if (this.client.user.bot) return this.client.rest.methods.getChannelMessage(this, messageID).then(data => {
+    if (!this.client.user.bot) return this.fetchMessages({ limit: 1, around: messageID });
+    return this.client.rest.methods.getChannelMessage(this, messageID).then(data => {
       const msg = data instanceof Message ? data : new Message(this, data, this.client);
       this._cacheMessage(msg);
       return msg;

--- a/src/structures/interface/TextBasedChannel.js
+++ b/src/structures/interface/TextBasedChannel.js
@@ -192,7 +192,13 @@ class TextBasedChannel {
    */
   fetchMessage(messageID) {
     if (!this.client.user.bot) {
-      return this.fetchMessages({ limit: 1, around: messageID }).then(messageCol => messageCol.first());
+      return new Promise((resolve, reject) => {
+        this.fetchMessages({ limit: 1, around: messageID }).then(messageCol => {
+          const message = messageCol.first();
+          if (message.id !== messageID) return reject(new Error('Error: Not Found'));
+          return resolve(message);
+        }).catch(reject);
+      });
     }
     return this.client.rest.methods.getChannelMessage(this, messageID).then(data => {
       const msg = data instanceof Message ? data : new Message(this, data, this.client);

--- a/src/structures/interface/TextBasedChannel.js
+++ b/src/structures/interface/TextBasedChannel.js
@@ -191,7 +191,7 @@ class TextBasedChannel {
    *   .catch(console.error);
    */
   fetchMessage(messageID) {
-    return this.client.rest.methods.getChannelMessage(this, messageID).then(data => {
+    if (this.client.user.bot) return this.client.rest.methods.getChannelMessage(this, messageID).then(data => {
       const msg = data instanceof Message ? data : new Message(this, data, this.client);
       this._cacheMessage(msg);
       return msg;

--- a/src/structures/interface/TextBasedChannel.js
+++ b/src/structures/interface/TextBasedChannel.js
@@ -181,7 +181,7 @@ class TextBasedChannel {
 
   /**
    * Gets a single message from this channel, regardless of it being cached or not.
-   * When not using a bot account, it will use fetchMessages to fetch the message ID instead.
+   * When using a user account, this abstracts {@link #fetchMessages} to obtain the single message.
    * @param {Snowflake} messageID ID of the message to get
    * @returns {Promise<Message>}
    * @example
@@ -192,12 +192,10 @@ class TextBasedChannel {
    */
   fetchMessage(messageID) {
     if (!this.client.user.bot) {
-      return new Promise((resolve, reject) => {
-        this.fetchMessages({ limit: 1, around: messageID }).then(messageCol => {
-          const message = messageCol.first();
-          if (message.id !== messageID) return reject(new Error('Error: Not Found'));
-          return resolve(message);
-        }).catch(reject);
+      return this.fetchMessages({ limit: 1, around: messageID }).then(messages => {
+        const msg = messages.first();
+        if (msg.id !== messageID) throw new Error('Message not found.');
+        return msg;
       });
     }
     return this.client.rest.methods.getChannelMessage(this, messageID).then(data => {


### PR DESCRIPTION
Basically just a shortcut to `fetchMessages({ limit: 1, around: ID })`, but it can be useful in case e.g. someone transfers their bot to an user account, or even be useful as a shortcut itself.