### PR TITLE
make User#displayAvatarURL a method and make it and avatarURL accept an options object

### DIFF
--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -105,12 +105,13 @@ class User {
 
   /**
    * A link to the user's avatar
-   * @param {string} [format='webp'] One of `webp`, `png`, `jpg`, `gif`. If no format is provided, it will be `gif`
-   * for animated avatars or otherwise `webp`
-   * @param {number} [size=128] One of `128`, '256', `512`, `1024`, `2048`
-   * @returns {?string} avatarURL
+   * @param {Object} [options={}] Options for the avatar url
+   * @param {string} [options.format='webp'] One of `webp`, `png`, `jpg`, `gif`. If no format is provided,
+   * it will be `gif` for animated avatars or otherwise `webp`
+   * @param {number} [options.size=128] One of `128`, '256', `512`, `1024`, `2048`
+   * @returns {?string}
    */
-  avatarURL(format, size) {
+  avatarURL({ format, size } = {}) {
     if (!this.avatar) return null;
     if (typeof format === 'number') {
       size = format;
@@ -130,13 +131,14 @@ class User {
 
   /**
    * A link to the user's avatar if they have one. Otherwise a link to their default avatar will be returned
-   * @param {string} [format='webp'] One of `webp`, `png`, `jpg`, `gif`. If no format is provided, it will be `gif`
-   * for animated avatars or otherwise `webp`
-   * @param {number} [size=128] One of `128`, '256', `512`, `1024`, `2048`
+   * @param {Object} [options={}] Options for the avatar url
+   * @param {string} [options.format='webp'] One of `webp`, `png`, `jpg`, `gif`. If no format is provided,
+   * it will be `gif` for animated avatars or otherwise `webp`
+   * @param {number} [options.size=128] One of `128`, '256', `512`, `1024`, `2048`
    * @returns {string}
    */
-  displayAvatarURL(format, size) {
-    return this.avatarURL(format, size) || this.defaultAvatarURL;
+  displayAvatarURL(options) {
+    return this.avatarURL(options) || this.defaultAvatarURL;
   }
 
   /**

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -130,11 +130,13 @@ class User {
 
   /**
    * A link to the user's avatar if they have one. Otherwise a link to their default avatar will be returned
-   * @type {string}
-   * @readonly
+   * @param {string} [format='webp'] One of `webp`, `png`, `jpg`, `gif`. If no format is provided, it will be `gif`
+   * for animated avatars or otherwise `webp`
+   * @param {number} [size=128] One of `128`, '256', `512`, `1024`, `2048`
+   * @returns {string}
    */
-  get displayAvatarURL() {
-    return this.avatarURL() || this.defaultAvatarURL;
+  displayAvatarURL(format, size) {
+    return this.avatarURL(format, size) || this.defaultAvatarURL;
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Made ``User#displayAvatarURL`` a Method instead of a getter to allow specifying a format and a size.
Will still return a png for the default avatar for obvious reasons.

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
