### PR TITLE
Update `uws` package version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "node-opus": "^0.2.0",
     "opusscript": "^0.0.2",
     "sodium": "^2.0.1",
-    "uws": "^0.12.0"
+    "uws": "^0.14.1"
   },
   "devDependencies": {
     "discord.js-docgen": "hydrabolt/discord.js-docgen",


### PR DESCRIPTION
The version 0.12.x of `uws` has been recently removed from NPM and only the latest version (0.14.1) is available.
The reason is described here: https://github.com/uWebSockets/uWebSockets/issues/551.