### PR TITLE
fix fetchMentions' auth header, options and data mapping

### DIFF
--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -185,7 +185,7 @@ class RESTMethods {
         channel_id: channel.id,
         ids: messages,
       }).messages
-    );
+      );
   }
 
   search(target, options) {
@@ -764,10 +764,8 @@ class RESTMethods {
   }
 
   fetchMentions(options) {
-    if (typeof options.limit === 'undefined') options.limit = 25;
-    if (typeof options.roles === 'undefined') options.roles = true;
-    if (typeof options.everyone === 'undefined') options.everyone = true;
     if (options.guild && options.guild.id) options.guild = options.guild.id;
+    Util.mergeDefault({ limit: 25, roles: true, everyone: true, guild: null }, options);
 
     return this.rest.makeRequest(
       'get', Endpoints.User('@me').Mentions(options.limit, options.roles, options.everyone, options.guild), true

--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -764,7 +764,7 @@ class RESTMethods {
   }
 
   fetchMentions(options) {
-    if (options.guild && options.guild.id) options.guild = options.guild.id;
+    if (options.guild instanceof Guild) options.guild = options.guild.id;
     Util.mergeDefault({ limit: 25, roles: true, everyone: true, guild: null }, options);
 
     return this.rest.makeRequest(

--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -185,7 +185,7 @@ class RESTMethods {
         channel_id: channel.id,
         ids: messages,
       }).messages
-      );
+    );
   }
 
   search(target, options) {

--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -185,7 +185,7 @@ class RESTMethods {
         channel_id: channel.id,
         ids: messages,
       }).messages
-    );
+      );
   }
 
   search(target, options) {
@@ -764,11 +764,14 @@ class RESTMethods {
   }
 
   fetchMentions(options) {
-    if (options.guild) options.guild = options.guild.id ? options.guild.id : options.guild;
+    if (typeof options.limit === 'undefined') options.limit = 25;
+    if (typeof options.roles === 'undefined') options.roles = true;
+    if (typeof options.everyone === 'undefined') options.everyone = true;
+    if (options.guild && options.guild.id) options.guild = options.guild.id;
+
     return this.rest.makeRequest(
-      'get',
-      Endpoints.User('@me').Mentions(options.limit, options.roles, options.everyone, options.guild)
-    ).then(res => res.body.map(m => new Message(this.client.channels.get(m.channel_id), m, this.client)));
+      'get', Endpoints.User('@me').Mentions(options.limit, options.roles, options.everyone, options.guild), true
+    ).then(data => data.map(m => new Message(this.client.channels.get(m.channel_id), m, this.client)));
   }
 
   addFriend(user) {

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -265,7 +265,7 @@ class ClientUser extends User {
    * @param {Guild|Snowflake} [options.guild] Limit the search to a specific guild
    * @returns {Promise<Message[]>}
    */
-  fetchMentions(options = { limit: 25, roles: true, everyone: true, guild: null }) {
+  fetchMentions(options = {}) {
     return this.client.rest.methods.fetchMentions(options);
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
 - Setting an auth header works wonder when encountering a 401.
 - makeRequest already resolves with the body, removed ``.body``
 - Renamed ``res`` to ``data`` to be consistent with other methods.
 - Solution to make the arguments parts truly optional, rather than all or nothing.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
