### PR TITLE
fix sequential and burst ratelimiters from going on timeout because the queue is empty

### DIFF
--- a/src/client/rest/handlers/RequestHandler.js
+++ b/src/client/rest/handlers/RequestHandler.js
@@ -14,7 +14,7 @@ class RequestHandler {
   }
 
   get limited() {
-    return this.queue.length === 0 || this.manager.globallyRateLimited || this.remaining <= 0;
+    return this.manager.globallyRateLimited || this.remaining <= 0;
   }
 
   set globallyLimited(limited) {

--- a/src/client/rest/handlers/burst.js
+++ b/src/client/rest/handlers/burst.js
@@ -1,5 +1,5 @@
 module.exports = function burst() {
-  if (this.limited) return;
+  if (this.limited || this.queue.length === 0) return;
   this.execute(this.queue.shift())
     .then(this.handle.bind(this))
     .catch(({ timeout }) => {

--- a/src/client/rest/handlers/sequential.js
+++ b/src/client/rest/handlers/sequential.js
@@ -1,5 +1,5 @@
 module.exports = function sequential() {
-  if (this.busy || this.limited) return;
+  if (this.busy || this.limited || this.queue.length === 0) return;
   this.busy = true;
   this.execute(this.queue.shift())
     .then(() => {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
If the Request Handler queue was empty, this.limited was true, putting everything on cooldown until the x-ratelimit-reset time was fulfilled. This removes the check if the queue was empty from this.limited, and puts that check in the sequential/burst handlers, so that you may continue to request until you have no x-ratelimit-remaining left, or until you are globally rate limited. Whichever comes first.

**Semantic versioning classification:**  Patch
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
