### PR TITLE
Add backwards-compatibility for Node 6.9.1

### DIFF
--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -84,4 +84,4 @@ const Messages = {
   EMOJI_TYPE: 'Emoji must be a string or Emoji/ReactionEmoji',
 };
 
-for (const [name, message] of Object.entries(Messages)) register(name, message);
+for (const name in Messages) register(name, Messages[name]);

--- a/src/structures/ClientUserSettings.js
+++ b/src/structures/ClientUserSettings.js
@@ -15,7 +15,8 @@ class ClientUserSettings {
    * @param {Object} data Data to patch this with
    */
   patch(data) {
-    for (const [key, value] of Object.entries(Constants.UserSettingsMap)) {
+    for (const key in Constants.UserSettingsMap) {
+      const value = Constants.UserSettingsMap[key];
       if (!data.hasOwnProperty(key)) continue;
       if (typeof value === 'function') {
         this[value.name] = value(data[key]);

--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -171,7 +171,11 @@ Permissions.FLAGS = {
  * Bitfield representing every permission combined
  * @type {number}
  */
-Permissions.ALL = Object.values(Permissions.FLAGS).reduce((all, p) => all | p, 0);
+Permissions.ALL = 0;
+for (const p in Permissions.FLAGS)
+{
+  Permissions.ALL = Permissions.ALL | Permissions.FLAGS[p];
+}
 
 /**
  * Bitfield representing the default permissions for users


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This commit adds backwards compatibility for at least **Node v6.9.1**. Functions such as `Object.entries` and `Object.values` are not implemented in versions prior to Node v7. Tested on Node v6.9.1.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
