### PR TITLE
Make TextChannel#fetchMessage abstraction throw a better error.

### DIFF
--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -194,8 +194,8 @@ class TextBasedChannel {
   fetchMessage(messageID) {
     if (!this.client.user.bot) {
       return this.fetchMessages({ limit: 1, around: messageID }).then(messages => {
-        const msg = messages.first();
-        if (msg.id !== messageID) throw new Error('Message not found.');
+        const msg = messages.get(messageID);
+        if (!msg) throw new Error('Message not found.');
         return msg;
       });
     }


### PR DESCRIPTION
Currently a `TypeError: Cannot read property 'id' of undefined`, pointing to [this](https://github.com/hydrabolt/discord.js/blob/master/src/structures/interfaces/TextBasedChannel.js#L198) line, is thrown when using `TextChannel#fetchMessage` on an user account if the channel is either empty or the client has no `READ_MESSAGE_HISTORY` permission for that channel.

This is because `TextChannel#fetchMessages` resolves with an emtpy collection in that case and the `.first()` message will be undefined.

This will now throw `Error: Message not found` as probably expected.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
