### PR TITLE
Wait for the websocket event when creating a guild

### DIFF
--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -313,7 +313,7 @@ class ClientUser extends User {
 
             const timeout = this.client.setTimeout(() => {
               this.client.removeListener(Constants.Events.GUILD_CREATE, handleGuild);
-              reject(new Error('Took too long to receive guild data.'));
+              reject(new Error(Constants.Errors.TOOK_TOO_LONG));
             }, 10000);
             return undefined;
           }, reject)

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -297,11 +297,30 @@ class ClientUser extends User {
    */
   createGuild(name, { region, icon = null } = {}) {
     if (!icon || (typeof icon === 'string' && icon.startsWith('data:'))) {
-      return this.client.api.guilds.post({ data: { name, region, icon } })
-        .then(data => this.client.dataManager.newGuild(data));
+      return new Promise((resolve, reject) =>
+        this.client.api.guilds.post({ data: { name, region, icon } })
+          .then(data => {
+            if (this.client.guilds.has(data.id)) return resolve(this.client.guilds.get(data.id));
+
+            const handleGuild = guild => {
+              if (guild.id === data.id) {
+                this.client.removeListener(Constants.Events.GUILD_CREATE, handleGuild);
+                this.client.clearTimeout(timeout);
+                resolve(guild);
+              }
+            };
+            this.client.on(Constants.Events.GUILD_CREATE, handleGuild);
+
+            const timeout = this.client.setTimeout(() => {
+              this.client.removeListener(Constants.Events.GUILD_CREATE, handleGuild);
+              reject(new Error('Took too long to receive guild data.'));
+            }, 10000);
+            return undefined;
+          }, reject)
+      );
     } else {
       return this.client.resolver.resolveBuffer(icon)
-        .then(data => this.createGuild(name, region, this.client.resolver.resolveBase64(data) || null));
+        .then(data => this.createGuild(name, { region, icon: this.client.resolver.resolveBase64(data) || null }));
     }
   }
 

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -313,7 +313,7 @@ class ClientUser extends User {
 
             const timeout = this.client.setTimeout(() => {
               this.client.removeListener(Constants.Events.GUILD_CREATE, handleGuild);
-              reject(new Error(Constants.Errors.TOOK_TOO_LONG));
+              resolve(this.client.dataManager.newGuild(data));
             }, 10000);
             return undefined;
           }, reject)

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -68,8 +68,8 @@ class Guild {
        */
       this.id = data.id;
     } else {
-      this.available = true;
       this.setup(data);
+      if (!data.channels) this.available = false;
     }
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
See #1523 
Waiting for the websocket event will avoid that issue.

[This](https://github.com/hydrabolt/discord.js/blob/11.1-dev/src/client/rest/RESTMethods.js#L324-L342) was already part of the lib before the rest rewrite, must have been overlooked.

Also called the method with the correct object after resolving the buffer.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
