### PR TITLE
setField method for RichEmbeds

### DIFF
--- a/src/structures/RichEmbed.js
+++ b/src/structures/RichEmbed.js
@@ -140,6 +140,24 @@ class RichEmbed {
   }
 
   /**
+   * Validates a field before it is added
+   * @param {StringResolvable} name The name of the field
+   * @param {StringResolvable} value The value of the field
+   * @param {boolean} inline Set the field to display inline
+   * @returns {boolean} Validity of the field
+   * @private
+   */
+  _isValidField(name, value, inline) {
+    if (this.fields.length >= 25) throw new RangeError('RichEmbeds may not exceed 25 fields.');
+    if (name.length > 256) throw new RangeError('RichEmbed field names may not exceed 256 characters.');
+    if (!/\S/.test(name)) throw new RangeError('RichEmbed field names may not be empty.');
+    if (value.length > 1024) throw new RangeError('RichEmbed field values may not exceed 1024 characters.');
+    if (!/\S/.test(value)) throw new RangeError('RichEmbed field values may not be empty.');
+    if (typeof inline !== 'boolean') throw new TypeError('Richembed field inline must be a boolean');
+    return true;
+  }
+
+  /**
    * Adds a field to the embed (max 25)
    * @param {StringResolvable} name The name of the field
    * @param {StringResolvable} value The value of the field
@@ -147,13 +165,9 @@ class RichEmbed {
    * @returns {RichEmbed} This embed
    */
   addField(name, value, inline = false) {
-    if (this.fields.length >= 25) throw new RangeError('RichEmbeds may not exceed 25 fields.');
     name = resolveString(name);
-    if (name.length > 256) throw new RangeError('RichEmbed field names may not exceed 256 characters.');
-    if (!/\S/.test(name)) throw new RangeError('RichEmbed field names may not be empty.');
     value = resolveString(value);
-    if (value.length > 1024) throw new RangeError('RichEmbed field values may not exceed 1024 characters.');
-    if (!/\S/.test(value)) throw new RangeError('RichEmbed field values may not be empty.');
+    this._isValidField(name, value, inline);
     this.fields.push({ name, value, inline });
     return this;
   }
@@ -165,6 +179,25 @@ class RichEmbed {
    */
   addBlankField(inline = false) {
     return this.addField('\u200B', '\u200B', inline);
+  }
+
+  /**
+   * Changes properties of a field at a specified index, parameters can be made
+   * falsy to inherit properties of the field being changed
+   * @param {number} index The index number of the field, starting from 0
+   * @param {string} name The new name of the field
+   * @param {string} value The new value of the field
+   * @param {boolean} inline The new inline value of the field
+   * @returns {RichEmbed} This embed
+   */
+  setField(index, name, value, inline) {
+    if (typeof index !== "number") throw new TypeError('Field index must be a number');
+    if (!this.fields[index]) throw new RangeError('No field exists at specified index');
+    if (!name) name = this.fields[index].name;
+    if (!value) value = this.fields[index].value;
+    if (typeof inline === 'undefined') inline = this.fields[index].inline;
+    this.fields[index] = { name, value, inline };
+    return this;
   }
 
   /**

--- a/src/structures/RichEmbed.js
+++ b/src/structures/RichEmbed.js
@@ -196,6 +196,7 @@ class RichEmbed {
     if (!name) name = this.fields[index].name;
     if (!value) value = this.fields[index].value;
     if (typeof inline === 'undefined') inline = this.fields[index].inline;
+    this._isValidField(name, value, inline);
     this.fields[index] = { name, value, inline };
     return this;
   }

--- a/src/structures/RichEmbed.js
+++ b/src/structures/RichEmbed.js
@@ -191,7 +191,7 @@ class RichEmbed {
    * @returns {RichEmbed} This embed
    */
   setField(index, name, value, inline) {
-    if (typeof index !== "number") throw new TypeError('Field index must be a number');
+    if (typeof index !== 'number') throw new TypeError('Field index must be a number');
     if (!this.fields[index]) throw new RangeError('No field exists at specified index');
     if (!name) name = this.fields[index].name;
     if (!value) value = this.fields[index].value;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
A setField method for editing embed fields at a specified index. I have separated the logic for throwing errors when a field property is not valid to avoid repeating them, called `_isValidField` (might need to be renamed, also could be changed to public). Obviously sometimes it would be useful to only change the value of the field or something else whilst keeping the rest the same, I felt if I used an object to guarantee what properties were being changed it kinda didn't fit in with the rest of the methods so I just made it inherit them from the current field if a falsey param was provided, i.e you can do like `<RichEmbed>.setField(0, null, "new value")` to only change the value of the field. It doesn't use the resolve string function because this would turn `null` into `"null"` which is truthy. I tested it and it worked so hopefully no issues xD. Something similar to this will be useful as some people like to edit embed fields after they've been sent.

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
- [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
