### PR TITLE
Fix for sending files with Webhook class

### DIFF
--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -81,6 +81,7 @@ class Webhook {
    * @property {boolean} [disableEveryone=this.client.options.disableEveryone] Whether or not @everyone and @here
    * should be replaced with plain-text
    * @property {FileOptions|string} [file] A file to send with the message
+   * @property {FileOptions[]|string[]} [files] Files to send with the message
    * @property {string|boolean} [code] Language for optional codeblock formatting to apply
    * @property {boolean|SplitOptions} [split=false] Whether or not the message should be split into multiple messages if
    * it exceeds the character limit. If an object is provided, these are the options for splitting the message.
@@ -88,7 +89,7 @@ class Webhook {
 
   /**
    * Send a message with this webhook.
-   * @param {StringResolvable} content The content to send
+   * @param {StringResolvable} [content] The content to send
    * @param {WebhookMessageOptions} [options={}] The options to provide
    * @returns {Promise<Message|Message[]>}
    * @example
@@ -104,24 +105,36 @@ class Webhook {
     } else if (!options) {
       options = {};
     }
+
     if (options.file) {
-      if (typeof options.file === 'string') options.file = { attachment: options.file };
-      if (!options.file.name) {
-        if (typeof options.file.attachment === 'string') {
-          options.file.name = path.basename(options.file.attachment);
-        } else if (options.file.attachment && options.file.attachment.path) {
-          options.file.name = path.basename(options.file.attachment.path);
-        } else {
-          options.file.name = 'file.jpg';
-        }
-      }
-      return this.client.resolver.resolveBuffer(options.file.attachment).then(file =>
-        this.client.rest.methods.sendWebhookMessage(this, content, options, {
-          file,
-          name: options.file.name,
-        })
-      );
+      if (options.files) options.files.push(options.file);
+      else options.files = [options.file];
     }
+
+    if (options.files) {
+      for (const i in options.files) {
+        let file = options.files[i];
+        if (typeof file === 'string') file = { attachment: file };
+        if (!file.name) {
+          if (typeof file.attachment === 'string') {
+            file.name = path.basename(file.attachment);
+          } else if (file.attachment && file.attachment.path) {
+            file.name = path.basename(file.attachment.path);
+          } else {
+            file.name = 'file.jpg';
+          }
+        }
+        options.files[i] = file;
+      }
+
+      return Promise.all(options.files.map(file =>
+        this.client.resolver.resolveBuffer(file.attachment).then(buffer => {
+          file.file = buffer;
+          return file;
+        })
+      )).then(files => this.client.rest.methods.sendWebhookMessage(this, content, options, files));
+    }
+
     return this.client.rest.methods.sendWebhookMessage(this, content, options);
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
I hope this is the correct branch to PR to.

Sending a file with the webhook currently throws an error.
This will take care of that and allow sending multiple at once.

Tested with a Buffer, local path and an URL.

Also the documentation for other methods are slightly off or wrong, 
not sure if this should be in this PR, therefore left them out.
If they should be part of this PR, I could add them, shouldn't be that much.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
