### PR TITLE
Refactored static resolvers to Util

### DIFF
--- a/src/client/ClientDataResolver.js
+++ b/src/client/ClientDataResolver.js
@@ -2,8 +2,7 @@ const path = require('path');
 const fs = require('fs');
 const snekfetch = require('snekfetch');
 
-const Constants = require('../util/Constants');
-const convertToBuffer = require('../util/Util').convertToBuffer;
+const Util = require('../util/Util');
 const User = require('../structures/User');
 const Message = require('../structures/Message');
 const Guild = require('../structures/Guild');
@@ -156,25 +155,6 @@ class ClientDataResolver {
   }
 
   /**
-   * Data that can be resolved to give a string. This can be:
-   * * A string
-   * * An array (joined with a new line delimiter to give a string)
-   * * Any value
-   * @typedef {string|Array|*} StringResolvable
-   */
-
-  /**
-   * Resolves a StringResolvable to a string.
-   * @param {StringResolvable} data The string resolvable to resolve
-   * @returns {string}
-   */
-  resolveString(data) {
-    if (typeof data === 'string') return data;
-    if (data instanceof Array) return data.join('\n');
-    return String(data);
-  }
-
-  /**
    * Data that resolves to give a Base64 string, typically for image uploading. This can be:
    * * A Buffer
    * * A base64 string
@@ -206,7 +186,7 @@ class ClientDataResolver {
    */
   resolveBuffer(resource) {
     if (resource instanceof Buffer) return Promise.resolve(resource);
-    if (this.client.browser && resource instanceof ArrayBuffer) return Promise.resolve(convertToBuffer(resource));
+    if (this.client.browser && resource instanceof ArrayBuffer) return Promise.resolve(Util.convertToBuffer(resource));
 
     if (typeof resource === 'string') {
       return new Promise((resolve, reject) => {
@@ -256,72 +236,6 @@ class ClientDataResolver {
       else return emoji;
     }
     return null;
-  }
-
-  /**
-   * Can be a Hex Literal, Hex String, Number, RGB Array, or one of the following
-   * ```
-   * [
-   *   'DEFAULT',
-   *   'AQUA',
-   *   'GREEN',
-   *   'BLUE',
-   *   'PURPLE',
-   *   'GOLD',
-   *   'ORANGE',
-   *   'RED',
-   *   'GREY',
-   *   'DARKER_GREY',
-   *   'NAVY',
-   *   'DARK_AQUA',
-   *   'DARK_GREEN',
-   *   'DARK_BLUE',
-   *   'DARK_PURPLE',
-   *   'DARK_GOLD',
-   *   'DARK_ORANGE',
-   *   'DARK_RED',
-   *   'DARK_GREY',
-   *   'LIGHT_GREY',
-   *   'DARK_NAVY',
-   *   'RANDOM',
-   * ]
-   * ```
-   * or something like
-   * ```
-   * [255, 0, 255]
-   * ```
-   * for purple
-   * @typedef {string|number|Array} ColorResolvable
-   */
-
-  /**
-   * Resolves a ColorResolvable into a color number.
-   * @param {ColorResolvable} color Color to resolve
-   * @returns {number} A color
-   */
-  static resolveColor(color) {
-    if (typeof color === 'string') {
-      if (color === 'RANDOM') return Math.floor(Math.random() * (0xFFFFFF + 1));
-      color = Constants.Colors[color] || parseInt(color.replace('#', ''), 16);
-    } else if (color instanceof Array) {
-      color = (color[0] << 16) + (color[1] << 8) + color[2];
-    }
-
-    if (color < 0 || color > 0xFFFFFF) {
-      throw new RangeError('Color must be within the range 0 - 16777215 (0xFFFFFF).');
-    } else if (color && isNaN(color)) {
-      throw new TypeError('Unable to convert color to a number.');
-    }
-
-    return color;
-  }
-
-  /**
-   * @param {ColorResolvable} color Color to resolve
-   * @returns {number} A color
-   */
-  resolveColor(color) {
-    return this.constructor.resolveColor(color);
   }
 }
 

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -911,7 +911,7 @@ class Guild {
    * .catch(console.error)
    */
   createRole({ data = {}, reason } = {}) {
-    if (data.color) data.color = this.client.resolver.resolveColor(data.color);
+    if (data.color) data.color = Util.resolveColor(data.color);
     if (data.permissions) data.permissions = Permissions.resolve(data.permissions);
 
     return this.client.api.guilds(this.id).roles.post({ data, reason }).then(role =>

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -381,13 +381,13 @@ class Message {
       options = {};
     }
 
-    if (typeof content !== 'undefined') content = this.client.resolver.resolveString(content);
+    if (typeof content !== 'undefined') content = Util.resolveString(content);
 
     const { embed, code, reply } = options;
 
     // Wrap everything in a code block
     if (typeof code !== 'undefined' && (typeof code !== 'boolean' || code === true)) {
-      content = Util.escapeMarkdown(this.client.resolver.resolveString(content), true);
+      content = Util.escapeMarkdown(Util.resolveString(content), true);
       content = `\`\`\`${typeof code !== 'boolean' ? code || '' : ''}\n${content}\n\`\`\``;
     }
 

--- a/src/structures/RichEmbed.js
+++ b/src/structures/RichEmbed.js
@@ -1,4 +1,4 @@
-const ClientDataResolver = require('../client/ClientDataResolver');
+const Util = require('../util/Util');
 
 /**
  * A rich embed to be sent with a message with a fluent interface for creation.
@@ -79,7 +79,7 @@ class RichEmbed {
    * @returns {RichEmbed} This embed
    */
   setTitle(title) {
-    title = resolveString(title);
+    title = Util.resolveString(title);
     if (title.length > 256) throw new RangeError('RichEmbed titles may not exceed 256 characters.');
     this.title = title;
     return this;
@@ -91,7 +91,7 @@ class RichEmbed {
    * @returns {RichEmbed} This embed
    */
   setDescription(description) {
-    description = resolveString(description);
+    description = Util.resolveString(description);
     if (description.length > 2048) throw new RangeError('RichEmbed descriptions may not exceed 2048 characters.');
     this.description = description;
     return this;
@@ -113,7 +113,7 @@ class RichEmbed {
    * @returns {RichEmbed} This embed
    */
   setColor(color) {
-    this.color = ClientDataResolver.resolveColor(color);
+    this.color = Util.resolveColor(color);
     return this;
   }
 
@@ -125,7 +125,7 @@ class RichEmbed {
    * @returns {RichEmbed} This embed
    */
   setAuthor(name, icon, url) {
-    this.author = { name: resolveString(name), icon_url: icon, url };
+    this.author = { name: Util.resolveString(name), icon_url: icon, url };
     return this;
   }
 
@@ -148,10 +148,10 @@ class RichEmbed {
    */
   addField(name, value, inline = false) {
     if (this.fields.length >= 25) throw new RangeError('RichEmbeds may not exceed 25 fields.');
-    name = resolveString(name);
+    name = Util.resolveString(name);
     if (name.length > 256) throw new RangeError('RichEmbed field names may not exceed 256 characters.');
     if (!/\S/.test(name)) throw new RangeError('RichEmbed field names may not be empty.');
-    value = resolveString(value);
+    value = Util.resolveString(value);
     if (value.length > 1024) throw new RangeError('RichEmbed field values may not exceed 1024 characters.');
     if (!/\S/.test(value)) throw new RangeError('RichEmbed field values may not be empty.');
     this.fields.push({ name, value, inline });
@@ -194,7 +194,7 @@ class RichEmbed {
    * @returns {RichEmbed} This embed
    */
   setFooter(text, icon) {
-    text = resolveString(text);
+    text = Util.resolveString(text);
     if (text.length > 2048) throw new RangeError('RichEmbed footer text may not exceed 2048 characters.');
     this.footer = { text, icon_url: icon };
     return this;
@@ -214,9 +214,3 @@ class RichEmbed {
 }
 
 module.exports = RichEmbed;
-
-function resolveString(data) {
-  if (typeof data === 'string') return data;
-  if (data instanceof Array) return data.join('\n');
-  return String(data);
-}

--- a/src/structures/Role.js
+++ b/src/structures/Role.js
@@ -1,5 +1,6 @@
 const Snowflake = require('../util/Snowflake');
 const Permissions = require('../util/Permissions');
+const Util = require('../util/Util');
 
 /**
  * Represents a role on Discord.
@@ -205,7 +206,7 @@ class Role {
       data: {
         name: data.name || this.name,
         position: typeof data.position !== 'undefined' ? data.position : this.position,
-        color: this.client.resolver.resolveColor(data.color || this.color),
+        color: Util.resolveColor(data.color || this.color),
         hoist: typeof data.hoist !== 'undefined' ? data.hoist : this.hoist,
         mentionable: typeof data.mentionable !== 'undefined' ? data.mentionable : this.mentionable,
       },

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const Util = require('../util/Util');
 
 /**
  * Represents a webhook.
@@ -113,7 +114,7 @@ class Webhook {
       options.avatarURL = null;
     }
 
-    if (typeof content !== 'undefined') content = this.client.resolver.resolveString(content);
+    if (typeof content !== 'undefined') content = Util.resolveString(content);
     if (content) {
       if (options.disableEveryone ||
         (typeof options.disableEveryone === 'undefined' && this.client.options.disableEveryone)

--- a/src/structures/shared/SendMessage.js
+++ b/src/structures/shared/SendMessage.js
@@ -12,7 +12,7 @@ module.exports = function sendMessage(channel, options) {
   }
 
   if (content) {
-    content = channel.client.resolver.resolveString(content);
+    content = Util.resolveString(content);
     if (split && typeof split !== 'object') split = {};
     // Wrap everything in a code block
     if (typeof code !== 'undefined' && (typeof code !== 'boolean' || code === true)) {

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -207,6 +207,85 @@ class Util {
     }
     return array.indexOf(element);
   }
+
+  /**
+   * Data that can be resolved to give a string. This can be:
+   * * A string
+   * * An array (joined with a new line delimiter to give a string)
+   * * Any value
+   * @typedef {string|Array|*} StringResolvable
+   */
+
+  /**
+   * Resolves a StringResolvable to a string.
+   * @param {StringResolvable} data The string resolvable to resolve
+   * @returns {string}
+   */
+
+  static resolveString(data) {
+    if (typeof data === 'string') return data;
+    if (data instanceof Array) return data.join('\n');
+    return String(data);
+  }
+
+  /**
+   * Can be a Hex Literal, Hex String, Number, RGB Array, or one of the following
+   * ```
+   * [
+   *   'DEFAULT',
+   *   'AQUA',
+   *   'GREEN',
+   *   'BLUE',
+   *   'PURPLE',
+   *   'GOLD',
+   *   'ORANGE',
+   *   'RED',
+   *   'GREY',
+   *   'DARKER_GREY',
+   *   'NAVY',
+   *   'DARK_AQUA',
+   *   'DARK_GREEN',
+   *   'DARK_BLUE',
+   *   'DARK_PURPLE',
+   *   'DARK_GOLD',
+   *   'DARK_ORANGE',
+   *   'DARK_RED',
+   *   'DARK_GREY',
+   *   'LIGHT_GREY',
+   *   'DARK_NAVY',
+   *   'RANDOM',
+   * ]
+   * ```
+   * or something like
+   * ```
+   * [255, 0, 255]
+   * ```
+   * for purple
+   * @typedef {string|number|Array} ColorResolvable
+   */
+
+  /**
+   * Resolves a ColorResolvable into a color number.
+   * @param {ColorResolvable} color Color to resolve
+   * @returns {number} A color
+   */
+
+  static resolveColor(color) {
+    if (typeof color === 'string') {
+      if (color === 'RANDOM') return Math.floor(Math.random() * (0xFFFFFF + 1));
+      color = Constants.Colors[color] || parseInt(color.replace('#', ''), 16);
+    } else if (color instanceof Array) {
+      color = (color[0] << 16) + (color[1] << 8) + color[2];
+    }
+
+    if (color < 0 || color > 0xFFFFFF) {
+      throw new RangeError('Color must be within the range 0 - 16777215 (0xFFFFFF).');
+    } else if (color && isNaN(color)) {
+      throw new TypeError('Unable to convert color to a number.');
+    }
+
+    return color;
+  }
 }
 
 module.exports = Util;


### PR DESCRIPTION
Moved the static data resolvers to the util class.

This change is motivated because #1345 has circular references between the data resolver and the message embeds. 

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
