### PR TITLE
Removed deprecated file option from MessageOptions

### DIFF
--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -81,11 +81,9 @@ class TextBasedChannel {
 
     if (!options.content) options.content = content;
 
-    if (options.embed && options.embed.file) options.file = options.embed.file;
-
-    if (options.file) {
-      if (options.files) options.files.push(options.file);
-      else options.files = [options.file];
+    if (options.embed && options.embed.file) {
+      if (options.files) options.files.push(options.embed.file);
+      else options.files = [options.embed.file];
     }
 
     if (options.files) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Removed deprecated `file` option from the [MessageOptions](https://discord.js.org/#/docs/main/stable/typedef/MessageOptions).

Regarding the `WebhookMessageOptions`:
- There is also the `file` option which is not marked as deprecated.
Is this correct?
- The `embeds` array only accepts an `Object` but not a `RichEmbed`, which would behave differently than the `TextBasedChannel#send` because `RichEmbed#file` wouldn't be attached here.
This is correctly documented, but feels inconsistent.
Is this correct?

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
