### PR TITLE
Using a traditional for loop rather than a for in loop for options.files

### DIFF
--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -112,7 +112,7 @@ class Webhook {
     }
 
     if (options.files) {
-      for (const i in options.files) {
+      for (let i = 0; i < options.files.length; i++) {
         let file = options.files[i];
         if (typeof file === 'string') file = { attachment: file };
         if (!file.name) {

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -88,7 +88,7 @@ class TextBasedChannel {
     }
 
     if (options.files) {
-      for (const i in options.files) {
+      for (let i = 0; i < options.files.length; i++) {
         let file = options.files[i];
         if (typeof file === 'string') file = { attachment: file };
         if (!file.name) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Changed the for in loop to a traditional for loop, to avoid iterating through prototypes.
Not like they should be there in the first place, but a for in seems not to be necessary here.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
