### PR TITLE
Improve Message's ID attribute documentation

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -33,7 +33,7 @@ class Message {
 
   setup(data) { // eslint-disable-line complexity
     /**
-     * The ID of the message (unique in the channel it was sent)
+     * The ID of the message
      * @type {Snowflake}
      */
     this.id = data.id;


### PR DESCRIPTION
Remove the implication that a Message object's ID is unique only to the channel it was sent on

Message ID's are snowflakes, and as stated in Discord's API documentation, globally unique throughout Discord

See the [API reference](https://github.com/hammerandchisel/discord-api-docs/blob/master/docs/Reference.md#snowflake-ids) and the [Message docs](https://github.com/hammerandchisel/discord-api-docs/blob/master/docs/resources/Channel.md#message-object)


**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
