### PR TITLE
Guild#fetchMember's options paremeter should be optional

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -505,7 +505,7 @@ class Guild {
    * @param {number} [options.limit=0] Maximum number of members to request
    * @returns {Promise<Collection<Snowflake, GuildMember>>}
    */
-  fetchMembers({ query = '', limit = 0 }) {
+  fetchMembers({ query = '', limit = 0 } = {}) {
     return new Promise((resolve, reject) => {
       if (this.memberCount === this.members.size) {
         resolve((query || limit) ? new Collection() : this.members);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

As mentioned in #1669.
The `options` paremeter for `Guild#fetchMembers` should be optional.


**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
