### PR TITLE
Using ws.connection.status rather than undefined ws.status

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -190,7 +190,7 @@ class Client extends EventEmitter {
    * @readonly
    */
   get status() {
-    return this.ws.status;
+    return this.ws.connection.status;
   }
 
   /**

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -897,7 +897,7 @@ class Guild {
      * @event Client#guildMemberAdd
      * @param {GuildMember} member The member that has joined a guild
      */
-    if (this.client.ws.status === Constants.Status.READY && emitEvent && !existing) {
+    if (this.client.ws.connection.status === Constants.Status.READY && emitEvent && !existing) {
       this.client.emit(Constants.Events.GUILD_MEMBER_ADD, member);
     }
 
@@ -912,7 +912,7 @@ class Guild {
 
     const notSame = member.nickname !== oldMember.nickname || !Util.arraysEqual(member._roles, oldMember._roles);
 
-    if (this.client.ws.status === Constants.Status.READY && notSame) {
+    if (this.client.ws.connection.status === Constants.Status.READY && notSame) {
       /**
        * Emitted whenever a guild member changes - i.e. new role, removed role, nickname
        * @event Client#guildMemberUpdate


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

`client#status` now returns the status, instead of undefined
also `client#guildMemberUpdate` and `client#guildMemberAdd` are firing again

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
