### PR TITLE
better setstatus for selfbots

### DIFF
--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -2,6 +2,7 @@ const User = require('./User');
 const Collection = require('../util/Collection');
 const ClientUserSettings = require('./ClientUserSettings');
 const Constants = require('../util/Constants');
+
 /**
  * Represents the logged in client's Discord user
  * @extends {User}
@@ -179,7 +180,12 @@ class ClientUser extends User {
 
       if (data.status) {
         if (typeof data.status !== 'string') throw new TypeError('Status must be a string');
-        status = data.status;
+        if (this.bot) {
+          status = data.status;
+        } else {
+          this.settings.update(Constants.UserSettingsMap.status, data.status);
+          status = 'invisible';
+        }
       }
 
       if (data.game) {
@@ -222,7 +228,6 @@ class ClientUser extends User {
    * @returns {Promise<ClientUser>}
    */
   setStatus(status) {
-    if (!this.bot) this.settings.update(Constants.UserSettingsMap.status, status);
     return this.setPresence({ status });
   }
 
@@ -234,10 +239,12 @@ class ClientUser extends User {
    */
   setGame(game, streamingURL) {
     if (!game) return this.setPresence({ game: null });
-    return this.setPresence({ game: {
-      name: game,
-      url: streamingURL,
-    } });
+    return this.setPresence({
+      game: {
+        name: game,
+        url: streamingURL,
+      },
+    });
   }
 
   /**

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -1,6 +1,7 @@
 const User = require('./User');
 const Collection = require('../util/Collection');
 const ClientUserSettings = require('./ClientUserSettings');
+const Constants = require('../util/Constants');
 /**
  * Represents the logged in client's Discord user
  * @extends {User}
@@ -221,7 +222,11 @@ class ClientUser extends User {
    * @returns {Promise<ClientUser>}
    */
   setStatus(status) {
-    return this.setPresence({ status });
+    if (this.bot) {
+      return this.setPresence({ status });
+    } else {
+      return this.settings.update(Constants.UserSettingsMap.status, status);
+    }
   }
 
   /**

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -222,8 +222,8 @@ class ClientUser extends User {
    * @returns {Promise<ClientUser>}
    */
   setStatus(status) {
-    this.setPresence({ status });
     if (!this.bot) this.settings.update(Constants.UserSettingsMap.status, status);
+    return this.setPresence({ status });
   }
 
   /**

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -222,11 +222,8 @@ class ClientUser extends User {
    * @returns {Promise<ClientUser>}
    */
   setStatus(status) {
-    if (this.bot) {
-      return this.setPresence({ status });
-    } else {
-      return this.settings.update(Constants.UserSettingsMap.status, status);
-    }
+    this.setPresence({ status });
+    if (!this.bot) this.settings.update(Constants.UserSettingsMap.status, status);
   }
 
   /**


### PR DESCRIPTION
This PR makes minor modifications to the `ClientUser#setStatus` function to make it function properly for user accounts (selfbots).

Previously using the generic endpoint, setting a status programmatically on a user account would not work most of the time, and it would never adjust it on the client settings.

By modifying the ClientUserSettings object, we can circumvent this issue.
1. Modifying statuses on a user account will work 100% of the time
2. Modifying statuses on a user account selfbot will reflect on the actual client

This PR accomplishes this by
1. Checking if the ClientUser is a bot
2. If it is a user, then use the `ClientUser#settings.update('status', value)` function to properly update the user status
3. If it is a bot, perform the presence update as per usual

I have made a GIF demonstrating this behavior
![Hooray for status changes](https://requires.discord.gold/7ffb4b.gif)

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
