### PR TITLE
Document flattenErrors keys param.

### DIFF
--- a/src/client/rest/DiscordAPIError.js
+++ b/src/client/rest/DiscordAPIError.js
@@ -25,7 +25,7 @@ class DiscordAPIError extends Error {
     let messages = [];
 
     for (const k of Object.keys(obj)) {
-      const newKey = key ? (isNaN(k) ? `${key}.${k}` : `${key}[${k}]`) : k;
+      const newKey = key ? isNaN(k) ? `${key}.${k}` : `${key}[${k}]` : k;
 
       if (obj[k]._errors) {
         messages.push(`${newKey}: ${obj[k]._errors.map(e => e.message).join(' ')}`);

--- a/src/client/rest/DiscordAPIError.js
+++ b/src/client/rest/DiscordAPIError.js
@@ -18,13 +18,15 @@ class DiscordAPIError extends Error {
   /**
    * Flattens an errors object returned from the API into an array.
    * @param {Object} obj Discord errors object
-   * @param {string} [key] idklol
+   * @param {string} [key] used internally to determine key names of nested fields
    * @returns {string[]}
    */
   static flattenErrors(obj, key = '') {
     let messages = [];
+
     for (const k of Object.keys(obj)) {
-      const newKey = key ? isNaN(k) ? `${key}.${k}` : `${key}[${k}]` : k;
+      const newKey = key ? (isNaN(k) ? `${key}.${k}` : `${key}[${k}]`) : k;
+
       if (obj[k]._errors) {
         messages.push(`${newKey}: ${obj[k]._errors.map(e => e.message).join(' ')}`);
       } else {

--- a/src/client/rest/DiscordAPIError.js
+++ b/src/client/rest/DiscordAPIError.js
@@ -18,7 +18,7 @@ class DiscordAPIError extends Error {
   /**
    * Flattens an errors object returned from the API into an array.
    * @param {Object} obj Discord errors object
-   * @param {string} [key] used internally to determine key names of nested fields
+   * @param {string} [key] Used internally to determine key names of nested fields
    * @returns {string[]}
    */
   static flattenErrors(obj, key = '') {


### PR DESCRIPTION
Improve the documentation for `DiscordAPIError.flattenErrors`. Also added some parens to make the order of ternary operations more clear to future readers.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
