### PR TITLE
Handing promise rejections from GuildAuditLogs#build to the user

### DIFF
--- a/src/structures/GuildAuditLogs.js
+++ b/src/structures/GuildAuditLogs.js
@@ -68,6 +68,7 @@ class GuildAuditLogs {
     const logs = new GuildAuditLogs(...args);
     return Promise.all(logs.entries.map(e => e.target)).then(() => logs);
   }
+
   /**
    * Find target type from entry action.
    * @param {number} target The action target

--- a/src/structures/GuildAuditLogs.js
+++ b/src/structures/GuildAuditLogs.js
@@ -67,7 +67,7 @@ class GuildAuditLogs {
   static build(...args) {
     return new Promise(resolve => {
       const logs = new GuildAuditLogs(...args);
-      Promise.all(logs.entries.map(e => e.target)).then(() => resolve(logs));
+      resolve(Promise.all(logs.entries.map(e => e.target)).then(() => logs));
     });
   }
 

--- a/src/structures/GuildAuditLogs.js
+++ b/src/structures/GuildAuditLogs.js
@@ -62,15 +62,12 @@ class GuildAuditLogs {
 
   /**
    * Handles possible promises for entry targets.
-   * @returns {GuildAuditLogs}
+   * @returns {Promise<GuildAuditLogs>}
    */
   static build(...args) {
-    return new Promise(resolve => {
-      const logs = new GuildAuditLogs(...args);
-      resolve(Promise.all(logs.entries.map(e => e.target)).then(() => logs));
-    });
+    const logs = new GuildAuditLogs(...args);
+    return Promise.all(logs.entries.map(e => e.target)).then(() => logs);
   }
-
   /**
    * Find target type from entry action.
    * @param {number} target The action target


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

See #1471 
The not catchable rejection is caused by a rejection when fetching webhooks or invites.

This will take care of that.

~~Appending a ``.catch(reject);`` would also work.
Not sure what is the preferred solution here, both will lead to the same result.~~

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
