### PR TITLE
Fix typo in RESTMethods.js

### DIFF
--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -763,7 +763,7 @@ class RESTMethods {
     );
   }
 
-  fetchMeMentions(options) {
+  fetchMentions(options) {
     if (options.guild) options.guild = options.guild.id ? options.guild.id : options.guild;
     return this.rest.makeRequest(
       'get',


### PR DESCRIPTION
fetchMeMentions -> fetchMentions :thinking:

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
- [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.

I have no idea which one includes fixing typos :/