### PR TITLE
update GuildAuditLogs for MESSAGE_DELETE and fixed extras

### DIFF
--- a/src/structures/GuildAuditLogs.js
+++ b/src/structures/GuildAuditLogs.js
@@ -4,6 +4,7 @@ const Snowflake = require('../util/Snowflake');
 const Targets = {
   GUILD: 'GUILD',
   CHANNEL: 'CHANNEL',
+  MESSAGE: 'MESSAGE',
   USER: 'USER',
   ROLE: 'ROLE',
   INVITE: 'INVITE',
@@ -83,6 +84,7 @@ class GuildAuditLogs {
     if (target < 50) return Targets.INVITE;
     if (target < 60) return Targets.WEBHOOK;
     if (target < 70) return Targets.EMOJI;
+    if (target < 80) return Targets.MESSAGE;
     return null;
   }
 
@@ -198,15 +200,20 @@ class GuildAuditLogsEntry {
           removed: data.options.members_removed,
           days: data.options.delete_member_days,
         };
+      } else if (data.action_type === Actions.MESSAGE_DELETE) {
+        this.extra = {
+          count: data.options.count,
+          channel: guild.channels.get(data.options.channel_id),
+        };
       } else {
         switch (data.options.type) {
           case 'member':
-            this.extra = guild.members.get(this.options.id);
-            if (!this.extra) this.extra = { id: this.options.id };
+            this.extra = guild.members.get(data.options.id);
+            if (!this.extra) this.extra = { id: data.options.id };
             break;
           case 'role':
-            this.extra = guild.roles.get(this.options.id);
-            if (!this.extra) this.extra = { id: this.options.id, name: this.options.role_name };
+            this.extra = guild.roles.get(data.options.id);
+            if (!this.extra) this.extra = { id: data.options.id, name: data.options.role_name };
             break;
           default:
             break;
@@ -233,6 +240,8 @@ class GuildAuditLogsEntry {
           this.target = invites.find(i => i.code === (change.new || change.old));
           return this.target;
         });
+    } else if (targetType === Targets.MESSAGE) {
+      this.target = guild.client.users.get(data.target_id);
     } else {
       this.target = guild[`${targetType.toLowerCase()}s`].get(data.target_id);
     }

--- a/src/structures/GuildAuditLogs.js
+++ b/src/structures/GuildAuditLogs.js
@@ -4,12 +4,12 @@ const Snowflake = require('../util/Snowflake');
 const Targets = {
   GUILD: 'GUILD',
   CHANNEL: 'CHANNEL',
-  MESSAGE: 'MESSAGE',
   USER: 'USER',
   ROLE: 'ROLE',
   INVITE: 'INVITE',
   WEBHOOK: 'WEBHOOK',
   EMOJI: 'EMOJI',
+  MESSAGE: 'MESSAGE',
 };
 
 const Actions = {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

I am not sure whether ``target < 80`` is correct, it just seemed logical to me.

`this.options` should be `data.options`

Shouldn't at least GuildAudLogs.build be private, if not all methods?

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
