### PR TITLE
Docs Missing Deny and Allow for PermissionOverwrites

### DIFF
--- a/src/structures/PermissionOverwrites.js
+++ b/src/structures/PermissionOverwrites.js
@@ -32,7 +32,7 @@ class PermissionOverwrites {
      * @type {PermissionResolvable}
      */
     this.deny = data.deny;
-    
+
     /**
      * The allowed permissions.
      * @type {PermissionResolvable}

--- a/src/structures/PermissionOverwrites.js
+++ b/src/structures/PermissionOverwrites.js
@@ -30,12 +30,14 @@ class PermissionOverwrites {
     /**
      * The denied permissions.
      * @type {PermissionResolvable}
+     * @private
      */
     this.deny = data.deny;
 
     /**
      * The allowed permissions.
      * @type {PermissionResolvable}
+     * @private
      */
     this.allow = data.allow;
   }

--- a/src/structures/PermissionOverwrites.js
+++ b/src/structures/PermissionOverwrites.js
@@ -27,7 +27,16 @@ class PermissionOverwrites {
      */
     this.type = data.type;
 
+    /**
+     * The denied permissions.
+     * @type {PermissionResolvable}
+     */
     this.deny = data.deny;
+    
+    /**
+     * The allowed permissions.
+     * @type {PermissionResolvable}
+     */
     this.allow = data.allow;
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The docs are missing for PermissionOverwrites allow and deny property.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
