### PR TITLE
Fix typo in RESTMethods.js

### DIFF
--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -767,7 +767,7 @@ class RESTMethods {
     if (options.guild) options.guild = options.guild.id ? options.guild.id : options.guild;
     return this.rest.makeRequest(
       'get',
-      Endpoints.User('@me').mentions(options.limit, options.roles, options.everyone, options.guild)
+      Endpoints.User('@me').Mentions(options.limit, options.roles, options.everyone, options.guild)
     ).then(res => res.body.map(m => new Message(this.client.channels.get(m.channel_id), m, this.client)));
   }
 


### PR DESCRIPTION
[Mentions should be written with a capital M](https://github.com/hydrabolt/discord.js/blob/35ef9cd33defba82ad77c4d64f10c71a3eea7b3a/src/util/Constants.js#L122)

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
- [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
