### PR TITLE
renamed OAuth2Application#reset to resetSecret and added resetToken

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -408,7 +408,7 @@ class Client extends EventEmitter {
    * @returns {Promise<OAuth2Application>}
    */
   fetchApplication(id = '@me') {
-    return this.rest.api.oauth2.applications(id).get()
+    return this.api.oauth2.applications(id).get()
     .then(app => new OAuth2Application(this, app));
   }
 

--- a/src/client/rest/APIRouter.js
+++ b/src/client/rest/APIRouter.js
@@ -7,7 +7,7 @@ const paramable = [
   'bans', 'emojis', 'pins', 'permissions',
   'reactions', 'webhooks', 'messages',
   'notes', 'roles', 'applications',
-  'invites',
+  'invites', 'bot',
 ];
 const reflectors = ['toString', 'valueOf', 'inspect', Symbol.toPrimitive, util.inspect.custom];
 

--- a/src/structures/OAuth2Application.js
+++ b/src/structures/OAuth2Application.js
@@ -133,12 +133,23 @@ class OAuth2Application {
   }
 
   /**
-   * Reset the app's secret and bot token.
+   * Reset the app's secret.
+   * <warn>This is only available when using a user account.</warn>
    * @returns {OAuth2Application}
    */
-  reset() {
-    return this.rest.api.oauth2.applications(this.id).reset.post()
+  resetSecret() {
+    return this.client.api.oauth2.applications(this.id).reset.post()
       .then(app => new OAuth2Application(this.client, app));
+  }
+
+  /**
+   * Reset the app's bot token.
+   * <warn>This is only available when using a user account.</warn>
+   * @returns {OAuth2Application}
+   */
+  resetToken() {
+    return this.client.api.oauth2.applications(this.id).bot().reset.post()
+      .then(app => new OAuth2Application(this.client, Object.assign({}, this, { bot: app })));
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- Shortened ``this.rest.api`` in ``Client#fetchApplication`` to ``this.api``
- Renamed ``OAuth2Application#reset`` to ``#resetSecret``, because it only resets the secret and not the token.
- Added a ``#resetToken`` method to reset the token.
- Added a warning, indicating that both methods are for user account only.

``Object.assign`` might not be the best solution for the ``resetToken`` method,
something different or just resolving with the new bot object may be better.

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
