### PR TITLE
Fix Guild#createRole with position

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -911,6 +911,7 @@ class Guild {
 
   /**
    * Creates a new role in the guild with given information
+   * <warn>The position will silently reset to 1 if an invalid one is provided, or none.</warn>
    * @param {Object} [options] Options
    * @param {RoleData} [options.data] The data to update the role with
    * @param {string} [options.reason] Reason for creating this role
@@ -937,10 +938,10 @@ class Guild {
     if (data.permissions) data.permissions = Permissions.resolve(data.permissions);
 
     return this.client.api.guilds(this.id).roles.post({ data, reason }).then(r => {
-      const role = this.client.actions.GuildRoleCreate.handle({
+      const { role } = this.client.actions.GuildRoleCreate.handle({
         guild_id: this.id,
         role: r,
-      }).role;
+      });
       if (data.position) {
         role.setPosition(data.position, reason);
         role.position = data.position;

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -942,10 +942,7 @@ class Guild {
         guild_id: this.id,
         role: r,
       });
-      if (data.position) {
-        role.setPosition(data.position, reason);
-        role.position = data.position;
-      }
+      if (data.position) return role.setPosition(data.position, reason);
       return role;
     });
   }

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -936,12 +936,17 @@ class Guild {
     if (data.color) data.color = Util.resolveColor(data.color);
     if (data.permissions) data.permissions = Permissions.resolve(data.permissions);
 
-    return this.client.api.guilds(this.id).roles.post({ data, reason }).then(role =>
-      this.client.actions.GuildRoleCreate.handle({
+    return this.client.api.guilds(this.id).roles.post({ data, reason }).then(r => {
+      const role = this.client.actions.GuildRoleCreate.handle({
         guild_id: this.id,
-        role,
-      }).role
-    );
+        role: r,
+      }).role;
+      if (data.position) {
+        role.setPosition(data.position, reason);
+        role.position = data.position;
+      }
+      return role;
+    });
   }
 
   /**

--- a/src/structures/Role.js
+++ b/src/structures/Role.js
@@ -269,6 +269,9 @@ class Role {
    *  .catch(console.error);
    */
   setPosition(position, relative) {
+    if (position < 1 || position >= this.guild.me.highestRole.position) {
+      return Promise.reject(new RangeError('Invalid position.'));
+    }
     return this.guild.setRolePosition(this, position, relative).then(() => this);
   }
 

--- a/src/structures/Role.js
+++ b/src/structures/Role.js
@@ -269,9 +269,6 @@ class Role {
    *  .catch(console.error);
    */
   setPosition(position, relative) {
-    if (position < 1 || position >= this.guild.me.highestRole.position) {
-      return Promise.reject(new RangeError('Invalid position.'));
-    }
     return this.guild.setRolePosition(this, position, relative).then(() => this);
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This fixes an issue with Guild#createRole where you could supply a permission (according to the docs), but it would not reflect in Discord. The role would be created, but the position would sort itself at the bottom, as you cannot create a role and set its position at the same time.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
- [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.