### PR TITLE
Fix wrong error message

### DIFF
--- a/src/client/ClientManager.js
+++ b/src/client/ClientManager.js
@@ -38,7 +38,7 @@ class ClientManager {
   connectToWebSocket(token, resolve, reject) {
     this.client.emit(Constants.Events.DEBUG, `Authenticated using token ${token}`);
     this.client.token = token;
-    const timeout = this.client.setTimeout(() => reject(new Error('INVALID_TOKEN')), 1000 * 300);
+    const timeout = this.client.setTimeout(() => reject(new Error('TOKEN_INVALID')), 1000 * 300);
     this.client.api.gateway.get().then(res => {
       const protocolVersion = Constants.DefaultOptions.ws.version;
       const gateway = `${res.url}/?v=${protocolVersion}&encoding=${WebSocketConnection.ENCODING}`;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
In ClientManager#connectToWebSocket, `INVALID_TOKEN` was used instead of `TOKEN_INVALID`.
I'm not sure if this should actually be a different error though, because the error fires when the login times out, and not when an invalid token is used

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
