### PR TITLE
Handle unexpected disconnects via packets

### DIFF
--- a/src/client/voice/ClientVoiceManager.js
+++ b/src/client/voice/ClientVoiceManager.js
@@ -1,4 +1,5 @@
 const Collection = require('../../util/Collection');
+const Constants = require('../../util/Constants');
 const VoiceConnection = require('./VoiceConnection');
 
 /**
@@ -30,10 +31,13 @@ class ClientVoiceManager {
 
   onVoiceStateUpdate({ guild_id, session_id, channel_id }) {
     const connection = this.connections.get(guild_id);
-    if (connection) {
-      connection.channel = this.client.channels.get(channel_id);
-      connection.setSessionID(session_id);
+    if (!connection) return;
+    if (!channel_id && connection.status !== Constants.VoiceStatus.DISCONNECTED) {
+      connection._disconnect();
+      return;
     }
+    connection.channel = this.client.channels.get(channel_id);
+    connection.setSessionID(session_id);
   }
 
   /**

--- a/src/client/voice/VoiceConnection.js
+++ b/src/client/voice/VoiceConnection.js
@@ -305,7 +305,14 @@ class VoiceConnection extends EventEmitter {
     this.sendVoiceStateUpdate({
       channel_id: null,
     });
-    this.player.destroy();
+    this._disconnect();
+  }
+
+  /**
+   * Internally disconnects (doesn't send disconnect packet.)
+   * @private
+   */
+  _disconnect() {
     this.cleanup();
     this.status = Constants.VoiceStatus.DISCONNECTED;
     /**
@@ -315,11 +322,14 @@ class VoiceConnection extends EventEmitter {
     this.emit('disconnect');
   }
 
+
   /**
    * Cleans up after disconnect.
    * @private
    */
   cleanup() {
+    this.player.destroy();
+
     const { ws, udp } = this.sockets;
 
     if (ws) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
An attempt to fix #1494, this tries to help keep the Discord state and voice connection synchronous by doing the following:
if Discord sends a voice disconnect packet, but the voice connection still believes it isn't disconnected, forcefully disconnect the voice connection.

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
