### PR TITLE
getters for decibel and logarithmic volume

### DIFF
--- a/src/client/voice/util/VolumeInterface.js
+++ b/src/client/voice/util/VolumeInterface.js
@@ -63,16 +63,16 @@ class VolumeInterface extends EventEmitter {
   get volume() {
     return this._volume;
   }
-  
+
   /**
    * The current volume of the broadcast in decibels
    * @readonly
    * @type {number}
    */
   get volumeDecibels() {
-    return Math.log10(this._volume) * 20; 
+    return Math.log10(this._volume) * 20;
   }
-  
+
   /**
    * The current volume of the broadcast from a logarithmic scale
    * @readonly

--- a/src/client/voice/util/VolumeInterface.js
+++ b/src/client/voice/util/VolumeInterface.js
@@ -63,6 +63,24 @@ class VolumeInterface extends EventEmitter {
   get volume() {
     return this._volume;
   }
+  
+  /**
+   * The current volume of the broadcast in decibels
+   * @readonly
+   * @type {number}
+   */
+  get volumeDecibels() {
+    return Math.log10(this._volume) * 20; 
+  }
+  
+  /**
+   * The current volume of the broadcast from a logarithmic scale
+   * @readonly
+   * @type {number}
+   */
+  get volumeLogarithmic() {
+    return Math.pow(this._volume, 1 / 1.660964);
+  }
 }
 
 module.exports = VolumeInterface;


### PR DESCRIPTION
I don't really understand where the conversion numbers come from but having this allows for an easy way to get the volume back based on what method you used to set it. I think the math is right, but yeah I've just used the conversion numbers from the other methods and rearranged the equations to get the original numbers

hopefully I did this right xD