### PR TITLE
VoiceManager reject on error

### DIFF
--- a/src/client/voice/ClientVoiceManager.js
+++ b/src/client/voice/ClientVoiceManager.js
@@ -68,12 +68,10 @@ class ClientVoiceManager {
         this.connections.delete(channel.guild.id);
         reject(reason);
       });
-      
       connection.once('error', reason => {
         this.connections.delete(channel.guild.id);
         reject(reason);
       });
-      
       connection.once('authenticated', () => {
         connection.once('ready', () => resolve(connection));
         connection.once('error', reject);

--- a/src/client/voice/ClientVoiceManager.js
+++ b/src/client/voice/ClientVoiceManager.js
@@ -73,7 +73,7 @@ class ClientVoiceManager {
         this.connections.delete(channel.guild.id);
         reject(reason);
       });
-
+      
       connection.once('authenticated', () => {
         connection.once('ready', () => resolve(connection));
         connection.once('error', reject);

--- a/src/client/voice/ClientVoiceManager.js
+++ b/src/client/voice/ClientVoiceManager.js
@@ -68,6 +68,11 @@ class ClientVoiceManager {
         this.connections.delete(channel.guild.id);
         reject(reason);
       });
+      
+      connection.once('error', reason => {
+        this.connections.delete(channel.guild.id);
+        reject(reason);
+      });
 
       connection.once('authenticated', () => {
         connection.once('ready', () => resolve(connection));


### PR DESCRIPTION
Fix unhandled event error for VoiceManager. This manager calls VoiceConnection, but did not handle the reject event. Causing programs to crash.

This pull request handles the crash in #1595 . And will properly handles the catch event.

**Catch will never be console logged**
```js
// Join a voice channel
voiceChannel.join()
 .then(connection => console.log('Connected!'))
 .catch(console.error);
```