### PR TITLE
Add guild#createRole resolve permissions and RoleData optional

### DIFF
--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -418,6 +418,7 @@ class RESTMethods {
 
   createGuildRole(guild, data) {
     if (data.color) data.color = this.client.resolver.resolveColor(data.color);
+    if (data.permissions) data.permissions = Permissions.resolve(data.permissions);
     return this.rest.makeRequest('post', Constants.Endpoints.guildRoles(guild.id), true, data).then(role =>
       this.client.actions.GuildRoleCreate.handle({
         guild_id: guild.id,

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -683,7 +683,7 @@ class Guild {
    * .then(role => console.log(`Created role ${role}`))
    * .catch(console.error)
    */
-  createRole(data) {
+  createRole(data = {}) {
     return this.client.rest.methods.createGuildRole(this, data);
   }
 


### PR DESCRIPTION
Currently the permission property of RoleData is just passed as is to discord api.

That will resolve them beforehand.