### PR TITLE
Failing to resolve a role should reject and not throw an error

### DIFF
--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -394,7 +394,7 @@ class GuildMember {
    */
   addRole(role) {
     if (!(role instanceof Role)) role = this.guild.roles.get(role);
-    if (!role) throw new TypeError('Supplied parameter was neither a Role nor a Snowflake.');
+    if (!role) return Promise.reject(new TypeError('Supplied parameter was neither a Role nor a Snowflake.'));
     return this.client.rest.methods.addMemberRole(this, role);
   }
 
@@ -421,7 +421,7 @@ class GuildMember {
    */
   removeRole(role) {
     if (!(role instanceof Role)) role = this.guild.roles.get(role);
-    if (!role) throw new TypeError('Supplied parameter was neither a Role nor a Snowflake.');
+    if (!role) return Promise.reject(new TypeError('Supplied parameter was neither a Role nor a Snowflake.'));
     return this.client.rest.methods.removeMemberRole(this, role);
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
When, while using GuildMember#addRole or GuildMember#removeRole, resolving a role fails, a TypeError is thrown rather than rejected, which makes it impossible to catch it with a ``.catch(someFunction)``.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
