### PR TITLE
Add <client>.leave() method

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -456,6 +456,23 @@ class Client extends EventEmitter {
   }
 
   /**
+   * Makes the client leave guilds.
+   * @param {Snowflake[]} guildIDs IDs of guilds to leave
+   * @returns {Promise<Guild[]>}
+   */
+  leave(guildIDs) {
+    const guildPromises = [];
+    if (!guildIDs || !guildIDs.length) return Promise.reject(new Error('An array of guild IDs must be provided.'));
+    for (const id of guildIDs) {
+      const guild = this.guilds.get(id);
+      if (guild) guildPromises.push(guild.leave());
+      else guildPromises.push(Promise.reject(new Error(`Guild with ID ${id} not found.`)));
+    }
+
+    return Promise.all(guildPromises);
+  }
+
+  /**
    * Adds a ping to {@link Client#pings}.
    * @param {number} startTime Starting time of the ping
    * @private


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- Changes:

This PR introduces a new method to the client object, ``<client>.leave()``, which, as the name suggests, makes the client leave one or multiple guild(s).

- Reason:

A method to make the client leave guilds without having to manually get them each time seems very convenient to me and I believe it to be very useful for other users aswell. In addition, the method takes an array of guild IDs as input, meaning that you do not have to call the method for every single guild, but can do it all in one run.

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.