### PR TITLE
emojis should use cdn endpoint

### DIFF
--- a/src/structures/Emoji.js
+++ b/src/structures/Emoji.js
@@ -89,7 +89,7 @@ class Emoji {
    * @readonly
    */
   get url() {
-    return Constants.Endpoints.CDN(this.client.options.http.host).Emoji(this.id);
+    return Constants.Endpoints.CDN(this.client.options.http.cdn).Emoji(this.id);
   }
 
   /**

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -132,7 +132,7 @@ const Endpoints = exports.Endpoints = {
       webhooks: `${base}/webhooks`,
       ack: `${base}/ack`,
       settings: `${base}/settings`,
-      Emoji: emojiID => `${base}/emojis/${emojiID}`,
+      Emoji: hash => Endpoints.CDN(root).Emoji(hash),
       Icon: (root, hash) => Endpoints.CDN(root).Icon(guildID, hash),
       Splash: (root, hash) => Endpoints.CDN(root).Splash(guildID, hash),
       Role: roleID => `${base}/roles/${roleID}`,
@@ -187,7 +187,7 @@ const Endpoints = exports.Endpoints = {
   Member: m => exports.Endpoints.Guild(m.guild).Member(m),
   CDN(root) {
     return {
-      Emoji: emojiID => `${root}/emojis/${emojiID}.png`,
+      Emoji: hash => `${root}/emojis/${hash}.png`,
       Asset: name => `${root}/assets/${name}`,
       Avatar: (userID, hash) => `${root}/avatars/${userID}/${hash}.${hash.startsWith('a_') ? 'gif' : 'png'}?size=2048`,
       Icon: (guildID, hash) => `${root}/icons/${guildID}/${hash}.jpg`,


### PR DESCRIPTION
Emojis were using wrong endpoint, this should amend the issue.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
