### PR TITLE
fix Guild setOwner example typo

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -581,7 +581,7 @@ class Guild {
    * @returns {Promise<Guild>}
    * @example
    * // edit the guild owner
-   * guild.setOwner(guilds.members.first())
+   * guild.setOwner(guild.members.first())
    *  .then(updated => console.log(`Updated the guild owner to ${updated.owner.username}`))
    *  .catch(console.error);
    */

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -581,7 +581,7 @@ class Guild {
    * @returns {Promise<Guild>}
    * @example
    * // edit the guild owner
-   * guild.setOwner(guilds.members[0])
+   * guild.setOwner(guilds.members.first())
    *  .then(updated => console.log(`Updated the guild owner to ${updated.owner.username}`))
    *  .catch(console.error);
    */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
it Fixes setOwner example in discord.js docs :eyes: 

**Semantic versioning classification:**  
-[  ] This PR changes the library's interface (methods or parameters added)
-[  ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-[x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
