### PR TITLE
Not firing messageReactionAdd internally & doc fix

### DIFF
--- a/src/client/actions/MessageReactionRemoveAll.js
+++ b/src/client/actions/MessageReactionRemoveAll.js
@@ -20,6 +20,6 @@ class MessageReactionRemoveAll extends Action {
 /**
  * Emitted whenever all reactions are removed from a message.
  * @event Client#messageReactionRemoveAll
- * @param {MessageReaction} messageReaction The reaction object.
+ * @param {Message} message The message the reactions were removed from.
  */
 module.exports = MessageReactionRemoveAll;

--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -818,12 +818,7 @@ class RESTMethods {
     return this.rest.makeRequest(
       'put', Endpoints.Message(message).Reaction(emoji).User('@me'), true
     ).then(() =>
-      this.client.actions.MessageReactionAdd.handle({
-        user_id: this.client.user.id,
-        message_id: message.id,
-        emoji: Util.parseEmoji(emoji),
-        channel_id: message.channel.id,
-      }).reaction
+      message._addReaction(Util.parseEmoji(emoji), message.client.user)
       );
   }
 


### PR DESCRIPTION
Fix for #1285 
When using ``Message#react`` the messageReactionAdd event was fired twice, because the action was called one time by react and one time from the ws. This avoid the first, while returning the correct value.

Also a small correction for the messageReactionRemoveAll in the docs.