### PR TITLE
Fix for AudioPlayer causing a crash on voiceConnection#closing

### DIFF
--- a/src/client/voice/player/AudioPlayer.js
+++ b/src/client/voice/player/AudioPlayer.js
@@ -44,7 +44,7 @@ class AudioPlayer extends EventEmitter {
       timestamp: 0,
       pausedTime: 0,
     };
-    this.voiceConnection.once('closing', () => this.destroyAllStreams());
+    this.voiceConnection.once('closing', () => this.destroyCurrentStream());
   }
 
   /**


### PR DESCRIPTION
Looks like some leftover from commit [9eaf145](https://github.com/hydrabolt/discord.js/commit/9eaf1456b28f3152c84fff15c2afcbadb1684bde)
```js
TypeError: this.destroyAllStreams is not a function
```
Should be `this.destroyCurrentStream()`