### PR TITLE
Fixed acknowledging of channels

### DIFF
--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -159,7 +159,7 @@ class RESTMethods {
   }
 
   ackTextChannel(channel) {
-    return this.rest.makeRequest('post', Endpoints.Channel(channel).Message(Snowflake.generate()).ack, true, {
+    return this.rest.makeRequest('post', Endpoints.Channel(channel).Message(channel.lastMessageID).ack, true, {
       token: this._ackToken,
     }).then(res => {
       if (res.token) this._ackToken = res.token;

--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -159,7 +159,9 @@ class RESTMethods {
   }
 
   ackTextChannel(channel) {
-    return this.rest.makeRequest('post', Endpoints.Channel(channel).ack, true, { token: this._ackToken }).then(res => {
+    return this.rest.makeRequest('post', Endpoints.Channel(channel).Message(Snowflake.generate()).ack, true, {
+      token: this._ackToken,
+    }).then(res => {
       if (res.token) this._ackToken = res.token;
       return channel;
     });

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -385,6 +385,7 @@ class TextBasedChannel {
    * @returns {Promise<TextChannel|GroupDMChannel|DMChannel>}
    */
   acknowledge() {
+    if (!this.lastMessageID) return Promise.resolve(this);
     return this.client.rest.methods.ackTextChannel(this);
   }
 

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -385,7 +385,7 @@ class TextBasedChannel {
    * @returns {Promise<TextChannel|GroupDMChannel|DMChannel>}
    */
   acknowledge() {
-    return this.client.rest.methods.ackTextMessage(this);
+    return this.client.rest.methods.ackTextChannel(this);
   }
 
   _cacheMessage(message) {
@@ -480,6 +480,7 @@ exports.applyToClass = (structure, full = false, ignore = []) => {
   if (full) {
     props.push(
       '_cacheMessage',
+      'acknowledge',
       'fetchMessages',
       'fetchMessage',
       'search',

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -155,7 +155,6 @@ const Endpoints = exports.Endpoints = {
       permissions: `${base}/permissions`,
       webhooks: `${base}/webhooks`,
       search: `${base}/messages/search`,
-      ack: `${base}/ack`,
       pins: `${base}/pins`,
       Pin: messageID => `${base}/pins/${messageID}`,
       Recipient: recipientID => `${base}/recipients/${recipientID}`,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- `/channels/{channel.id}/ack` seems not to be a valid endpoint, it responds with 404.
Also the discord client itself uses `/channels/{channel.id}/messages/{message.id}` to ack channels.
Therefore I removed the seemingly not working endpoint from the Constants file and made the ackTextChannel method now using the working one.
Alse the `message.id` of the request url seems not to be a specific's message ID, more like just the current time as a discord snowflake, 
`Slowflake.generate()` seems to be the correct way to generate that snowflake, correct me if I am wrong.

- Fixed typo `ackTextMessage` -> `ackTextChannel`.

- It wouldn't hurt to add `acknowledge` to the full props in `applyToClass`, to actually implement this :^)

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
