### PR TITLE
afkChannelID returns a Snowflake rather than an string

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -136,7 +136,7 @@ class Guild {
 
     /**
      * The ID of the voice channel where AFK members are moved
-     * @type {?string}
+     * @type {?Snowflake}
      */
     this.afkChannelID = data.afk_channel_id;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
<guild>.afkChannelID returns an ID as an string what should be declared as an Snowflake in the docs

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
