### PR TITLE
Fix for MessageMentions properties always being null or empty

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -127,7 +127,7 @@ class Message {
      * All valid mentions that the message contains
      * @type {MessageMentions}
      */
-    this.mentions = new Mentions(this, data.mentions, data.mentions_roles, data.mention_everyone);
+    this.mentions = new Mentions(this, data.mentions, data.mention_roles, data.mention_everyone);
 
     /**
      * ID of the webhook that sent the message, if applicable

--- a/src/structures/MessageMentions.js
+++ b/src/structures/MessageMentions.js
@@ -84,7 +84,7 @@ class MessageMentions {
    */
   get members() {
     if (this._members) return this._members;
-    if (!this.guild) return null;
+    if (!this._guild) return null;
     this._members = new Collection();
     this.users.forEach(user => {
       const member = this._guild.member(user);
@@ -100,7 +100,7 @@ class MessageMentions {
    */
   get channels() {
     if (this._channels) return this._channels;
-    if (!this.guild) return null;
+    if (!this._guild) return null;
     this._channels = new Collection();
     let matches;
     while ((matches = this.constructor.CHANNELS_PATTERN.exec(this._content)) !== null) {


### PR DESCRIPTION
Currently the channels and members properties are always null and the roles collection is always empty.