### PR TITLE
Made (hopefully) all url related methods accept an options objects

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -260,16 +260,13 @@ class Guild {
 
   /**
    * Gets the URL to this guild's icon
-   * @param {string} [format='webp'] One of `webp`, `png`, `jpg`, `gif`
-   * @param {number} [size=128] One of `128`, '256', `512`, `1024`, `2048`
+   * @param {Object} [options={}] Options for the icon url
+   * @param {string} [options.format='webp'] One of `webp`, `png`, `jpg`
+   * @param {number} [options.size=128] One of `128`, '256', `512`, `1024`, `2048`
    * @returns {?string}
    */
-  iconURL(format, size) {
+  iconURL({ format, size } = {}) {
     if (!this.icon) return null;
-    if (typeof format === 'number') {
-      size = format;
-      format = 'default';
-    }
     return Constants.Endpoints.CDN(this.client.options.http.cdn).Icon(this.id, this.icon, format, size);
   }
 
@@ -284,12 +281,14 @@ class Guild {
 
   /**
    * The URL to this guild's splash
-   * @type {?string}
-   * @readonly
+   * @param {Object} [options={}] Options for the splash url
+   * @param {string} [options.format='webp'] One of `webp`, `png`, `jpg`
+   * @param {number} [options.size=128] One of `128`, '256', `512`, `1024`, `2048`
+   * @returns {?string}
    */
-  get splashURL() {
+  splashURL({ format, size } = {}) {
     if (!this.splash) return null;
-    return Constants.Endpoints.CDN(this.client.options.http.cdn).Splash(this.id, this.splash);
+    return Constants.Endpoints.CDN(this.client.options.http.cdn).Splash(this.id, this.splash, format, size);
   }
 
   /**

--- a/src/structures/OAuth2Application.js
+++ b/src/structures/OAuth2Application.js
@@ -119,16 +119,13 @@ class OAuth2Application {
 
   /**
    * A link to the application's icon
-   * @param {string} [format='webp'] One of `webp`, `png`, `jpg`, `gif`.
-   * @param {number} [size=128] One of `128`, '256', `512`, `1024`, `2048`
+   * @param {Object} [options={}] Options for the icon url
+   * @param {string} [options.format='webp'] One of `webp`, `png`, `jpg`
+   * @param {number} [options.size=128] One of `128`, '256', `512`, `1024`, `2048`
    * @returns {?string} URL to the icon
    */
-  iconURL(format, size) {
+  iconURL({ format, size } = {}) {
     if (!this.icon) return null;
-    if (typeof format === 'number') {
-      size = format;
-      format = 'default';
-    }
     return Constants.Endpoints.CDN(this.client.options.http.cdn).AppIcon(this.id, this.icon, format, size);
   }
 

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -113,10 +113,6 @@ class User {
    */
   avatarURL({ format, size } = {}) {
     if (!this.avatar) return null;
-    if (typeof format === 'number') {
-      size = format;
-      format = 'default';
-    }
     return Constants.Endpoints.CDN(this.client.options.http.cdn).Avatar(this.id, this.avatar, format, size);
   }
 


### PR DESCRIPTION
and removed a leftover in User#avatarURL

**Please describe the changes this PR makes and why it should be merged:**

- ``Guild#splashURL`` is no longer a getter because it's now accepting an options object.
- ``OAuth2Application#iconURL`` now accepts an options object.
- Same for ``Guild#iconURL`` ^
- Removed a small leftover in ``User#avatarURL``

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
