### PR TITLE
fixed MessageEmbed#timestamp and changed attachFile to attachFiles

### DIFF
--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -32,7 +32,6 @@ const Messages = {
   EMBED_FIELD_COUNT: 'MessageEmbeds may not exceed 25 fields.',
   EMBED_FIELD_NAME: 'MessageEmbed field names may not exceed 256 characters or be empty.',
   EMBED_FIELD_VALUE: 'MessageEmbed field values may not exceed 1024 characters or be empty.',
-  EMBED_FILE_LIMIT: 'You may not upload more than one file at once.',
   EMBED_DESCRIPTION: 'MessageEmbed descriptions may not exceed 2048 characters.',
   EMBED_FOOTER_TEXT: 'MessageEmbed footer text may not exceed 2048 characters.',
   EMBED_TITLE: 'MessageEmbed titles may not exceed 256 characters.',

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -44,11 +44,11 @@ class MessageEmbed {
      * The timestamp of this embed
      * @type {?number}
      */
-    this.timestamp = new Date(data.timestamp);
+    this.timestamp = data.timestamp ? new Date(data.timestamp).getTime() : null;
 
     /**
      * The fields of this embed
-     * @type {?Object[]}
+     * @type {Object[]}
      * @property {string} name The name of this field
      * @property {string} value The value of this field
      * @property {boolean} inline If this field will be displayed inline
@@ -133,11 +133,11 @@ class MessageEmbed {
 
   /**
    * The date this embed was created
-   * @type {Date}
+   * @type {?Date}
    * @readonly
    */
   get createdAt() {
-    return !isNaN(this.timestamp) ? this.timestamp : null;
+    return this.timestamp ? new Date(this.timestamp) : null;
   }
 
   /**
@@ -178,12 +178,12 @@ class MessageEmbed {
   /**
    * Sets the file to upload alongside the embed. This file can be accessed via `attachment://fileName.extension` when
    * setting an embed image or author/footer icons. Only one file may be attached.
-   * @param {FileOptions|string} file Local path or URL to the file to attach, or valid FileOptions for a file to attach
+   * @param {Array<FileOptions|string>} files Files to attach
    * @returns {MessageEmbed} This embed
    */
-  attachFile(file) {
-    if (this.file) throw new RangeError('EMBED_FILE_LIMIT');
-    this.file = file;
+  attachFiles(files) {
+    if (this.files) this.files = this.files.concat(files);
+    else this.files = [files];
     return this;
   }
 
@@ -295,7 +295,7 @@ class MessageEmbed {
       timestamp: this.timestamp,
       color: this.color,
       fields: this.fields,
-      file: this.file,
+      files: this.files,
       thumbnail: this.thumbnail,
       image: this.image,
       author: this.author ? {

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -183,7 +183,7 @@ class MessageEmbed {
    */
   attachFiles(files) {
     if (this.files) this.files = this.files.concat(files);
-    else this.files = [files];
+    else this.files = files;
     return this;
   }
 

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -82,9 +82,9 @@ class TextBasedChannel {
 
     if (!options.content) options.content = content;
 
-    if (options.embed && options.embed.file) {
-      if (options.files) options.files.push(options.embed.file);
-      else options.files = [options.embed.file];
+    if (options.embed && options.embed.files) {
+      if (options.files) options.files = options.files.concat(...options.embed.files);
+      else options.files = options.embed.files;
     }
 
     if (options.files) {

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -83,7 +83,7 @@ class TextBasedChannel {
     if (!options.content) options.content = content;
 
     if (options.embed && options.embed.files) {
-      if (options.files) options.files = options.files.concat(...options.embed.files);
+      if (options.files) options.files = options.files.concat(options.embed.files);
       else options.files = options.embed.files;
     }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Notable changes
- Removed the `EMBED_FILE_LIMIT` error message
- Made the `MessageEmbed#timestamp` an actual timestamp instead of a date
- (docs) `MessageEmbed#fields` should not be optional (it defaults to an empty array)
- Changed `MessageEmbed#attachFile` to `MessageEmbed#attachFiles`, which appends to `MessageEmbed#files` on multiple calls like addField.
Maybe the error should be kept since one can only use up to 3(?) different images in an embed?

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
