### PR TITLE
fix for using wrong status, causing certain events not to be fired

### DIFF
--- a/src/client/ClientDataManager.js
+++ b/src/client/ClientDataManager.js
@@ -15,7 +15,7 @@ class ClientDataManager {
   }
 
   get pastReady() {
-    return this.client.ws.status === Constants.Status.READY;
+    return this.client.ws.connection.status === Constants.Status.READY;
   }
 
   newGuild(data) {

--- a/src/client/websocket/WebSocketManager.js
+++ b/src/client/websocket/WebSocketManager.js
@@ -16,12 +16,6 @@ class WebSocketManager extends EventEmitter {
     this.client = client;
 
     /**
-     * Status of the WebSocketManager, a type of Constants.Status. It defaults to IDLE.
-     * @type {number}
-     */
-    this.status = Constants.Status.IDLE;
-
-    /**
      * WebSocket connection of this manager
      * @type {?WebSocketConnection}
      */


### PR DESCRIPTION
ClientDataManager no longer uses the right status after the rewrite. Caused status to be in permanent idle state. WebSocketManager's status is unused, so it can be removed. 

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
