### PR TITLE
fix for .destroy() on never loggedin clients

### DIFF
--- a/src/client/ClientManager.js
+++ b/src/client/ClientManager.js
@@ -54,6 +54,7 @@ class ClientManager {
 
   destroy() {
     this.client.ws.destroy();
+    if (!this.client.user) return Promise.resolve();
     if (this.client.user.bot) {
       this.client.token = null;
       return Promise.resolve();


### PR DESCRIPTION
Example:
```
const client = new require('discord.js').Client()
client.destroy()
```
atm this is throwing a TypeError
since calling .destroy() on a already destroyed client just resolves i'd say this also fits better then a reject and would make it possible to just call .destroy() no matter which state ur bot is in and wait for the resolve to ensure its dead