### PR TITLE
Fixes error messages for rate limiting of changes to avatar

### DIFF
--- a/src/client/rest/DiscordAPIError.js
+++ b/src/client/rest/DiscordAPIError.js
@@ -5,9 +5,10 @@
 class DiscordAPIError extends Error {
   constructor(path, error) {
     super();
-    const flattened = error.errors ? `\n${this.constructor.flattenErrors(error.errors).join('\n')}` : '';
+
     this.name = 'DiscordAPIError';
-    this.message = `${error.message}${flattened}`;
+    const flattened = `\n${this.constructor.flattenErrors(error.errors || error).join('\n')}`;
+    this.message = `${error.message || ''}${flattened}`;
 
     /**
      * The path of the request relative to the HTTP endpoint


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Changing Avatars is rate limited. If the rate limit is reached, the Discord API responds with the following message.

<img width="500" alt="Rate Limit Error Message" src="https://cloud.githubusercontent.com/assets/9379317/26664438/a0e2e6a8-46cc-11e7-9883-e1f11c8c6f1e.png">

The class `DiscordAPIError` only checks for `error.errors` though, so only the following error is seen as error.errors is empty as well as `error.messages`.

<img width="195" alt="Error Message before PR" src="https://cloud.githubusercontent.com/assets/9379317/26664485/ff400c4e-46cc-11e7-8bc9-e1cb29847a64.png">

This PR makes it so that also `error.avatar` checked for possible errors, so we get this message instead.

<img width="500" alt="Error Message after PR" src="https://cloud.githubusercontent.com/assets/9379317/26664501/2774b656-46cd-11e7-9436-a71b13a9785e.png">




**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
