### PR TITLE
Fix for Message.editedTimestamp incorrectly being a string, rather than a number

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -159,7 +159,7 @@ class Message {
     const clone = Util.cloneObject(this);
     this._edits.unshift(clone);
 
-    this.editedTimestamp = data.edited_timestamp;
+    this.editedTimestamp = new Date(data.edited_timestamp).getTime();
     if ('content' in data) this.content = data.content;
     if ('pinned' in data) this.pinned = data.pinned;
     if ('tts' in data) this.tts = data.tts;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

`Message.editedTimestamp` is currently incorrectly the raw timestamp string from the discord api, rather than a number.

Converting it to a number was probably overlooked or forgotten in the Message#mentions / message update cleanup. [#fa016b6](https://github.com/hydrabolt/discord.js/commit/fa016b6b4178d18bf094646088a3d9f2d8c54a4d)

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
