### PR TITLE
check guild availability when aggregating client emojis

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -245,7 +245,7 @@ class Client extends EventEmitter {
   get emojis() {
     const emojis = new Collection();
     for (const guild of this.guilds.values()) {
-      for (const emoji of guild.emojis.values()) emojis.set(emoji.id, emoji);
+      if (guild.available) for (const emoji of guild.emojis.values()) emojis.set(emoji.id, emoji);
     }
     return emojis;
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Accessing `client.emojis` would throw an error if any guilds were unavailable.  This will check to make sure a guild is available before accessing its emojis.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
