### PR TITLE
Made search argument optional, added useronly warning and fixed endpoint

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -444,6 +444,7 @@ class Guild {
 
   /**
    * Performs a search within the entire guild.
+   * <warn>This is only available when using a user account.</warn>
    * @param {MessageSearchOptions} [options={}] Options to pass to the search
    * @returns {Promise<Array<Message[]>>}
    * An array containing arrays of messages. Each inner array is a search context cluster.
@@ -457,7 +458,7 @@ class Guild {
    *   console.log(`I found: **${hit}**, total results: ${res.totalResults}`);
    * }).catch(console.error);
    */
-  search(options) {
+  search(options = {}) {
     return this.client.rest.methods.search(this, options);
   }
 

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -218,6 +218,7 @@ class TextBasedChannel {
 
   /**
    * Performs a search within the channel.
+   * <warn>This is only available when using a user account.</warn>
    * @param {MessageSearchOptions} [options={}] Options to pass to the search
    * @returns {Promise<Array<Message[]>>}
    * An array containing arrays of messages. Each inner array is a search context cluster.
@@ -231,7 +232,7 @@ class TextBasedChannel {
    *   console.log(`I found: **${hit}**, total results: ${res.totalResults}`);
    * }).catch(console.error);
    */
-  search(options) {
+  search(options = {}) {
     return this.client.rest.methods.search(this, options);
   }
 

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -154,7 +154,7 @@ const Endpoints = exports.Endpoints = {
       typing: `${base}/typing`,
       permissions: `${base}/permissions`,
       webhooks: `${base}/webhooks`,
-      search: `${base}/search`,
+      search: `${base}/messages/search`,
       ack: `${base}/ack`,
       pins: `${base}/pins`,
       Pin: messageID => `${base}/pins/${messageID}`,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
 - Added a warning indicating that that method may only be used by a user account.
 - Made the MessageSearchOptions optional like in the docs stated.
 - Fixed Endpoint for searching in a certain channel.


**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
