### PR TITLE
Fix reaction collector example

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -254,7 +254,7 @@ class Message {
    * @example
    * // Create a reaction collector
    * const collector = message.createReactionCollector(
-   *  (reaction, user) => reaction.emoji.id === '👌' && user.id === 'someID',
+   *  (reaction, user) => reaction.emoji.name === '👌' && user.id === 'someID',
    *  { time: 15000 }
    * );
    * collector.on('collect', r => console.log(`Collected ${r.emoji.name}`));


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixes the example for Message#createReactionCollector by changing `reaction.emoji.id` to `reaction.emoji.name`.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
