### PR TITLE
Removing more deprecation leftovers

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -65,7 +65,7 @@ class GuildChannel extends Channel {
   permissionsFor(member) {
     member = this.client.resolver.resolveGuildMember(this.guild, member);
     if (!member) return null;
-    if (member.id === this.guild.ownerID) return new Permissions(member, Permissions.ALL);
+    if (member.id === this.guild.ownerID) return new Permissions(Permissions.ALL);
 
     let permissions = 0;
 
@@ -94,7 +94,7 @@ class GuildChannel extends Channel {
     const admin = Boolean(permissions & Permissions.FLAGS.ADMINISTRATOR);
     if (admin) permissions = Permissions.ALL;
 
-    return new Permissions(member, permissions);
+    return new Permissions(permissions);
   }
 
   overwritesFor(member, verified = false, roles = null) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Removed deprecation leftover that throws a ~~TypeError~~ RangeError when using ``GuildMember#permissionsIn`` and ``GuildChannel#permissionsFor``

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
