### PR TITLE
Make MessageMentions#channels return an empty collection in DMs

### DIFF
--- a/src/structures/MessageMentions.js
+++ b/src/structures/MessageMentions.js
@@ -94,17 +94,14 @@ class MessageMentions {
   }
 
   /**
-   * Any channels that were mentioned (only in {@link TextChannel}s)
-   * @type {?Collection<Snowflake, GuildChannel>}
+   * Any channels that were mentioned (only populated in {@link TextChannel}s)
+   * @type {Collection<Snowflake, GuildChannel>}
    * @readonly
    */
   get channels() {
     if (this._channels) return this._channels;
-    if (!this._guild) {
-      this._channels = new Collection();
-      return this._channels;
-    }
     this._channels = new Collection();
+    if (!this._guild) return this._channels;
     let matches;
     while ((matches = this.constructor.CHANNELS_PATTERN.exec(this._content)) !== null) {
       const chan = this._guild.channels.get(matches[1]);

--- a/src/structures/MessageMentions.js
+++ b/src/structures/MessageMentions.js
@@ -100,7 +100,10 @@ class MessageMentions {
    */
   get channels() {
     if (this._channels) return this._channels;
-    if (!this._guild) return null;
+    if (!this._guild) {
+      this._channels = new Collection();
+      return this._channels;
+    }
     this._channels = new Collection();
     let matches;
     while ((matches = this.constructor.CHANNELS_PATTERN.exec(this._content)) !== null) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Currently using ``Message#isMentioned`` for a DM throws
```js
TypeError: Cannot read property 'has' of null
```
This is because ``MessageMentions#channels`` returns null here.

To fix that ``MessageMentions#channels`` could return an empty collection in DMs like ``MessageMentions#roles`` is doing that.


**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
