### PR TITLE
Deprecate webhook send aliases and editCode

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -388,6 +388,7 @@ class Message {
    * @param {string} lang The language for the code block
    * @param {StringResolvable} content The new content for the message
    * @returns {Promise<Message>}
+   * @deprecated
    */
   editCode(lang, content) {
     content = Util.escapeMarkdown(this.client.resolver.resolveString(content), true);

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -143,6 +143,7 @@ class Webhook {
    * @param {StringResolvable} content The content to send
    * @param {WebhookMessageOptions} [options={}] The options to provide
    * @returns {Promise<Message|Message[]>}
+   * @deprecated
    * @example
    * // Send a message
    * webhook.sendMessage('hello!')
@@ -160,6 +161,7 @@ class Webhook {
    * @param {StringResolvable} [content] Text message to send with the attachment
    * @param {WebhookMessageOptions} [options] The options to provide
    * @returns {Promise<Message>}
+   * @deprecated
    */
   sendFile(attachment, name, content, options = {}) {
     return this.send(content, Object.assign(options, { file: { attachment, name } }));
@@ -171,6 +173,7 @@ class Webhook {
    * @param {StringResolvable} content Content of the code block
    * @param {WebhookMessageOptions} options The options to provide
    * @returns {Promise<Message|Message[]>}
+   * @deprecated
    */
   sendCode(lang, content, options = {}) {
     return this.send(content, Object.assign(options, { code: lang }));


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Deprecates the webhook send aliases and editCode, because someone forgot them for 11.1 :eyes:

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [X] This PR **only** includes non-code changes, like changes to documentation, README, etc.
