### PR TITLE
Alias setNick to setNickname

### DIFF
--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -451,6 +451,15 @@ class GuildMember {
   setNickname(nick) {
     return this.edit({ nick });
   }
+  
+  /**
+  * Set the nickname for the guild member
+  * @param {string} nick The nickname for the guild member
+  * @returns {Promise<GuildMember>}
+  */
+  setNick(nick) {
+    return this.setNickname(nick)
+  }
 
   /**
    * Creates a DM channel between the client and the member


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Alias setNick to setNickname, shortens the method name down by half making it easier to type


**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
