### PR TITLE
Allow await endpoint stage to not error

### DIFF
--- a/src/client/voice/VoiceConnection.js
+++ b/src/client/voice/VoiceConnection.js
@@ -169,19 +169,20 @@ class VoiceConnection extends EventEmitter {
    * @returns {void}
    */
   setTokenAndEndpoint(token, endpoint) {
-    if (!token) {
-      this.authenticateFailed('Token not provided from voice server packet.');
+    if (!endpoint) {
+      // Signifies awaiting endpoint stage
       return;
     }
-    if (!endpoint) {
-      this.authenticateFailed('Endpoint not provided from voice server packet.');
+
+    if (!token) {
+      this.authenticateFailed('Token not provided from voice server packet.');
       return;
     }
 
     endpoint = endpoint.match(/([^:]*)/)[0];
 
     if (!endpoint) {
-      this.authenticateFailed('Failed to find an endpoint.');
+      this.authenticateFailed('Invalid endpoint received.');
       return;
     }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
When a voice server update is received with no endpoint, this means the client is awaiting an endpoint. This should not throw an error right away.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
- [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
