### PR TITLE
Fix for failed emoji resolve attempts

### DIFF
--- a/src/client/ClientDataResolver.js
+++ b/src/client/ClientDataResolver.js
@@ -251,7 +251,7 @@ class ClientDataResolver {
   resolveEmojiIdentifier(emoji) {
     if (emoji instanceof Emoji || emoji instanceof ReactionEmoji) return emoji.identifier;
     if (typeof emoji === 'string') {
-      if (!isNaN(parseInt(emoji))) return this.client.emojis.get(emoji).identifier;
+      if (this.client.emojis.has(emoji)) return this.client.emojis.get(emoji).identifier;
       else if (!emoji.includes('%')) return encodeURIComponent(emoji);
       else return emoji;
     }


### PR DESCRIPTION
Trying to react with `1⃣` (aka 1️⃣ ) will throw this error
```js
TypeError: Cannot read property 'identifier' of undefined
```
That's because `parseInt(`1⃣`);` returns `1`.
The Data Resolver will then try to get it from the client.emojis collection and throw that error.

Checking for a valid ID with `this.client.emojis.has(emoji)` rather than `parseInt()` would solve that.