### PR TITLE
Make Guild#ban delete messages when specified

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -682,9 +682,11 @@ class Guild {
    */
   ban(user, options = {}) {
     if (typeof options === 'number') {
-      options = { reason: null, days: options };
+      options = { reason: null, 'delete-message-days': options };
     } else if (typeof options === 'string') {
-      options = { reason: options, days: 0 };
+      options = { reason: options, 'delete-message-days': 0 };
+    } else if ('days' in options && !('delete-message-days' in options)) {
+      options = { reason: options.reason, 'delete-message-days': options.days };
     }
     return this.client.rest.methods.banGuildMember(this, user, options);
   }
@@ -1061,8 +1063,8 @@ class Guild {
   _sortPositionWithID(collection) {
     return collection.sort((a, b) =>
       a.position !== b.position ?
-      a.position - b.position :
-      Long.fromString(a.id).sub(Long.fromString(b.id)).toNumber()
+        a.position - b.position :
+        Long.fromString(a.id).sub(Long.fromString(b.id)).toNumber()
     );
   }
 }

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -1063,8 +1063,8 @@ class Guild {
   _sortPositionWithID(collection) {
     return collection.sort((a, b) =>
       a.position !== b.position ?
-        a.position - b.position :
-        Long.fromString(a.id).sub(Long.fromString(b.id)).toNumber()
+      a.position - b.position :
+      Long.fromString(a.id).sub(Long.fromString(b.id)).toNumber()
     );
   }
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The last if feels pretty hacky, there is most likely a much better solution.

It would also be possible to:
- Remove `days` as accepted key and use `'delete-message-days'` instead,
but the name is imo a rather poor choice.
- A different conversion in RESTMethods, that would accept `days`.
- Or something entirely different, that I didn't thought of.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
