### PR TITLE
Fix for bulkDelete, acknowledge, createInvite and remove some redundant stuff

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -359,7 +359,7 @@ class Client extends EventEmitter {
    * @returns {Collection<string, VoiceRegion>}
    */
   fetchVoiceRegions() {
-    return this.rest.api.voice.regions.get().then(res => {
+    return this.api.voice.regions.get().then(res => {
       const regions = new Collection();
       for (const region of res) regions.set(region.id, new VoiceRegion(region));
       return regions;

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -975,7 +975,7 @@ class Guild {
    */
   leave() {
     if (this.ownerID === this.client.user.id) return Promise.reject(new Error('Guild is owned by the client.'));
-    return this.rest.api.users('@me').guilds(this.id).delete()
+    return this.client.api.users('@me').guilds(this.id).delete()
     .then(() => this.client.actions.GuildDelete.handle({ id: this.id }).guild);
   }
 

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -283,10 +283,10 @@ class GuildChannel extends Channel {
    * kicked after 24 hours if they have not yet received a role
    * @param {number} [options.maxAge=86400] How long the invite should last (in seconds, 0 for forever)
    * @param {number} [options.maxUses=0] Maximum number of uses
-   * @param {string} [reason] Reason for creating this
+   * @param {string} [options.reason] Reason for creating this
    * @returns {Promise<Invite>}
    */
-  createInvite({ temporary = false, maxAge = 86400, maxUses = 0 }, reason) {
+  createInvite({ temporary = false, maxAge = 86400, maxUses = 0, reason } = {}) {
     return this.client.api.channels(this.id).invites.post({ data: {
       temporary, max_age: maxAge, max_uses: maxUses,
     }, reason })

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -379,7 +379,7 @@ class TextBasedChannel {
           Date.now() - Snowflake.deconstruct(id).date.getTime() < 1209600000
         );
       }
-      return this.rest.api.channels(this.id).messages['bulk-delete']
+      return this.client.api.channels(this.id).messages()['bulk-delete']
       .post({ data: { messages: messageIDs } })
       .then(() =>
         this.client.actions.MessageDeleteBulk.handle({
@@ -398,7 +398,7 @@ class TextBasedChannel {
    */
   acknowledge() {
     if (!this.lastMessageID) return Promise.resolve(this);
-    return this.client.api.channels(this.id).messages(this.lastMessageID)
+    return this.client.api.channels(this.id).messages(this.lastMessageID).ack
       .post({ data: { token: this.client.rest._ackToken } })
       .then(res => {
         if (res.token) this.client.rest._ackToken = res.token;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
- Changed redundant `rest.api` to `.api`
- Fixed `TextChannel#bulkDelete`'s endpoint
- Fixed `TextBasedChanne#acknowledge`'s endpoint
- Made `GuildChannel#createInvite`'s argument optional again, also included reason in the options object

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
