### PR TITLE
Reconnect client option

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -526,6 +526,9 @@ class Client extends EventEmitter {
     if (typeof options.restWsBridgeTimeout !== 'number' || isNaN(options.restWsBridgeTimeout)) {
       throw new TypeError('The restWsBridgeTimeout option must be a number.');
     }
+    if (typeof options.reconnect != 'boolean') {
+      throw new TypeError('The reconnect option must be a boolean.');
+    }
     if (!(options.disabledEvents instanceof Array)) throw new TypeError('The disabledEvents option must be an Array.');
   }
 }

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -526,7 +526,7 @@ class Client extends EventEmitter {
     if (typeof options.restWsBridgeTimeout !== 'number' || isNaN(options.restWsBridgeTimeout)) {
       throw new TypeError('The restWsBridgeTimeout option must be a number.');
     }
-    if (typeof options.reconnect != 'boolean') {
+    if (typeof options.reconnect !== 'boolean') {
       throw new TypeError('The reconnect option must be a boolean.');
     }
     if (!(options.disabledEvents instanceof Array)) throw new TypeError('The disabledEvents option must be an Array.');

--- a/src/client/websocket/WebSocketManager.js
+++ b/src/client/websocket/WebSocketManager.js
@@ -249,7 +249,7 @@ class WebSocketManager extends EventEmitter {
      */
     if (!this.reconnecting) this.client.emit(Constants.Events.DISCONNECT, event);
     if ([4004, 4010, 4011].includes(event.code)) return;
-    if (!this.reconnecting && event.code !== 1000) this.tryReconnect();
+    if (!this.reconnecting && event.code !== 1000 && this.client.options.reconnect) this.tryReconnect();
   }
 
   /**

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -29,6 +29,7 @@ exports.Package = require('../../package.json');
  * 100% certain you don't need, as many are important, but not obviously so. The safest one to disable with the
  * most impact is typically `TYPING_START`.
  * @property {WebsocketOptions} [ws] Options for the websocket
+ * @property {boolean} [reconnect=true] Whether to reconnect after an abnormal disconnect
  */
 exports.DefaultOptions = {
   apiRequestMethod: 'sequential',
@@ -43,6 +44,7 @@ exports.DefaultOptions = {
   restWsBridgeTimeout: 5000,
   disabledEvents: [],
   restTimeOffset: 500,
+  reconnect: true,
 
   /**
    * Websocket options (these are left as snake_case to match the API)


### PR DESCRIPTION
This pull request implements a ClientSetting labeled as `reconnect`, which is a boolean defaulting to `true`. When set to `true`, the client will automatically attempt to reconnect on an abnormal CloseEvent, and likewise when set to `false` it will stay disconnected. I'm not sure why this was removed, because this should be considered part of basic connection flow. Forcing reconnects on users isn't good.

As a personal example, I'm running a selfbot. Sometimes, for reasons I have not yet isolated, it gets into reconnect loops. These run for so long that my token ends up getting reset, because there's no form of limitation on reconnects.

I attempted to remedy this with the following code:

```js
reconnectAttempts = 0;
bot.on('reconnecting', () => {
    console.log('Reconnecting');
    if (++reconnectAttempts >= 10) {
        bot.destroy();
        alert(`Destroyed the bot after ${reconnectAttempts} reconnect attempts. Please manually reconnect.`);
    }
});
```

However, the client would continue to reconnect after being destroyed. 

I took this issue to the official discord.js support guild, where they told me to call `process.exit()`. This does not work because of my environment. Calling process.exit() would also kill everything else in the process; namely, my discord client itself. Since discord clients automatically reload, it would still be an endless reconnect loop.

I would greatly appreciate this being re-implemented as a workaround for `Client#destroy` not working. Thank you.