### PR TITLE
.applicationID and .ownerID return a Snowflake rather than a string

### DIFF
--- a/src/structures/GroupDMChannel.js
+++ b/src/structures/GroupDMChannel.js
@@ -54,7 +54,7 @@ class GroupDMChannel extends Channel {
 
     /**
      * The user ID of this Group DM's owner
-     * @type {string}
+     * @type {Snowflake}
      */
     this.ownerID = data.owner_id;
 
@@ -66,7 +66,7 @@ class GroupDMChannel extends Channel {
 
     /**
      * Application ID of the application that made this Group DM, if applicable
-     * @type {?string}
+     * @type {?Snowflake}
      */
     this.applicationID = data.application_id;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
like my last PR <GroupDmChannel>.applicationID and <GroupDmChannel>.ownerID return both an ID as an string what should be declared as an Snowflake in the docs

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
