### PR TITLE
Fix broken contributing guide link.

### DIFF
--- a/docs/general/welcome.md
+++ b/docs/general/welcome.md
@@ -80,7 +80,7 @@ client.login('your token');
 ## Contributing
 Before creating an issue, please ensure that it hasn't already been reported/suggested, and double-check the
 [documentation](https://discord.js.org/#/docs).  
-See [the contribution guide](https://github.com/hydrabolt/discord.js/blob/master/CONTRIBUTING.md) if you'd like to submit a PR.
+See [the contribution guide](https://github.com/hydrabolt/discord.js/blob/master/.github/CONTRIBUTING.md) if you'd like to submit a PR.
 
 ## Help
 If you don't understand something in the documentation, you are experiencing problems, or you just need a gentle


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The Discord.js documentation [welcome page](#/docs/main/stable/general/welcome) has a broken link (link is at "See the contribution guide if you'd like to submit a PR."). This PR fixes the broken link.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
- [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
