### PR TITLE
Fix for error on removing message reaction.

### DIFF
--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -815,11 +815,11 @@ class RESTMethods {
       );
   }
 
-  removeMessageReaction(message, emoji, user) {
-    const endpoint = Endpoints.Message(message).Reaction(emoji).User(user === this.client.user.id ? '@me' : user.id);
+  removeMessageReaction(message, emoji, userID) {
+    const endpoint = Endpoints.Message(message).Reaction(emoji).User(userID === this.client.user.id ? '@me' : userID);
     return this.rest.makeRequest('delete', endpoint, true).then(() =>
       this.client.actions.MessageReactionRemove.handle({
-        user_id: user,
+        user_id: userID,
         message_id: message.id,
         emoji: Util.parseEmoji(emoji),
         channel_id: message.channel.id,

--- a/src/structures/MessageReaction.js
+++ b/src/structures/MessageReaction.js
@@ -62,10 +62,10 @@ class MessageReaction {
    */
   remove(user = this.message.client.user) {
     const message = this.message;
-    user = this.message.client.resolver.resolveUserID(user);
-    if (!user) return Promise.reject(new Error('Couldn\'t resolve the user ID to remove from the reaction.'));
+    const userID = this.message.client.resolver.resolveUserID(user);
+    if (!userID) return Promise.reject(new Error('Couldn\'t resolve the user ID to remove from the reaction.'));
     return message.client.rest.methods.removeMessageReaction(
-      message, this.emoji.identifier, user
+      message, this.emoji.identifier, userID
     );
   }
 


### PR DESCRIPTION
Steps to reproduce:
1.) Clone newest master
2.) Add the following to demo code
```js
client.on("messageReactionAdd", (reaction, user) => {
    reaction.remove(user).catch(console.error);
});
```
3.) Add reaction to message 
4.) Receive error: `'Value "undefined" is not snowflake.'`

This was throwing an error because user was being resolved to an ID, while the REST method was treating it like a user object. Fix is to remove `.id` property. I have also changed it to userID to be consistent with the surrounding variables. 