### PR TITLE
Fixing stuff, borked by #1323

### DIFF
--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -122,11 +122,8 @@ class RESTMethods {
         }
       };
 
-      if (channel instanceof User || channel instanceof GuildMember) {
-        this.createDM(channel).then(send, reject);
-      } else {
-        send(channel);
-      }
+      if (channel instanceof User || channel instanceof GuildMember) this.createDM(channel).then(send, reject);
+      else send(channel);
     });
   }
 
@@ -192,7 +189,7 @@ class RESTMethods {
         channel_id: channel.id,
         ids: messages,
       }).messages
-      );
+    );
   }
 
   search(target, options) {
@@ -278,7 +275,6 @@ class RESTMethods {
     const data = this.client.user.bot ?
       { access_tokens: options.accessTokens, nicks: options.nicks } :
       { recipients: options.recipients };
-
     return this.rest.makeRequest('post', Endpoints.User('@me').channels, true, data)
       .then(res => new GroupDMChannel(this.client, res));
   }
@@ -329,7 +325,6 @@ class RESTMethods {
     options.icon = this.client.resolver.resolveBase64(options.icon) || null;
     options.region = options.region || 'us-central';
     return new Promise((resolve, reject) => {
-      // eslint-disable-next-line consistent-return
       this.rest.makeRequest('post', Endpoints.guilds, true, options).then(data => {
         if (this.client.guilds.has(data.id)) return resolve(this.client.guilds.get(data.id));
 
@@ -346,6 +341,7 @@ class RESTMethods {
           this.client.removeListener(Constants.Events.GUILD_CREATE, handleGuild);
           reject(new Error('Took too long to receive guild data.'));
         }, 10000);
+        return undefined;
       }, reject);
     });
   }
@@ -823,7 +819,7 @@ class RESTMethods {
   }
 
   removeMessageReaction(message, emoji, user) {
-    let endpoint = Endpoints.Message(message).Reaction(emoji).User(user === this.client.user.id ? '@me' : user.id);
+    const endpoint = Endpoints.Message(message).Reaction(emoji).User(user === this.client.user.id ? '@me' : user.id);
     return this.rest.makeRequest('delete', endpoint, true).then(() =>
       this.client.actions.MessageReactionRemove.handle({
         user_id: user,

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -129,11 +129,12 @@ const Endpoints = exports.Endpoints = {
       Splash: (root, hash) => Endpoints.CDN(root).Splash(guildID, hash),
       Role: roleID => `${base}/roles/${roleID}`,
       Member: memberID => {
+        if (memberID.id) memberID = memberID.id;
         const mbase = `${base}/members/${memberID}`;
         return {
           toString: () => mbase,
-          role: roleID => `${mbase}/roles/${roleID}`,
-          nickname: `${mbase}/nick`,
+          Role: roleID => `${mbase}/roles/${roleID}`,
+          nickname: `${base}/members/@me/nick`,
         };
       },
     };


### PR DESCRIPTION
Fixed several things borked up by #1323, such as:
 - Creating Channels
 - Pass rejected add and remove role promises back to the top.
 - Resolving ID of guildmember for api requests.
 - Replacing client id with `@me` when modifying own member object, because discord api.
 - Replaced plain strings with their corresponding Constants.Events for consistency when attaching or removing event listeners.
 - One lined two if statements.
 - VS Code apparently changed some formatting stuff, npm run lint wasn't complaining.

`ClientUser#acceptInvite` is untested for obvious reasons.

I hope that was all. I couldn't find anything else.

__Update:__
- One-lined 3 more if statements.
- Catch/Reject addRole and removeRole the same way as other methods.
- Resolve permissions on updateGuildRole with `Permissions.resolve()` when neccessary.

To be under consideration is:
 - `// eslint-disable-line consistent-return` at RestMethods.js 332
 - The linebreaks to avoid max-length at RestMethods 503-504 & 526-527