### PR TITLE
move raw call so that any cache events happen before

### DIFF
--- a/src/client/websocket/WebSocketConnection.js
+++ b/src/client/websocket/WebSocketConnection.js
@@ -311,7 +311,6 @@ class WebSocketConnection extends EventEmitter {
       this.debug('Received null packet');
       return false;
     }
-    this.client.emit('raw', packet);
     switch (packet.op) {
       case Constants.OPCodes.HELLO:
         return this.heartbeat(packet.d.heartbeat_interval);
@@ -329,6 +328,7 @@ class WebSocketConnection extends EventEmitter {
       default:
         return this.packetManager.handle(packet);
     }
+    this.client.emit('raw', packet);
   }
 
   /**

--- a/src/client/websocket/WebSocketConnection.js
+++ b/src/client/websocket/WebSocketConnection.js
@@ -290,7 +290,8 @@ class WebSocketConnection extends EventEmitter {
     } catch (err) {
       this.emit('debug', err);
     }
-    return this.onPacket(data);
+    this.onPacket(data);
+    this.client.emit('raw', data);
   }
 
   /**
@@ -328,7 +329,6 @@ class WebSocketConnection extends EventEmitter {
       default:
         return this.packetManager.handle(packet);
     }
-    this.client.emit('raw', packet);
   }
 
   /**

--- a/src/client/websocket/WebSocketConnection.js
+++ b/src/client/websocket/WebSocketConnection.js
@@ -290,8 +290,9 @@ class WebSocketConnection extends EventEmitter {
     } catch (err) {
       this.emit('debug', err);
     }
-    this.onPacket(data);
+    const ret = this.onPacket(data);
     this.client.emit('raw', data);
+    return ret;
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
if someone working with the raw event needs something from the cache for some reason, it won't be there, so we call raw *after* cache processing happens

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
