### PR TITLE
Ignore setSpeaking requests when VC isn't connected

### DIFF
--- a/src/client/voice/VoiceConnection.js
+++ b/src/client/voice/VoiceConnection.js
@@ -133,6 +133,7 @@ class VoiceConnection extends EventEmitter {
    */
   setSpeaking(value) {
     if (this.speaking === value) return;
+    if (this.status !== Constants.VoiceStatus.CONNECTED) return;
     this.speaking = value;
     this.sockets.ws.sendPacket({
       op: Constants.VoiceOPCodes.SPEAKING,

--- a/src/client/voice/dispatcher/StreamDispatcher.js
+++ b/src/client/voice/dispatcher/StreamDispatcher.js
@@ -1,5 +1,6 @@
 const VolumeInterface = require('../util/VolumeInterface');
 const VoiceBroadcast = require('../VoiceBroadcast');
+const Constants = require('../../../util/Constants');
 
 const secretbox = require('../util/Secretbox');
 
@@ -108,6 +109,7 @@ class StreamDispatcher extends VolumeInterface {
 
   setSpeaking(value) {
     if (this.speaking === value) return;
+    if (this.player.voiceConnection.status !== Constants.VoiceStatus.CONNECTED) return;
     this.speaking = value;
     /**
      * Emitted when the dispatcher starts/stops speaking.


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
A lot of users have been getting this error:
`TypeError: Cannot read property 'sendPacket' of null`. It's because a StreamDispatcher is attempting to change the speaking state while the VoiceConnection has been disconnected. The most prevalent instance of this occurs when a VoiceConnection disconnects: the StreamDispatcher process loop determines that it should end itself and calls its internal destroy method. This triggers a setSpeaking call, which obviously doesn't work since the VoiceConnection is disconnected.

Thanks to Deadlystrike for providing a stacktrace for this issue.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
