### PR TITLE
Fix docs for Application secret type

### DIFF
--- a/src/structures/OAuth2Application.js
+++ b/src/structures/OAuth2Application.js
@@ -86,7 +86,7 @@ class OAuth2Application {
 
     /**
      * OAuth2 secret for the application
-     * @type {boolean}
+     * @type {string}
      */
     this.secret = data.secret;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The documentation for the OAuth2 application were stating the secret is a boolean, which does not make sense. They now say it is a string as supposed to be.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
