### PR TITLE
Make FEC and PLP non-default

### DIFF
--- a/src/client/voice/opus/BaseOpusEngine.js
+++ b/src/client/voice/opus/BaseOpusEngine.js
@@ -1,20 +1,25 @@
 class BaseOpus {
-  constructor(player) {
-    this.player = player;
-
+  /**
+   * @param {Object} [options] The options to apply to the Opus engine
+   * @param {boolean} [options.fec] Whether to enable forward error correction (defaults to false)
+   * @param {number} [options.plp] The expected packet loss percentage (0-1 inclusive, defaults to 0)
+   */
+  constructor(options = {}) {
     this.ctl = {
       FEC: 4012,
       PLP: 4014,
     };
+
+    this.options = options;
   }
 
   init() {
     try {
-      // Enable FEC (forward error correction)
-      this.setFEC(true);
+      // Set FEC (forward error correction)
+      if (this.options.fec) this.setFEC(this.options.fec);
 
-      // Set PLP (expected packet loss percentage) to 15%
-      this.setPLP(0.15);
+      // Set PLP (expected packet loss percentage)
+      if (this.options.plp) this.setPLP(this.options.plp);
     } catch (err) {
       // Opus engine likely has no support for libopus CTL
     }

--- a/src/client/voice/opus/OpusEngineList.js
+++ b/src/client/voice/opus/OpusEngineList.js
@@ -5,9 +5,9 @@ const list = [
 
 let opusEngineFound;
 
-function fetch(Encoder) {
+function fetch(Encoder, engineOptions) {
   try {
-    return new Encoder();
+    return new Encoder(engineOptions);
   } catch (err) {
     return null;
   }
@@ -17,9 +17,9 @@ exports.add = encoder => {
   list.push(encoder);
 };
 
-exports.fetch = () => {
+exports.fetch = engineOptions => {
   for (const encoder of list) {
-    const fetched = fetch(encoder);
+    const fetched = fetch(encoder, engineOptions);
     if (fetched) return fetched;
   }
   return null;


### PR DESCRIPTION
Many tests have shown that FEC and PLP cause issues such as untimely endings and performance decreases, respectively. It is possible that FEC and PLP would be able to help on certain weaker connections, however...

I considered it might be useful to have something exposed that allows the end-user to set these if they want, but our current code doesn't allow for that. It'll remain an internal feature for the time being.