### PR TITLE
Fixing MessageEmbed's timestamp transforming

### DIFF
--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -260,7 +260,7 @@ class MessageEmbed {
    * @returns {MessageEmbed} This embed
    */
   setTimestamp(timestamp = new Date()) {
-    this.timestamp = timestamp;
+    this.timestamp = timestamp.getTime();
     return this;
   }
 
@@ -292,7 +292,7 @@ class MessageEmbed {
       type: 'rich',
       description: this.description,
       url: this.url,
-      timestamp: this.timestamp,
+      timestamp: this.timestamp ? new Date(this.timestamp) : null,
       color: this.color,
       fields: this.fields,
       files: this.files,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
As @BobbyWibowo mentioned sending a received embed results in this error:
```
Invalid Form Body
embed.timestamp: Could not parse 1500218461229. Should be ISO8601.
```

This is because I forgot to account for that in #1670, this will take care of that as well as convert a set date via ``MessageEmbed#setTimestamp`` to milliseconds, like the typedef of ``MessageEmbed#timestamp`` suggests.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
