### PR TITLE
Emoji convenience methods

### DIFF
--- a/src/structures/Emoji.js
+++ b/src/structures/Emoji.js
@@ -120,7 +120,40 @@ class Emoji {
    *  .catch(console.error);
    */
   edit(data) {
-    return this.client.rest.methods.updateEmoji(this, data); // 
+    return this.client.rest.methods.updateEmoji(this, data);
+  }
+
+  /**
+   * Set the name of the emoji
+   * @param {string} name The new name for the emoji
+   * @returns {Promise<Emoji>}
+   */
+  setName(name) {
+    return this.edit({ name });
+  }
+
+  /**
+   * Add a role to the list of roles that can use this emoji
+   * @param {Role} role The role to add
+   * @returns {Promise<Emoji>}
+   */
+  addRestrictedRole(role) {
+    const newRoles = new Collection(this.roles);
+    newRoles.set(role.id, role);
+    return this.edit({ roles: newRoles });
+  }
+
+  /**
+   * Add multiple roles to the list of roles that can use this emoji
+   * @param {Array<Role>} roles Roles to add
+   * @returns {Promise<Emoji>}
+   */
+  addRestrictedRoles(roles) {
+    const newRoles = new Collection(this.roles);
+    for (const role of roles) {
+      if (this.guild.roles.has(role.id)) newRoles.set(role.id, role);
+    }
+    return this.edit({ roles: newRoles });
   }
 
   /**

--- a/src/structures/Emoji.js
+++ b/src/structures/Emoji.js
@@ -124,7 +124,7 @@ class Emoji {
   }
 
   /**
-   * Set the name of the emoji
+   * Set the name of the emoji.
    * @param {string} name The new name for the emoji
    * @returns {Promise<Emoji>}
    */

--- a/src/structures/Emoji.js
+++ b/src/structures/Emoji.js
@@ -173,7 +173,7 @@ class Emoji {
     for (const role of roles) {
       if (newRoles.has(role.id)) newRoles.delete(role.id);
     }
-    return newRoles;
+    return this.edit({ roles: newRoles });
   }
 
   /**

--- a/src/structures/Emoji.js
+++ b/src/structures/Emoji.js
@@ -133,7 +133,7 @@ class Emoji {
   }
 
   /**
-   * Add a role to the list of roles that can use this emoji
+   * Add a role to the list of roles that can use this emoji.
    * @param {Role} role The role to add
    * @returns {Promise<Emoji>}
    */
@@ -142,8 +142,8 @@ class Emoji {
   }
 
   /**
-   * Add multiple roles to the list of roles that can use this emoji
-   * @param {Array<Role>} roles Roles to add
+   * Add multiple roles to the list of roles that can use this emoji.
+   * @param {Role[]} roles Roles to add
    * @returns {Promise<Emoji>}
    */
   addRestrictedRoles(roles) {
@@ -155,7 +155,7 @@ class Emoji {
   }
 
   /**
-   * Remove a role from the list of roles that can use this emoji
+   * Remove a role from the list of roles that can use this emoji.
    * @param {Role} role The role to remove
    * @returns {Promise<Emoji>}
    */
@@ -164,8 +164,8 @@ class Emoji {
   }
 
   /**
-   * Remove multiple roles from the list of roles that can use this emoji
-   * @param {Array<Role>} roles Roles to remove
+   * Remove multiple roles from the list of roles that can use this emoji.
+   * @param {Role[]} roles Roles to remove
    * @returns {Promise<Emoji>}
    */
   removeRestrictedRoles(roles) {

--- a/src/structures/Emoji.js
+++ b/src/structures/Emoji.js
@@ -138,9 +138,7 @@ class Emoji {
    * @returns {Promise<Emoji>}
    */
   addRestrictedRole(role) {
-    const newRoles = new Collection(this.roles);
-    newRoles.set(role.id, role);
-    return this.edit({ roles: newRoles });
+    return this.addRestrictedRoles([role]);
   }
 
   /**
@@ -154,6 +152,28 @@ class Emoji {
       if (this.guild.roles.has(role.id)) newRoles.set(role.id, role);
     }
     return this.edit({ roles: newRoles });
+  }
+
+  /**
+   * Remove a role from the list of roles that can use this emoji
+   * @param {Role} role The role to remove
+   * @returns {Promise<Emoji>}
+   */
+  removeRestrictedRole(role) {
+    return this.removeRestrictedRoles([role]);
+  }
+
+  /**
+   * Remove multiple roles from the list of roles that can use this emoji
+   * @param {Array<Role>} roles Roles to remove
+   * @returns {Promise<Emoji>}
+   */
+  removeRestrictedRoles(roles) {
+    const newRoles = new Collection(this.roles);
+    for (const role of roles) {
+      if (newRoles.has(role.id)) newRoles.delete(role.id);
+    }
+    return newRoles;
   }
 
   /**

--- a/src/structures/Emoji.js
+++ b/src/structures/Emoji.js
@@ -120,7 +120,7 @@ class Emoji {
    *  .catch(console.error);
    */
   edit(data) {
-    return this.client.rest.methods.updateEmoji(this, data);
+    return this.client.rest.methods.updateEmoji(this, data); // 
   }
 
   /**


### PR DESCRIPTION
Adds convenience methods (similar to those of RichEmbed) to Emoji, for easier use:

- `setName`
- `addRestrictedRole`
- `addRestrictedRoles`
- `removeRestrictedRole`
- `removeRestrictedRoles`

Still a bit indecisive over either stay using array argument or use rest parameters for the `addRestrictedRoles` method. Let me know if I should use rest parameters.

**Edit:** I can also use both 🤔 
**Edit 2:** If I used both I could also merge the restricted role methods into one method 🤔 