### PR TITLE
Correctly mapping overwrites when creating a channel and renamed all relevant property names as of #1562

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -843,10 +843,10 @@ class Guild {
    *  .catch(console.error);
    */
   createChannel(name, type, { overwrites, reason } = {}) {
-    if (overwrites instanceof Collection) {
+    if (overwrites instanceof Collection || overwrites instanceof Array) {
       overwrites = overwrites.map(overwrite => ({
-        allow: overwrite._allowed,
-        deny: overwrite._denied,
+        allow: overwrite.allow || overwrite._allowed,
+        deny: overwrite.deny || overwrite._denied,
         type: overwrite.type,
         id: overwrite.id,
       }));

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -843,7 +843,14 @@ class Guild {
    *  .catch(console.error);
    */
   createChannel(name, type, { overwrites, reason } = {}) {
-    if (overwrites instanceof Collection) overwrites = overwrites.array();
+    if (overwrites instanceof Collection) {
+      overwrites = overwrites.map(overwrite => ({
+        allow: overwrite._allowed,
+        deny: overwrite._denied,
+        type: overwrite.type,
+        id: overwrite.id,
+      }));
+    }
     return this.client.api.guilds(this.id).channels.post({
       data: {
         name, type, permission_overwrites: overwrites,

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -76,20 +76,20 @@ class GuildChannel extends Channel {
     const overwrites = this.overwritesFor(member, true, roles);
 
     if (overwrites.everyone) {
-      permissions &= ~overwrites.everyone.deny;
-      permissions |= overwrites.everyone.allow;
+      permissions &= ~overwrites.everyone._denied;
+      permissions |= overwrites.everyone._alloweded;
     }
 
     let allow = 0;
     for (const overwrite of overwrites.roles) {
-      permissions &= ~overwrite.deny;
-      allow |= overwrite.allow;
+      permissions &= ~overwrite._denied;
+      allow |= overwrite._allowed;
     }
     permissions |= allow;
 
     if (overwrites.member) {
-      permissions &= ~overwrites.member.deny;
-      permissions |= overwrites.member.allow;
+      permissions &= ~overwrites.member._denied;
+      permissions |= overwrites.member._allowed;
     }
 
     const admin = Boolean(permissions & Permissions.FLAGS.ADMINISTRATOR);
@@ -171,8 +171,8 @@ class GuildChannel extends Channel {
     const prevOverwrite = this.permissionOverwrites.get(userOrRole.id);
 
     if (prevOverwrite) {
-      payload.allow = prevOverwrite.allow;
-      payload.deny = prevOverwrite.deny;
+      payload.allow = prevOverwrite._allowed;
+      payload.deny = prevOverwrite._denied;
     }
 
     for (const perm in options) {
@@ -290,7 +290,7 @@ class GuildChannel extends Channel {
     return this.client.api.channels(this.id).invites.post({ data: {
       temporary, max_age: maxAge, max_uses: maxUses,
     }, reason })
-    .then(invite => new Invite(this.client, invite));
+      .then(invite => new Invite(this.client, invite));
   }
 
   /**

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -77,7 +77,7 @@ class GuildChannel extends Channel {
 
     if (overwrites.everyone) {
       permissions &= ~overwrites.everyone._denied;
-      permissions |= overwrites.everyone._alloweded;
+      permissions |= overwrites.everyone._allowed;
     }
 
     let allow = 0;

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -301,7 +301,7 @@ class GuildChannel extends Channel {
    * @returns {Promise<GuildChannel>}
    */
   clone(name = this.name, withPermissions = true, withTopic = true) {
-    return this.guild.createChannel(name, this.type, withPermissions ? this.permissionOverwrites : [])
+    return this.guild.createChannel(name, this.type, { overwrites: withPermissions ? this.permissionOverwrites : [] })
       .then(channel => withTopic ? channel.setTopic(this.topic) : channel);
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Since [those](https://github.com/hydrabolt/discord.js/blob/1e47cfdd5df1654ac6ed47146e09f34e3e49b0c5/src/structures/PermissionOverwrites.js#L32-L33) two properties were renamed PermissionOverwrites require mapping before sending them to discord.

Changing the names of the properties back would be a better solution IMO.

Also passing now the overwrites as correct parameter when cloning a channel.

Edit:

Changed all `.deny` and `.allow` for permission related methods in `GuildChannel` to their new property names.
Related to #1595's problem with `.joinable` being incorrectly `true`.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
