### PR TITLE
Add `count` optional argument to Collection methods

### DIFF
--- a/src/util/Collection.js
+++ b/src/util/Collection.js
@@ -60,7 +60,7 @@ class Collection extends Map {
 
   /**
    * Obtains the first value(s) in this collection.
-   * @param {number} [count=1] Number of values to obtain from the beginning
+   * @param {number} [count] Number of values to obtain from the beginning
    * @returns {*|Array<*>} The single value if `count` is undefined, or an array of values of `count` length
    */
   first(count) {

--- a/src/util/Collection.js
+++ b/src/util/Collection.js
@@ -62,7 +62,7 @@ class Collection extends Map {
    * Obtains the first item in this collection.
    * @param {Integer} [count] Number of values to return. If omited, returns a single values.
    * If present, returns an array of values.
-   * @returns {*}
+   * @returns {*|Array}
    */
   first(count) {
     if (!count) return this.values().next().value;
@@ -79,7 +79,7 @@ class Collection extends Map {
    * Obtains the first key in this collection.
    * @param {Integer} [count] Number of keys to return. If omited, returns a single key.
    * If present, returns an array of keys.
-   * @returns {*}
+   * @returns {*|Array}
    */
   firstKey(count) {
     if (!count) return this.keys().next().value;
@@ -97,7 +97,7 @@ class Collection extends Map {
    * applies here as well.
    * @param {Integer} [count] Number of values to return. If omited, returns a single values.
    * If present, returns an array of values.
-   * @returns {*}
+   * @returns {*|Array}
    */
   last(count) {
     const arr = this.array();
@@ -116,7 +116,7 @@ class Collection extends Map {
    * applies here as well.
    * @param {Integer} [count] Number of keys to return. If omited, returns a single key.
    * If present, returns an array of keys.
-   * @returns {*}
+   * @returns {*|Array}
    */
   lastKey(count) {
     const arr = this.keyArray();
@@ -133,7 +133,9 @@ class Collection extends Map {
   /**
    * Obtains a random item from this collection. This relies on the `array()` method, and thus the caching mechanism
    * applies here as well.
-   * @returns {*}
+   * @param {Integer} [count] Number of values to return. If omited, returns a single values.
+   * If present, returns an array of values.
+   * @returns {*|Array}
    */
   random(count) {
     const arr = this.array();
@@ -149,7 +151,9 @@ class Collection extends Map {
   /**
    * Obtains a random key from this collection. This relies on the `keyArray()` method, and thus the caching mechanism
    * applies here as well.
-   * @returns {*}
+   * @param {Integer} [count] Number of keys to return. If omited, returns a single key.
+   * If present, returns an array of keys.
+   * @returns {*|Array}
    */
   randomKey(count) {
     const arr = this.keyArray();

--- a/src/util/Collection.js
+++ b/src/util/Collection.js
@@ -59,119 +59,99 @@ class Collection extends Map {
   }
 
   /**
-   * Obtains the first item in this collection.
-   * @param {number} [count] Number of values to return. If omitted, returns a single value.
-   * If present, returns an array of values.
-   * @returns {*|Array}
+   * Obtains the first value(s) in this collection.
+   * @param {number} [count=1] Number of values to obtain from the beginning
+   * @returns {*|Array<*>} The single value if `count` is undefined, or an array of values of `count` length
    */
   first(count) {
-    if (!count) return this.values().next().value;
-    if (!Number.isInteger(count) || count < 1) throw new TypeError('Count must be a positive integer');
-    const values = this.values();
-    const retArr = [];
+    if (count === undefined) return this.values().next().value;
+    if (typeof count !== 'number') throw new TypeError('The count must be a number.');
+    if (!Number.isInteger(count) || count < 1) throw new RangeError('The count must be an integer greater than 0.');
     count = Math.min(this.size, count);
-    for (let i = 0; i < count; i++) {
-      retArr[i] = values.next().value;
-    }
-    return retArr;
+    const arr = new Array(count);
+    const iter = this.values();
+    for (let i = 0; i < count; i++) arr[i] = iter.next().value;
+    return arr;
   }
 
   /**
-   * Obtains the first key in this collection.
-   * @param {number} [count] Number of keys to return. If omitted, returns a single key.
-   * If present, returns an array of keys.
-   * @returns {*|Array}
+   * Obtains the first key(s) in this collection.
+   * @param {number} [count] Number of keys to obtain from the beginning
+   * @returns {*|Array<*>} The single key if `count` is undefined, or an array of keys of `count` length
    */
   firstKey(count) {
-    if (!count) return this.keys().next().value;
-    if (!Number.isInteger(count) || count < 1) throw new TypeError('Count must be a positive integer');
-    const keys = this.keys();
-    const retArr = [];
+    if (count === undefined) return this.keys().next().value;
+    if (typeof count !== 'number') throw new TypeError('The count must be a number.');
+    if (!Number.isInteger(count) || count < 1) throw new RangeError('The count must be an integer greater than 0.');
     count = Math.min(this.size, count);
-    for (let i = 0; i < count; i++) {
-      retArr[i] = keys.next().value;
-    }
-    return retArr;
+    const arr = new Array(count);
+    const iter = this.iter();
+    for (let i = 0; i < count; i++) arr[i] = iter.next().value;
+    return arr;
   }
 
   /**
-   * Obtains the last item in this collection. This relies on the `array()` method, and thus the caching mechanism
+   * Obtains the last value(s) in this collection. This relies on {@link Collection#array}, and thus the caching mechanism
    * applies here as well.
-   * @param {number} [count] Number of values to return. If omitted, returns a single value.
-   * If present, returns an array of values.
-   * @returns {*|Array}
+   * @param {number} [count] Number of values to obtain from the end
+   * @returns {*|Array<*>} The single value if `count` is undefined, or an array of values of `count` length
    */
   last(count) {
     const arr = this.array();
-    if (!count) return arr[arr.length - 1];
-    if (!Number.isInteger(count) || count < 1) throw new TypeError('Count must be a positive integer');
-    const retArr = [];
-    const arrLen = arr.length;
-    count = Math.min(this.size, count);
-    for (let i = 0; i < count; i++) {
-      retArr[i] = arr[arrLen - (i + 1)];
-    }
-    return retArr;
+    if (count === undefined) return arr[arr.length - 1];
+    if (typeof count !== 'number') throw new TypeError('The count must be a number.');
+    if (!Number.isInteger(count) || count < 1) throw new RangeError('The count must be an integer greater than 0.');
+    return arr.slice(-count);
   }
 
   /**
-   * Obtains the last key in this collection. This relies on the `keyArray()` method, and thus the caching mechanism
+   * Obtains the last key(s) in this collection. This relies on {@link Collection#keyArray}, and thus the caching mechanism
    * applies here as well.
-   * @param {number} [count] Number of keys to return. If omitted, returns a single key.
-   * If present, returns an array of keys.
-   * @returns {*|Array}
+   * @param {number} [count] Number of keys to obtain from the end
+   * @returns {*|Array<*>} The single key if `count` is undefined, or an array of keys of `count` length
    */
   lastKey(count) {
     const arr = this.keyArray();
-    if (!count) return arr[arr.length - 1];
-    if (!Number.isInteger(count) || count < 1) throw new TypeError('Count must be a positive integer');
-    const retArr = [];
-    const arrLen = arr.length;
-    count = Math.min(this.size, count);
-    for (let i = 0; i < count; i++) {
-      retArr[i] = arr[arrLen - (i + 1)];
-    }
-    return retArr;
+    if (count === undefined) return arr[arr.length - 1];
+    if (typeof count !== 'number') throw new TypeError('The count must be a number.');
+    if (!Number.isInteger(count) || count < 1) throw new RangeError('The count must be an integer greater than 0.');
+    return arr.slice(-count);
   }
 
   /**
-   * Obtains a random item from this collection. This relies on the `array()` method, and thus the caching mechanism
+   * Obtains random value(s) from this collection. This relies on {@link Collection#array}, and thus the caching mechanism
    * applies here as well.
-   * @param {number} [count] Number of values to return. If omitted, returns a single value.
-   * If present, returns an array of values.
-   * @returns {*|Array}
+   * @param {number} [count] Number of values to obtain randomly
+   * @returns {*|Array<*>} The single value if `count` is undefined, or an array of values of `count` length
    */
   random(count) {
     const arr = this.array();
-    if (!count) return arr[Math.floor(Math.random() * arr.length)];
-    if (!Number.isInteger(count) || count < 1) throw new TypeError('Count must be a positive integer');
-    const retArr = [];
-    while (retArr.length < count && arr.length > 0) {
-      const i = Math.floor(Math.random() * arr.length);
-      retArr.push(arr[i]);
-      arr.splice(i, 1);
-    }
-    return retArr;
+    if (count === undefined) return arr[Math.floor(Math.random() * arr.length)];
+    if (typeof count !== 'number') throw new TypeError('The count must be a number.');
+    if (!Number.isInteger(count) || count < 1) throw new RangeError('The count must be an integer greater than 0.');
+    if (arr.length === 0) return [];
+    const rand = new Array(count);
+    arr = arr.slice();
+    for (let r = 0; r < count; r++) rand[i] = arr.splice(Math.floor(Math.random() * arr.length), 1)[0];
+    return rand;
   }
 
   /**
-   * Obtains a random key from this collection. This relies on the `keyArray()` method, and thus the caching mechanism
+   * Obtains random key(s) from this collection. This relies on {@link Collection#keyArray}, and thus the caching mechanism
    * applies here as well.
-   * @param {number} [count] Number of keys to return. If omitted, returns a single key.
-   * If present, returns an array of keys.
-   * @returns {*|Array}
+   * @param {number} [count] Number of keys to obtain randomly
+   * @returns {*|Array<*>} The single key if `count` is undefined, or an array of keys of `count` length
    */
   randomKey(count) {
     const arr = this.keyArray();
-    if (!count) return arr[Math.floor(Math.random() * arr.length)];
-    if (!Number.isInteger(count) || count < 1) throw new TypeError('Count must be a positive integer');
-    const retArr = [];
-    while (retArr.length < count && arr.length > 0) {
-      const i = Math.floor(Math.random() * arr.length);
-      retArr.push(arr[i]);
-      arr.splice(i, 1);
-    }
-    return retArr;
+    if (count === undefined) return arr[Math.floor(Math.random() * arr.length)];
+    if (typeof count !== 'number') throw new TypeError('The count must be a number.');
+    if (!Number.isInteger(count) || count < 1) throw new RangeError('The count must be an integer greater than 0.');
+    if (arr.length === 0) return [];
+    const rand = new Array(count);
+    arr = arr.slice();
+    for (let r = 0; r < count; r++) rand[i] = arr.splice(Math.floor(Math.random() * arr.length), 1)[0];
+    return rand;
   }
 
   /**

--- a/src/util/Collection.js
+++ b/src/util/Collection.js
@@ -60,58 +60,104 @@ class Collection extends Map {
 
   /**
    * Obtains the first item in this collection.
+   * @param {Integer} [count] Number of values to return. If omited, returns a single values. If present, returns an array of values.
    * @returns {*}
    */
-  first() {
-    return this.values().next().value;
+  first(count) {
+    if(!count) return this.values().next().value;
+    if (!Number.isInteger(count)) throw new TypeError('Count must be an integer');
+    const values = this.values();
+    const retArr = [];
+    for(let i=0;i<count;i++) {
+      retArr[i] = values.next().value;
+    }
+    return retArr;
   }
 
   /**
    * Obtains the first key in this collection.
+   * @param {Integer} [count] Number of keys to return. If omited, returns a single key. If present, returns an array of keys.
    * @returns {*}
    */
-  firstKey() {
-    return this.keys().next().value;
+  firstKey(count) {
+    if(!count) return this.keys().next().value;
+    if (!Number.isInteger(count)) throw new TypeError('Count must be an integer');
+    const keys = this.keys();
+    const retArr = [];
+    for(let i=0;i<count;i++) {
+      retArr[i] = keys.next().value;
+    }
+    return retArr;
   }
 
   /**
    * Obtains the last item in this collection. This relies on the `array()` method, and thus the caching mechanism
    * applies here as well.
+   * @param {Integer} [count] Number of values to return. If omited, returns a single values. If present, returns an array of values.
    * @returns {*}
    */
-  last() {
+  last(count) {
     const arr = this.array();
-    return arr[arr.length - 1];
+    if(!count) return arr[arr.length - 1];
+    if (!Number.isInteger(count)) throw new TypeError('Count must be an integer');
+    const retArr = [];
+    const arrLen = arr.length;
+    for(let i=0;i<count;i++) {
+      retArr[i] = arr[arrLen - (i+1)];
+    }
+    return retArr;
   }
 
   /**
    * Obtains the last key in this collection. This relies on the `keyArray()` method, and thus the caching mechanism
    * applies here as well.
+   * @param {Integer} [count] Number of keys to return. If omited, returns a single key. If present, returns an array of keys.
    * @returns {*}
    */
-  lastKey() {
+  lastKey(count) {
     const arr = this.keyArray();
-    return arr[arr.length - 1];
+    if(!count) return arr[arr.length - 1];
+    if (!Number.isInteger(count)) throw new TypeError('Count must be an integer');
+    const retArr = [];
+    const arrLen = arr.length;
+    for(let i=0;i<count;i++) {
+      retArr[i] = arr[arrLen - (i+1)];
+    }
+    return retArr;
   }
 
   /**
    * Obtains a random item from this collection. This relies on the `array()` method, and thus the caching mechanism
    * applies here as well.
+   * @param {Integer} [count] Number of values to return. If omited, returns a single values. If present, returns an array of values.
    * @returns {*}
    */
-  random() {
+  random(count) {
     const arr = this.array();
-    return arr[Math.floor(Math.random() * arr.length)];
+    if(!count) return arr[Math.floor(Math.random() * arr.length)];
+    if (!Number.isInteger(count)) throw new TypeError('Count must be an integer');
+    const retArr = [];
+    for(let i=0;i<count;i++) {
+      retArr[i] = arr[Math.floor(Math.random() * arr.length)];
+    }
+    return retArr;
   }
 
   /**
    * Obtains a random key from this collection. This relies on the `keyArray()` method, and thus the caching mechanism
    * applies here as well.
+   * @param {Integer} [count] Number of keys to return. If omited, returns a single key. If present, returns an array of keys.
    * @returns {*}
    */
-  randomKey() {
+  randomKey(count) {
     const arr = this.keyArray();
-    return arr[Math.floor(Math.random() * arr.length)];
+    if(!count) return arr[Math.floor(Math.random() * arr.length)];
+    if (!Number.isInteger(count)) throw new TypeError('Count must be an integer');
+    const retArr = [];
+    for(let i=0;i<count;i++) {
+      retArr[i] = arr[Math.floor(Math.random() * arr.length)];
+    }
+    return retArr;
   }
 
   /**

--- a/src/util/Collection.js
+++ b/src/util/Collection.js
@@ -60,7 +60,7 @@ class Collection extends Map {
 
   /**
    * Obtains the first item in this collection.
-   * @param {number} [count] Number of values to return. If omited, returns a single value.
+   * @param {number} [count] Number of values to return. If omitted, returns a single value.
    * If present, returns an array of values.
    * @returns {*|Array}
    */
@@ -78,7 +78,7 @@ class Collection extends Map {
 
   /**
    * Obtains the first key in this collection.
-   * @param {number} [count] Number of keys to return. If omited, returns a single key.
+   * @param {number} [count] Number of keys to return. If omitted, returns a single key.
    * If present, returns an array of keys.
    * @returns {*|Array}
    */
@@ -97,7 +97,7 @@ class Collection extends Map {
   /**
    * Obtains the last item in this collection. This relies on the `array()` method, and thus the caching mechanism
    * applies here as well.
-   * @param {number} [count] Number of values to return. If omited, returns a single value.
+   * @param {number} [count] Number of values to return. If omitted, returns a single value.
    * If present, returns an array of values.
    * @returns {*|Array}
    */
@@ -117,7 +117,7 @@ class Collection extends Map {
   /**
    * Obtains the last key in this collection. This relies on the `keyArray()` method, and thus the caching mechanism
    * applies here as well.
-   * @param {number} [count] Number of keys to return. If omited, returns a single key.
+   * @param {number} [count] Number of keys to return. If omitted, returns a single key.
    * If present, returns an array of keys.
    * @returns {*|Array}
    */
@@ -137,7 +137,7 @@ class Collection extends Map {
   /**
    * Obtains a random item from this collection. This relies on the `array()` method, and thus the caching mechanism
    * applies here as well.
-   * @param {number} [count] Number of values to return. If omited, returns a single value.
+   * @param {number} [count] Number of values to return. If omitted, returns a single value.
    * If present, returns an array of values.
    * @returns {*|Array}
    */
@@ -157,7 +157,7 @@ class Collection extends Map {
   /**
    * Obtains a random key from this collection. This relies on the `keyArray()` method, and thus the caching mechanism
    * applies here as well.
-   * @param {number} [count] Number of keys to return. If omited, returns a single key.
+   * @param {number} [count] Number of keys to return. If omitted, returns a single key.
    * If present, returns an array of keys.
    * @returns {*|Array}
    */

--- a/src/util/Collection.js
+++ b/src/util/Collection.js
@@ -60,15 +60,16 @@ class Collection extends Map {
 
   /**
    * Obtains the first item in this collection.
-   * @param {Integer} [count] Number of values to return. If omited, returns a single values. If present, returns an array of values.
+   * @param {Integer} [count] Number of values to return. If omited, returns a single values.
+   * If present, returns an array of values.
    * @returns {*}
    */
   first(count) {
-    if(!count) return this.values().next().value;
+    if (!count) return this.values().next().value;
     if (!Number.isInteger(count)) throw new TypeError('Count must be an integer');
     const values = this.values();
     const retArr = [];
-    for(let i=0;i<count;i++) {
+    for (let i = 0; i < count; i++) {
       retArr[i] = values.next().value;
     }
     return retArr;
@@ -76,15 +77,16 @@ class Collection extends Map {
 
   /**
    * Obtains the first key in this collection.
-   * @param {Integer} [count] Number of keys to return. If omited, returns a single key. If present, returns an array of keys.
+   * @param {Integer} [count] Number of keys to return. If omited, returns a single key.
+   * If present, returns an array of keys.
    * @returns {*}
    */
   firstKey(count) {
-    if(!count) return this.keys().next().value;
+    if (!count) return this.keys().next().value;
     if (!Number.isInteger(count)) throw new TypeError('Count must be an integer');
     const keys = this.keys();
     const retArr = [];
-    for(let i=0;i<count;i++) {
+    for (let i = 0; i < count; i++) {
       retArr[i] = keys.next().value;
     }
     return retArr;
@@ -93,16 +95,17 @@ class Collection extends Map {
   /**
    * Obtains the last item in this collection. This relies on the `array()` method, and thus the caching mechanism
    * applies here as well.
-   * @param {Integer} [count] Number of values to return. If omited, returns a single values. If present, returns an array of values.
+   * @param {Integer} [count] Number of values to return. If omited, returns a single values.
+   * If present, returns an array of values.
    * @returns {*}
    */
   last(count) {
     const arr = this.array();
-    if(!count) return arr[arr.length - 1];
+    if (!count) return arr[arr.length - 1];
     if (!Number.isInteger(count)) throw new TypeError('Count must be an integer');
     const retArr = [];
     const arrLen = arr.length;
-    for(let i=0;i<count;i++) {
+    for (let i = 0; i < count; i++) {
       retArr[i] = arr[arrLen - (i+1)];
     }
     return retArr;
@@ -111,16 +114,17 @@ class Collection extends Map {
   /**
    * Obtains the last key in this collection. This relies on the `keyArray()` method, and thus the caching mechanism
    * applies here as well.
-   * @param {Integer} [count] Number of keys to return. If omited, returns a single key. If present, returns an array of keys.
+   * @param {Integer} [count] Number of keys to return. If omited, returns a single key.
+   * If present, returns an array of keys.
    * @returns {*}
    */
   lastKey(count) {
     const arr = this.keyArray();
-    if(!count) return arr[arr.length - 1];
+    if (!count) return arr[arr.length - 1];
     if (!Number.isInteger(count)) throw new TypeError('Count must be an integer');
     const retArr = [];
     const arrLen = arr.length;
-    for(let i=0;i<count;i++) {
+    for (let i = 0; i < count; i++) {
       retArr[i] = arr[arrLen - (i+1)];
     }
     return retArr;
@@ -129,15 +133,14 @@ class Collection extends Map {
   /**
    * Obtains a random item from this collection. This relies on the `array()` method, and thus the caching mechanism
    * applies here as well.
-   * @param {Integer} [count] Number of values to return. If omited, returns a single values. If present, returns an array of values.
    * @returns {*}
    */
   random(count) {
     const arr = this.array();
-    if(!count) return arr[Math.floor(Math.random() * arr.length)];
+    if (!count) return arr[Math.floor(Math.random() * arr.length)];
     if (!Number.isInteger(count)) throw new TypeError('Count must be an integer');
     const retArr = [];
-    for(let i=0;i<count;i++) {
+    for (let i = 0; i < count; i++) {
       retArr[i] = arr[Math.floor(Math.random() * arr.length)];
     }
     return retArr;
@@ -146,15 +149,14 @@ class Collection extends Map {
   /**
    * Obtains a random key from this collection. This relies on the `keyArray()` method, and thus the caching mechanism
    * applies here as well.
-   * @param {Integer} [count] Number of keys to return. If omited, returns a single key. If present, returns an array of keys.
    * @returns {*}
    */
   randomKey(count) {
     const arr = this.keyArray();
-    if(!count) return arr[Math.floor(Math.random() * arr.length)];
+    if (!count) return arr[Math.floor(Math.random() * arr.length)];
     if (!Number.isInteger(count)) throw new TypeError('Count must be an integer');
     const retArr = [];
-    for(let i=0;i<count;i++) {
+    for (let i = 0; i < count; i++) {
       retArr[i] = arr[Math.floor(Math.random() * arr.length)];
     }
     return retArr;

--- a/src/util/Collection.js
+++ b/src/util/Collection.js
@@ -1,10 +1,6 @@
 /**
- * This file has been extracted from the Discord.js source code
- * Original URL: https://github.com/hydrabolt/discord.js/blob/master/src/util/Collection.js
- * Credits to Amish Shah (hydrabolt) and other Discord.js contributors
-
-/**
- * A Map with additional utility methods.
+ * A Map with additional utility methods. This is used throughout discord.js rather than Arrays for anything that has
+ * an ID, for significantly improved performance and ease-of-use.
  * @extends {Map}
  */
 class Collection extends Map {

--- a/src/util/Collection.js
+++ b/src/util/Collection.js
@@ -91,8 +91,8 @@ class Collection extends Map {
   }
 
   /**
-   * Obtains the last value(s) in this collection. This relies on {@link Collection#array}, and thus the caching mechanism
-   * applies here as well.
+   * Obtains the last value(s) in this collection. This relies on {@link Collection#array}, and thus the caching
+   * mechanism applies here as well.
    * @param {number} [count] Number of values to obtain from the end
    * @returns {*|Array<*>} The single value if `count` is undefined, or an array of values of `count` length
    */
@@ -105,8 +105,8 @@ class Collection extends Map {
   }
 
   /**
-   * Obtains the last key(s) in this collection. This relies on {@link Collection#keyArray}, and thus the caching mechanism
-   * applies here as well.
+   * Obtains the last key(s) in this collection. This relies on {@link Collection#keyArray}, and thus the caching
+   * mechanism applies here as well.
    * @param {number} [count] Number of keys to obtain from the end
    * @returns {*|Array<*>} The single key if `count` is undefined, or an array of keys of `count` length
    */
@@ -119,38 +119,38 @@ class Collection extends Map {
   }
 
   /**
-   * Obtains random value(s) from this collection. This relies on {@link Collection#array}, and thus the caching mechanism
-   * applies here as well.
+   * Obtains random value(s) from this collection. This relies on {@link Collection#array}, and thus the caching
+   * mechanism applies here as well.
    * @param {number} [count] Number of values to obtain randomly
    * @returns {*|Array<*>} The single value if `count` is undefined, or an array of values of `count` length
    */
   random(count) {
-    const arr = this.array();
+    let arr = this.array();
     if (count === undefined) return arr[Math.floor(Math.random() * arr.length)];
     if (typeof count !== 'number') throw new TypeError('The count must be a number.');
     if (!Number.isInteger(count) || count < 1) throw new RangeError('The count must be an integer greater than 0.');
     if (arr.length === 0) return [];
     const rand = new Array(count);
     arr = arr.slice();
-    for (let r = 0; r < count; r++) rand[i] = arr.splice(Math.floor(Math.random() * arr.length), 1)[0];
+    for (let i = 0; i < count; i++) rand[i] = arr.splice(Math.floor(Math.random() * arr.length), 1)[0];
     return rand;
   }
 
   /**
-   * Obtains random key(s) from this collection. This relies on {@link Collection#keyArray}, and thus the caching mechanism
-   * applies here as well.
+   * Obtains random key(s) from this collection. This relies on {@link Collection#keyArray}, and thus the caching
+   * mechanism applies here as well.
    * @param {number} [count] Number of keys to obtain randomly
    * @returns {*|Array<*>} The single key if `count` is undefined, or an array of keys of `count` length
    */
   randomKey(count) {
-    const arr = this.keyArray();
+    let arr = this.keyArray();
     if (count === undefined) return arr[Math.floor(Math.random() * arr.length)];
     if (typeof count !== 'number') throw new TypeError('The count must be a number.');
     if (!Number.isInteger(count) || count < 1) throw new RangeError('The count must be an integer greater than 0.');
     if (arr.length === 0) return [];
     const rand = new Array(count);
     arr = arr.slice();
-    for (let r = 0; r < count; r++) rand[i] = arr.splice(Math.floor(Math.random() * arr.length), 1)[0];
+    for (let i = 0; i < count; i++) rand[i] = arr.splice(Math.floor(Math.random() * arr.length), 1)[0];
     return rand;
   }
 

--- a/src/util/Collection.js
+++ b/src/util/Collection.js
@@ -60,13 +60,13 @@ class Collection extends Map {
 
   /**
    * Obtains the first item in this collection.
-   * @param {number} [count] Number of values to return. If omited, returns a single values.
+   * @param {number} [count] Number of values to return. If omited, returns a single value.
    * If present, returns an array of values.
    * @returns {*|Array}
    */
   first(count) {
     if (!count) return this.values().next().value;
-    if (!Number.isInteger(count)) throw new TypeError('Count must be an integer');
+    if (!Number.isInteger(count) || count < 1) throw new TypeError('Count must be a positive integer');
     const values = this.values();
     const retArr = [];
     count = Math.min(this.size, count);
@@ -84,7 +84,7 @@ class Collection extends Map {
    */
   firstKey(count) {
     if (!count) return this.keys().next().value;
-    if (!Number.isInteger(count)) throw new TypeError('Count must be an integer');
+    if (!Number.isInteger(count) || count < 1) throw new TypeError('Count must be a positive integer');
     const keys = this.keys();
     const retArr = [];
     count = Math.min(this.size, count);
@@ -97,14 +97,14 @@ class Collection extends Map {
   /**
    * Obtains the last item in this collection. This relies on the `array()` method, and thus the caching mechanism
    * applies here as well.
-   * @param {number} [count] Number of values to return. If omited, returns a single values.
+   * @param {number} [count] Number of values to return. If omited, returns a single value.
    * If present, returns an array of values.
    * @returns {*|Array}
    */
   last(count) {
     const arr = this.array();
     if (!count) return arr[arr.length - 1];
-    if (!Number.isInteger(count)) throw new TypeError('Count must be an integer');
+    if (!Number.isInteger(count) || count < 1) throw new TypeError('Count must be a positive integer');
     const retArr = [];
     const arrLen = arr.length;
     count = Math.min(this.size, count);
@@ -124,7 +124,7 @@ class Collection extends Map {
   lastKey(count) {
     const arr = this.keyArray();
     if (!count) return arr[arr.length - 1];
-    if (!Number.isInteger(count)) throw new TypeError('Count must be an integer');
+    if (!Number.isInteger(count) || count < 1) throw new TypeError('Count must be a positive integer');
     const retArr = [];
     const arrLen = arr.length;
     count = Math.min(this.size, count);
@@ -137,14 +137,14 @@ class Collection extends Map {
   /**
    * Obtains a random item from this collection. This relies on the `array()` method, and thus the caching mechanism
    * applies here as well.
-   * @param {number} [count] Number of values to return. If omited, returns a single values.
+   * @param {number} [count] Number of values to return. If omited, returns a single value.
    * If present, returns an array of values.
    * @returns {*|Array}
    */
   random(count) {
     const arr = this.array();
     if (!count) return arr[Math.floor(Math.random() * arr.length)];
-    if (!Number.isInteger(count)) throw new TypeError('Count must be an integer');
+    if (!Number.isInteger(count) || count < 1) throw new TypeError('Count must be a positive integer');
     const retArr = [];
     while (retArr.length < count && arr.length > 0) {
       const i = Math.floor(Math.random() * arr.length);
@@ -164,7 +164,7 @@ class Collection extends Map {
   randomKey(count) {
     const arr = this.keyArray();
     if (!count) return arr[Math.floor(Math.random() * arr.length)];
-    if (!Number.isInteger(count)) throw new TypeError('Count must be an integer');
+    if (!Number.isInteger(count) || count < 1) throw new TypeError('Count must be a positive integer');
     const retArr = [];
     while (retArr.length < count && arr.length > 0) {
       const i = Math.floor(Math.random() * arr.length);

--- a/src/util/Collection.js
+++ b/src/util/Collection.js
@@ -1,6 +1,10 @@
 /**
- * A Map with additional utility methods. This is used throughout discord.js rather than Arrays for anything that has
- * an ID, for significantly improved performance and ease-of-use.
+ * This file has been extracted from the Discord.js source code
+ * Original URL: https://github.com/hydrabolt/discord.js/blob/master/src/util/Collection.js
+ * Credits to Amish Shah (hydrabolt) and other Discord.js contributors
+
+/**
+ * A Map with additional utility methods.
  * @extends {Map}
  */
 class Collection extends Map {
@@ -69,6 +73,7 @@ class Collection extends Map {
     if (!Number.isInteger(count)) throw new TypeError('Count must be an integer');
     const values = this.values();
     const retArr = [];
+    count = Math.min(this.size, count);
     for (let i = 0; i < count; i++) {
       retArr[i] = values.next().value;
     }
@@ -86,6 +91,7 @@ class Collection extends Map {
     if (!Number.isInteger(count)) throw new TypeError('Count must be an integer');
     const keys = this.keys();
     const retArr = [];
+    count = Math.min(this.size, count);
     for (let i = 0; i < count; i++) {
       retArr[i] = keys.next().value;
     }
@@ -105,6 +111,7 @@ class Collection extends Map {
     if (!Number.isInteger(count)) throw new TypeError('Count must be an integer');
     const retArr = [];
     const arrLen = arr.length;
+    count = Math.min(this.size, count);
     for (let i = 0; i < count; i++) {
       retArr[i] = arr[arrLen - (i + 1)];
     }
@@ -124,6 +131,7 @@ class Collection extends Map {
     if (!Number.isInteger(count)) throw new TypeError('Count must be an integer');
     const retArr = [];
     const arrLen = arr.length;
+    count = Math.min(this.size, count);
     for (let i = 0; i < count; i++) {
       retArr[i] = arr[arrLen - (i + 1)];
     }
@@ -142,8 +150,10 @@ class Collection extends Map {
     if (!count) return arr[Math.floor(Math.random() * arr.length)];
     if (!Number.isInteger(count)) throw new TypeError('Count must be an integer');
     const retArr = [];
-    for (let i = 0; i < count; i++) {
-      retArr[i] = arr[Math.floor(Math.random() * arr.length)];
+    while (retArr.length < count && arr.length > 0) {
+      const i = Math.floor(Math.random() * arr.length);
+      retArr.push(arr[i]);
+      arr.splice(i, 1);
     }
     return retArr;
   }
@@ -160,8 +170,10 @@ class Collection extends Map {
     if (!count) return arr[Math.floor(Math.random() * arr.length)];
     if (!Number.isInteger(count)) throw new TypeError('Count must be an integer');
     const retArr = [];
-    for (let i = 0; i < count; i++) {
-      retArr[i] = arr[Math.floor(Math.random() * arr.length)];
+    while (retArr.length < count && arr.length > 0) {
+      const i = Math.floor(Math.random() * arr.length);
+      retArr.push(arr[i]);
+      arr.splice(i, 1);
     }
     return retArr;
   }

--- a/src/util/Collection.js
+++ b/src/util/Collection.js
@@ -60,7 +60,7 @@ class Collection extends Map {
 
   /**
    * Obtains the first item in this collection.
-   * @param {Integer} [count] Number of values to return. If omited, returns a single values.
+   * @param {number} [count] Number of values to return. If omited, returns a single values.
    * If present, returns an array of values.
    * @returns {*|Array}
    */
@@ -77,7 +77,7 @@ class Collection extends Map {
 
   /**
    * Obtains the first key in this collection.
-   * @param {Integer} [count] Number of keys to return. If omited, returns a single key.
+   * @param {number} [count] Number of keys to return. If omited, returns a single key.
    * If present, returns an array of keys.
    * @returns {*|Array}
    */
@@ -95,7 +95,7 @@ class Collection extends Map {
   /**
    * Obtains the last item in this collection. This relies on the `array()` method, and thus the caching mechanism
    * applies here as well.
-   * @param {Integer} [count] Number of values to return. If omited, returns a single values.
+   * @param {number} [count] Number of values to return. If omited, returns a single values.
    * If present, returns an array of values.
    * @returns {*|Array}
    */
@@ -106,7 +106,7 @@ class Collection extends Map {
     const retArr = [];
     const arrLen = arr.length;
     for (let i = 0; i < count; i++) {
-      retArr[i] = arr[arrLen - (i+1)];
+      retArr[i] = arr[arrLen - (i + 1)];
     }
     return retArr;
   }
@@ -114,7 +114,7 @@ class Collection extends Map {
   /**
    * Obtains the last key in this collection. This relies on the `keyArray()` method, and thus the caching mechanism
    * applies here as well.
-   * @param {Integer} [count] Number of keys to return. If omited, returns a single key.
+   * @param {number} [count] Number of keys to return. If omited, returns a single key.
    * If present, returns an array of keys.
    * @returns {*|Array}
    */
@@ -125,7 +125,7 @@ class Collection extends Map {
     const retArr = [];
     const arrLen = arr.length;
     for (let i = 0; i < count; i++) {
-      retArr[i] = arr[arrLen - (i+1)];
+      retArr[i] = arr[arrLen - (i + 1)];
     }
     return retArr;
   }
@@ -133,7 +133,7 @@ class Collection extends Map {
   /**
    * Obtains a random item from this collection. This relies on the `array()` method, and thus the caching mechanism
    * applies here as well.
-   * @param {Integer} [count] Number of values to return. If omited, returns a single values.
+   * @param {number} [count] Number of values to return. If omited, returns a single values.
    * If present, returns an array of values.
    * @returns {*|Array}
    */
@@ -151,7 +151,7 @@ class Collection extends Map {
   /**
    * Obtains a random key from this collection. This relies on the `keyArray()` method, and thus the caching mechanism
    * applies here as well.
-   * @param {Integer} [count] Number of keys to return. If omited, returns a single key.
+   * @param {number} [count] Number of keys to return. If omited, returns a single key.
    * If present, returns an array of keys.
    * @returns {*|Array}
    */


### PR DESCRIPTION
[NON-BREAKING CHANGE]
An optional `count` argument is added to the following methods:
- random() and randomKey()
- first() and firstKey()
- last() and lastKey()

If `count` is used, the method returns an array instead of only the value. Performance impact non-existent for existing code. Performance for returning an array has been measured and this is the fastest I could find (array[i] = value is faster than array.push()).

**Please describe the changes this PR makes and why it should be merged:**


**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
