### PR TITLE
Remove unused VoiceBroadcast#guaranteeOpusEngine (fixes #1556)

### DIFF
--- a/src/client/voice/VoiceBroadcast.js
+++ b/src/client/voice/VoiceBroadcast.js
@@ -242,8 +242,6 @@ class VoiceBroadcast extends VolumeInterface {
    * @returns {VoiceBroadcast}
    */
   playArbitraryInput(input, { seek = 0, volume = 1, passes = 1 } = {}) {
-    this.guaranteeOpusEngine();
-
     const options = { seek, volume, passes, input };
     return this._playTranscodable(input, options);
   }
@@ -270,10 +268,6 @@ class VoiceBroadcast extends VolumeInterface {
         dispatcher.resume();
       }
     }
-  }
-
-  guaranteeOpusEngine() {
-    if (!this.opusEncoder) throw new Error('Couldn\'t find an Opus engine.');
   }
 
   _startPlaying() {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
VoiceBroadcast#guaranteeOpusEngine is an old method that shouldn't be used anymore.

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
