### PR TITLE
Remove global flag from ffmpeg tutorial doc

### DIFF
--- a/docs/topics/voice.md
+++ b/docs/topics/voice.md
@@ -4,7 +4,7 @@ Voice in discord.js can be used for many things, such as music bots, recording o
 In discord.js, you can use voice by connecting to a `VoiceChannel` to obtain a `VoiceConnection`, where you can start streaming and receiving audio.
 
 To get started, make sure you have:
-* ffmpeg - `npm install --global ffmpeg-binaries`
+* ffmpeg - `npm install ffmpeg-binaries`
 * an opus encoder, choose one from below:
   * `npm install opusscript`
   * `npm install node-opus`


### PR DESCRIPTION
Installing ffmpeg-binaries globally would not work.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
