### PR TITLE
Throw an error if you try to initiate a new SnowflakeUtil class instance

### DIFF
--- a/src/util/Snowflake.js
+++ b/src/util/Snowflake.js
@@ -8,6 +8,10 @@ let INCREMENT = 0;
  * A container for useful snowflake-related methods
  */
 class SnowflakeUtil {
+  constructor() {
+    throw new Error(`The ${this.constructor.name} class may not be instantiated.`);
+  }
+
   /**
    * A Twitter snowflake, except the epoch is 2015-01-01T00:00:00.000Z
    * ```


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Adds a constructor to SnowflakeUtil similar to the Util constructor letting the user know that it cannot be initiated.

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
- [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
