### PR TITLE
Fix search method of Guild and TextBasedChannel

### DIFF
--- a/src/structures/shared/Search.js
+++ b/src/structures/shared/Search.js
@@ -88,7 +88,7 @@ module.exports = function search(target, options) {
 
   if (!(target instanceof Channel || target instanceof Guild)) throw new TypeError('SEARCH_CHANNEL_TYPE');
 
-  let endpoint = target.client.api[target instanceof Channel ? 'channels' : 'guilds'](target.id).messages().search;
+  let endpoint = target.client.api[target instanceof Channel ? 'channels' : 'guilds'][target.id].messages.search;
   return endpoint.get({ query: options }).then(body => {
     const results = body.messages.map(x =>
       x.map(m => new Message(target.client.channels.get(m.channel_id), m, target.client))


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Searching from both a channel and a guild throws the following error:
```js
target.client.api[(intermediate value)(intermediate value)(intermediate value)] is not a function
```
This will take care of that.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
