### PR TITLE
Ready event will now throw errors properly

### DIFF
--- a/src/client/websocket/WebSocketConnection.js
+++ b/src/client/websocket/WebSocketConnection.js
@@ -273,12 +273,11 @@ class WebSocketConnection extends EventEmitter {
    */
   onMessage(event) {
     try {
-      this.onPacket(this.unpack(event.data));
-      return true;
+      event.data = this.unpack(event.data);
     } catch (err) {
-      this.debug(err);
-      return false;
+      this.emit('debug', err);
     }
+    return this.onPacket(event.data);
   }
 
   /**

--- a/src/client/websocket/packets/WebSocketPacketManager.js
+++ b/src/client/websocket/packets/WebSocketPacketManager.js
@@ -99,11 +99,7 @@ class WebSocketPacketManager {
     }
 
     if (!queue && this.queue.length > 0) this.handleQueue();
-    try {
-      if (this.handlers[packet.t]) return this.handlers[packet.t].handle(packet);
-    } catch (error) {
-      this.client.emit(Constants.Events.ERROR, error);
-    }
+    if (this.handlers[packet.t]) return this.handlers[packet.t].handle(packet);
     return false;
   }
 }


### PR DESCRIPTION
Errors in ready event were being emitted, rather than being properly thrown. These changes were made with the help of hydrabolt. 

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
