### PR TITLE
Fixed typo in Guild#createEmoji

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -941,7 +941,7 @@ class Guild {
    *  .catch(console.error);
    */
   createEmoji(attachment, name, roles) {
-    if (typeof attahment === 'string' && attachment.startsWith('data:')) {
+    if (typeof attachment === 'string' && attachment.startsWith('data:')) {
       const data = { image: attachment, name };
       if (roles) data.roles = roles.map(r => r.id ? r.id : r);
       return this.client.api.guilds(this.id).emojis.post({ data })


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Small typo in `Guild#createEmoji` with great impact.
Creating emojis will be possible again.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
