### PR TITLE
Opus engine fetching: don't ignore non-missing errors

### DIFF
--- a/src/client/voice/opus/OpusEngineList.js
+++ b/src/client/voice/opus/OpusEngineList.js
@@ -9,7 +9,10 @@ function fetch(Encoder, engineOptions) {
   try {
     return new Encoder(engineOptions);
   } catch (err) {
-    return null;
+    if (err.includes('Cannot find module')) return null;
+
+    // The Opus engine exists, but another error occurred.
+    throw err;
   }
 }
 

--- a/src/client/voice/opus/OpusEngineList.js
+++ b/src/client/voice/opus/OpusEngineList.js
@@ -9,7 +9,7 @@ function fetch(Encoder, engineOptions) {
   try {
     return new Encoder(engineOptions);
   } catch (err) {
-    if (err.includes('Cannot find module')) return null;
+    if (err.message.includes('Cannot find module')) return null;
 
     // The Opus engine exists, but another error occurred.
     throw err;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
If an Opus engine cannot be found for a reason other than it not being present, we shouldn't simply ignore the error.

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
