### PR TITLE
Fix typo in client.voiceConnections docs

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -228,7 +228,7 @@ class Client extends EventEmitter {
   }
 
   /**
-   * All active voice connections that have been established, mapped by Guild ID
+   * All active voice connections that have been established, mapped by guild ID
    * @type {Collection<Snowflake, VoiceConnection>}
    * @readonly
    */

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -228,7 +228,7 @@ class Client extends EventEmitter {
   }
 
   /**
-   * All active voice connections that have been established, mapped by channel ID
+   * All active voice connections that have been established, mapped by Guild ID
    * @type {Collection<Snowflake, VoiceConnection>}
    * @readonly
    */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Updated a typo made by gawdl3y in the documentation of client.voiceConnections collection
proofed by aemino
![ss 2017-07-10 at 09 17 01](https://user-images.githubusercontent.com/20647088/28035541-454f44dc-65b5-11e7-8fcb-00dc17513b0e.png)

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
