### PR TITLE
Adding reason parameter to GuildMember's methods

### DIFF
--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -356,19 +356,21 @@ class GuildMember {
   /**
    * Mute/unmute a user.
    * @param {boolean} mute Whether or not the member should be muted
+   * @param {string} reason Reason for muting or unmuting
    * @returns {Promise<GuildMember>}
    */
-  setMute(mute) {
-    return this.edit({ mute });
+  setMute(mute, reason) {
+    return this.edit({ mute }, reason);
   }
 
   /**
    * Deafen/undeafen a user.
    * @param {boolean} deaf Whether or not the member should be deafened
+   * @param {string} reason Reason for deafening or undeafening
    * @returns {Promise<GuildMember>}
    */
-  setDeaf(deaf) {
-    return this.edit({ deaf });
+  setDeaf(deaf, reason) {
+    return this.edit({ deaf }, reason);
   }
 
   /**
@@ -383,32 +385,35 @@ class GuildMember {
   /**
    * Sets the roles applied to the member.
    * @param {Collection<Snowflake, Role>|Role[]|Snowflake[]} roles The roles or role IDs to apply
+   * @param {string} reason Reason for applying the roles
    * @returns {Promise<GuildMember>}
    */
-  setRoles(roles) {
-    return this.edit({ roles });
+  setRoles(roles, reason) {
+    return this.edit({ roles }, reason);
   }
 
   /**
    * Adds a single role to the member.
    * @param {Role|Snowflake} role The role or ID of the role to add
+   * @param {string} reason Reason for adding the role
    * @returns {Promise<GuildMember>}
    */
-  addRole(role) {
+  addRole(role, reason) {
     if (!(role instanceof Role)) role = this.guild.roles.get(role);
     if (!role) return Promise.reject(new TypeError('INVALID_TYPE', 'role', 'Role nor a Snowflake'));
     if (this._roles.includes(role.id)) return Promise.resolve(this);
     return this.client.api.guilds(this.guild.id).members(this.user.id).roles(role.id)
-      .put()
+      .put({ reason })
       .then(() => this);
   }
 
   /**
    * Adds multiple roles to the member.
    * @param {Collection<Snowflake, Role>|Role[]|Snowflake[]} roles The roles or role IDs to add
+   * @param {string} reason Reason for adding the roles
    * @returns {Promise<GuildMember>}
    */
-  addRoles(roles) {
+  addRoles(roles, reason) {
     let allRoles;
     if (roles instanceof Collection) {
       allRoles = this._roles.slice();
@@ -416,28 +421,30 @@ class GuildMember {
     } else {
       allRoles = this._roles.concat(roles.map(r => r.id ? r.id : r));
     }
-    return this.edit({ roles: allRoles });
+    return this.edit({ roles: allRoles }, reason);
   }
 
   /**
    * Removes a single role from the member.
    * @param {Role|Snowflake} role The role or ID of the role to remove
+   * @param {string} reason Reason for removing the role
    * @returns {Promise<GuildMember>}
    */
-  removeRole(role) {
+  removeRole(role, reason) {
     if (!(role instanceof Role)) role = this.guild.roles.get(role);
     if (!role) return Promise.reject(new TypeError('INVALID_TYPE', 'role', 'Role nor a Snowflake'));
     return this.client.api.guilds(this.guild.id).members(this.user.id).roles(role.id)
-      .delete()
+      .delete({ reason })
       .then(() => this);
   }
 
   /**
    * Removes multiple roles from the member.
    * @param {Collection<Snowflake, Role>|Role[]|Snowflake[]} roles The roles or role IDs to remove
+   * @param {string} reason Reason for removing the roles
    * @returns {Promise<GuildMember>}
    */
-  removeRoles(roles) {
+  removeRoles(roles, reason) {
     const allRoles = this._roles.slice();
     if (roles instanceof Collection) {
       for (const role of roles.values()) {
@@ -450,16 +457,17 @@ class GuildMember {
         if (index >= 0) allRoles.splice(index, 1);
       }
     }
-    return this.edit({ roles: allRoles });
+    return this.edit({ roles: allRoles }, reason);
   }
 
   /**
    * Set the nickname for the guild member.
    * @param {string} nick The nickname for the guild member
+   * @param {string} reason Reason for setting the nickname
    * @returns {Promise<GuildMember>}
    */
-  setNickname(nick) {
-    return this.edit({ nick });
+  setNickname(nick, reason) {
+    return this.edit({ nick }, reason);
   }
 
   /**

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -356,7 +356,7 @@ class GuildMember {
   /**
    * Mute/unmute a user.
    * @param {boolean} mute Whether or not the member should be muted
-   * @param {string} reason Reason for muting or unmuting
+   * @param {string} [reason] Reason for muting or unmuting
    * @returns {Promise<GuildMember>}
    */
   setMute(mute, reason) {
@@ -366,7 +366,7 @@ class GuildMember {
   /**
    * Deafen/undeafen a user.
    * @param {boolean} deaf Whether or not the member should be deafened
-   * @param {string} reason Reason for deafening or undeafening
+   * @param {string} [reason] Reason for deafening or undeafening
    * @returns {Promise<GuildMember>}
    */
   setDeaf(deaf, reason) {
@@ -385,7 +385,7 @@ class GuildMember {
   /**
    * Sets the roles applied to the member.
    * @param {Collection<Snowflake, Role>|Role[]|Snowflake[]} roles The roles or role IDs to apply
-   * @param {string} reason Reason for applying the roles
+   * @param {string} [reason] Reason for applying the roles
    * @returns {Promise<GuildMember>}
    */
   setRoles(roles, reason) {
@@ -395,7 +395,7 @@ class GuildMember {
   /**
    * Adds a single role to the member.
    * @param {Role|Snowflake} role The role or ID of the role to add
-   * @param {string} reason Reason for adding the role
+   * @param {string} [reason] Reason for adding the role
    * @returns {Promise<GuildMember>}
    */
   addRole(role, reason) {
@@ -410,7 +410,7 @@ class GuildMember {
   /**
    * Adds multiple roles to the member.
    * @param {Collection<Snowflake, Role>|Role[]|Snowflake[]} roles The roles or role IDs to add
-   * @param {string} reason Reason for adding the roles
+   * @param {string} [reason] Reason for adding the roles
    * @returns {Promise<GuildMember>}
    */
   addRoles(roles, reason) {
@@ -427,7 +427,7 @@ class GuildMember {
   /**
    * Removes a single role from the member.
    * @param {Role|Snowflake} role The role or ID of the role to remove
-   * @param {string} reason Reason for removing the role
+   * @param {string} [reason] Reason for removing the role
    * @returns {Promise<GuildMember>}
    */
   removeRole(role, reason) {
@@ -441,7 +441,7 @@ class GuildMember {
   /**
    * Removes multiple roles from the member.
    * @param {Collection<Snowflake, Role>|Role[]|Snowflake[]} roles The roles or role IDs to remove
-   * @param {string} reason Reason for removing the roles
+   * @param {string} [reason] Reason for removing the roles
    * @returns {Promise<GuildMember>}
    */
   removeRoles(roles, reason) {
@@ -463,7 +463,7 @@ class GuildMember {
   /**
    * Set the nickname for the guild member.
    * @param {string} nick The nickname for the guild member
-   * @param {string} reason Reason for setting the nickname
+   * @param {string} [reason] Reason for setting the nickname
    * @returns {Promise<GuildMember>}
    */
   setNickname(nick, reason) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Just a small enhancement that has been requested a couple of times.

Allows things like: ``someMember.addRole('someId', 'someReason');``
Instead of something like this:
```js
const roles = someMember.roles.map(r => r.id);
roles.push('someId');
someMember.edit({ roles }, 'someReason');
```

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
