### PR TITLE
Added Client#status and Message#type typedefs

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -198,7 +198,7 @@ class Client extends EventEmitter {
 
   /**
    * Current status of the client's connection to Discord
-   * @type {?number}
+   * @type {?Status}
    * @readonly
    */
   get status() {

--- a/src/client/voice/VoiceConnection.js
+++ b/src/client/voice/VoiceConnection.js
@@ -52,7 +52,7 @@ class VoiceConnection extends EventEmitter {
 
     /**
      * The current status of the voice connection
-     * @type {number}
+     * @type {VoiceStatus}
      */
     this.status = Constants.VoiceStatus.AUTHENTICATING;
 

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -40,7 +40,7 @@ class Message {
 
     /**
      * The type of the message
-     * @type {MessageTypes}
+     * @type {MessageType}
      */
     this.type = Constants.MessageTypes[data.type];
 

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -40,7 +40,7 @@ class Message {
 
     /**
      * The type of the message
-     * @type {string}
+     * @type {MessageTypes}
      */
     this.type = Constants.MessageTypes[data.type];
 

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -329,6 +329,18 @@ exports.WSEvents = {
   RELATIONSHIP_REMOVE: 'RELATIONSHIP_REMOVE',
 };
 
+/**
+ * The type of a message, e.g. `DEFAULT`. Here are the available types:
+ * - DEFAULT
+ * - RECIPIENT_ADD
+ * - RECIPIENT_REMOVE
+ * - CALL
+ * - CHANNEL_NAME_CHANGE
+ * - CHANNEL_ICON_CHANGE
+ * - PINS_ADD
+ * - GUILD_MEMBER_JOIN
+ * @typedef {string} MessageTypes
+ */
 exports.MessageTypes = [
   'DEFAULT',
   'RECIPIENT_ADD',

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -339,7 +339,7 @@ exports.WSEvents = {
  * - CHANNEL_ICON_CHANGE
  * - PINS_ADD
  * - GUILD_MEMBER_JOIN
- * @typedef {string} MessageTypes
+ * @typedef {string} MessageType
  */
 exports.MessageTypes = [
   'DEFAULT',


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Those typedefs are asked all the times in the support channels, usually I just link them to the constants file.
Why not just add them to the docs then?

Note: [`Status`](https://discord.js.org/#/docs/main/master/typedef/Status) is already documented, `Client#status` was just not pointing to it.

Edit:
``VoiceConnection#status`` points now to `VoiceStatus`

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
