### PR TITLE
Readding Client#disconnect and docs for Client#reconnecting

### DIFF
--- a/src/client/websocket/WebSocketConnection.js
+++ b/src/client/websocket/WebSocketConnection.js
@@ -333,6 +333,10 @@ class WebSocketConnection extends EventEmitter {
    */
   reconnect() {
     this.debug('Attemping to reconnect in 5500ms...');
+    /**
+     * Emitted whenever the client tries to reconnect to the websocket.
+     * @event Client#reconnecting
+     */
     this.client.emit(Constants.Events.RECONNECTING);
     this.connect(this.gateway, 5500, true);
   }
@@ -358,6 +362,12 @@ class WebSocketConnection extends EventEmitter {
   onClose(event) {
     this.debug(`Closed: ${event.code}`);
     this.closeSequence = this.sequence;
+    /**
+     * Emitted whenever the client's websocket is disconnected.
+     * @event Client#disconnect
+     * @param {CloseEvent} event The WebSocket close event
+     */
+    this.client.emit(Constants.Events.DISCONNECT, event);
     // Reset the state before trying to fix anything
     this.emit('close', event);
     this.heartbeat(-1);

--- a/src/client/websocket/WebSocketConnection.js
+++ b/src/client/websocket/WebSocketConnection.js
@@ -334,7 +334,7 @@ class WebSocketConnection extends EventEmitter {
   reconnect() {
     this.debug('Attemping to reconnect in 5500ms...');
     /**
-     * Emitted whenever the client tries to reconnect to the websocket.
+     * Emitted whenever the client tries to reconnect to the WebSocket.
      * @event Client#reconnecting
      */
     this.client.emit(Constants.Events.RECONNECTING);
@@ -362,17 +362,17 @@ class WebSocketConnection extends EventEmitter {
   onClose(event) {
     this.debug(`Closed: ${event.code}`);
     this.closeSequence = this.sequence;
-    /**
-     * Emitted whenever the client's websocket is disconnected.
-     * @event Client#disconnect
-     * @param {CloseEvent} event The WebSocket close event
-     */
-    this.client.emit(Constants.Events.DISCONNECT, event);
     // Reset the state before trying to fix anything
     this.emit('close', event);
     this.heartbeat(-1);
     // Should we reconnect?
     if (Constants.WSCodes[event.code]) {
+      /**
+       * Emitted when the client's WebSocket disconnects and will no longer attempt to reconnect.
+       * @event Client#disconnect
+       * @param {CloseEvent} event The WebSocket close event
+       */
+      this.client.emit(Constants.Events.DISCONNECT, event);
       this.debug(Constants.WSCodes[event.code]);
       this.destroy();
       return;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- Readded documentation for `Client#reconnecting`

Note: Maybe needs to be reworded or moved to a different location.

- Readded `Client#disconnect`

Note: That event was previously only fired when the client was not currently reconnecting: [see](https://github.com/hydrabolt/discord.js/commit/195fcfa15cfdfbeede545f22009006f3a34a0dfc#diff-25533af2af0a39d16191a08cc17046b9L234)
Since the reconnecting itself is no longer behind that condition it's probably also no longer necessary for the event anymore: [see](https://github.com/hydrabolt/discord.js/blob/master/src/client/websocket/WebSocketConnection.js#L370)
I may be wrong here.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
