### PR TITLE
Fix invite resolver

### DIFF
--- a/src/client/ClientDataResolver.js
+++ b/src/client/ClientDataResolver.js
@@ -149,7 +149,7 @@ class ClientDataResolver {
    * @returns {string}
    */
   resolveInviteCode(data) {
-    const inviteRegex = /discord(?:app)?\.(?:gg|com\/invite)\/([a-z0-9]{5})/i;
+    const inviteRegex = /discord(?:app\.com\/invite|\.gg)\/([\w-]{2,255})/i;
     const match = inviteRegex.exec(data);
     if (match && match[1]) return match[1];
     return data;


### PR DESCRIPTION
Added support for:
* Vanity URLs
* Permanent Invites

Also fixed `discord.com/invite/{code}` being a valid invite