### PR TITLE
fix node.js crash due to error messages being called with invalid error keys

### DIFF
--- a/src/client/voice/VoiceWebSocket.js
+++ b/src/client/voice/VoiceWebSocket.js
@@ -65,7 +65,7 @@ class VoiceWebSocket extends EventEmitter {
     if (this.dead) return;
     if (this.ws) this.reset();
     if (this.attempts >= 5) {
-      this.emit('debug', new Error(`Too many connection attempts (${this.attempts}).`));
+      this.emit('debug', new Error(`Too many connection attempts (${this.attempts}).`)); // This line of code crashes node.js because the string is not recognized as a valid error key
       return;
     }
 

--- a/src/client/voice/VoiceWebSocket.js
+++ b/src/client/voice/VoiceWebSocket.js
@@ -65,7 +65,7 @@ class VoiceWebSocket extends EventEmitter {
     if (this.dead) return;
     if (this.ws) this.reset();
     if (this.attempts >= 5) {
-      this.emit('debug', new Error('VOICE_CONNECTION_ATTEMPTS_EXCEEDED', this.attempts)); 
+      this.emit('debug', new Error('VOICE_CONNECTION_ATTEMPTS_EXCEEDED', this.attempts));
       return;
     }
 

--- a/src/client/voice/VoiceWebSocket.js
+++ b/src/client/voice/VoiceWebSocket.js
@@ -123,7 +123,7 @@ class VoiceWebSocket extends EventEmitter {
         session_id: this.voiceConnection.authentication.sessionID,
       },
     }).catch(() => {
-      this.emit('error', new Error('WS_JOIN_NOT_OPEN'));
+      this.emit('error', new Error('VOICE_JOIN_SOCKET_CLOSED'));
     });
   }
 

--- a/src/client/voice/VoiceWebSocket.js
+++ b/src/client/voice/VoiceWebSocket.js
@@ -123,7 +123,7 @@ class VoiceWebSocket extends EventEmitter {
         session_id: this.voiceConnection.authentication.sessionID,
       },
     }).catch(() => {
-      this.emit('error', new Error('Tried to send join packet, but the WebSocket is not open.'));
+      this.emit('error', new Error('WS_JOIN_NOT_OPEN'));
     });
   }
 
@@ -204,7 +204,7 @@ class VoiceWebSocket extends EventEmitter {
    */
   setHeartbeat(interval) {
     if (!interval || isNaN(interval)) {
-      this.onError(new Error('Tried to set voice heartbeat but no valid interval was specified.'));
+      this.onError(new Error('VOICE_INVALID_HEARTBEAT'));
       return;
     }
     if (this.heartbeatInterval) {

--- a/src/client/voice/VoiceWebSocket.js
+++ b/src/client/voice/VoiceWebSocket.js
@@ -65,7 +65,7 @@ class VoiceWebSocket extends EventEmitter {
     if (this.dead) return;
     if (this.ws) this.reset();
     if (this.attempts >= 5) {
-      this.emit('debug', new Error(`Too many connection attempts (${this.attempts}).`)); // This line of code crashes node.js because the string is not recognized as a valid error key
+      this.emit('debug', new Error('VOICE_CONNECTION_ATTEMPTS_EXCEEDED', this.attempts)); 
       return;
     }
 

--- a/src/errors/DJSError.js
+++ b/src/errors/DJSError.js
@@ -11,7 +11,7 @@ const util = require('util');
  * @returns {DiscordjsError}
  */
 function makeDiscordjsError(Base) {
-  return class DiscordjsError extends Base {
+  return class DiscordjsError extends Base { // IF an error is created and the key has not been registered node.js crashes
     constructor(key, ...args) {
       super(message(key, args));
       this[kCode] = key;
@@ -37,7 +37,7 @@ function makeDiscordjsError(Base) {
 function message(key, args) {
   assert.strictEqual(typeof key, 'string');
   const msg = messages.get(key);
-  assert(msg, `An invalid error message key was used: ${key}.`);
+  assert(msg, `An invalid error message key was used: ${key}.`); // If the key is not found this crashes node.js
   let fmt = util.format;
   if (typeof msg === 'function') {
     fmt = msg;

--- a/src/errors/DJSError.js
+++ b/src/errors/DJSError.js
@@ -11,7 +11,7 @@ const util = require('util');
  * @returns {DiscordjsError}
  */
 function makeDiscordjsError(Base) {
-  return class DiscordjsError extends Base { 
+  return class DiscordjsError extends Base {
     constructor(key, ...args) {
       super(message(key, args));
       this[kCode] = key;

--- a/src/errors/DJSError.js
+++ b/src/errors/DJSError.js
@@ -11,7 +11,7 @@ const util = require('util');
  * @returns {DiscordjsError}
  */
 function makeDiscordjsError(Base) {
-  return class DiscordjsError extends Base { // IF an error is created and the key has not been registered node.js crashes
+  return class DiscordjsError extends Base { 
     constructor(key, ...args) {
       super(message(key, args));
       this[kCode] = key;
@@ -37,7 +37,7 @@ function makeDiscordjsError(Base) {
 function message(key, args) {
   assert.strictEqual(typeof key, 'string');
   const msg = messages.get(key);
-  assert(msg, `An invalid error message key was used: ${key}.`); // If the key is not found this crashes node.js
+  assert(msg, `An invalid error message key was used: ${key}.`);
   let fmt = util.format;
   if (typeof msg === 'function') {
     fmt = msg;

--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -12,6 +12,7 @@ const Messages = {
   WS_BAD_MESSAGE: 'A bad message was received from the websocket; either bad compression, or not JSON.',
   WS_CONNECTION_EXISTS: 'There is already an existing WebSocket connection.',
   WS_NOT_OPEN: (data = 'data') => `Websocket not open to send ${data}`,
+  WS_JOIN_NOT_OPEN: 'Tried to send join packet, but the WebSocket is not open.',
 
   PERMISSION_INVALID: 'Invalid permission string or number.',
 

--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -12,7 +12,6 @@ const Messages = {
   WS_BAD_MESSAGE: 'A bad message was received from the websocket; either bad compression, or not JSON.',
   WS_CONNECTION_EXISTS: 'There is already an existing WebSocket connection.',
   WS_NOT_OPEN: (data = 'data') => `Websocket not open to send ${data}`,
-  WS_JOIN_NOT_OPEN: 'Tried to send join packet, but the WebSocket is not open.',
 
   PERMISSION_INVALID: 'Invalid permission string or number.',
 
@@ -55,6 +54,7 @@ const Messages = {
   VOICE_INVALID_ENDPOINT: 'Invalid endpoint received.',
   VOICE_NO_BROWSER: 'Voice connections are not available in browsers.',
   VOICE_CONNECTION_ATTEMPTS_EXCEEDED: attempts => `Too many connection attempts (${attempts}).`,
+  VOICE_JOIN_SOCKET_CLOSED: 'Tried to send join packet, but the WebSocket is not open.',
 
   OPUS_ENGINE_MISSING: 'Couldn\'t find an Opus engine.',
 

--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -53,6 +53,7 @@ const Messages = {
   VOICE_SESSION_ABSENT: 'Session ID not supplied.',
   VOICE_INVALID_ENDPOINT: 'Invalid endpoint received.',
   VOICE_NO_BROWSER: 'Voice connections are not available in browsers.',
+  VOICE_CONNECTION_ATTEMPTS_EXCEEDED: attempts => `Too many connection attempts (${attempts}).`,
 
   OPUS_ENGINE_MISSING: 'Couldn\'t find an Opus engine.',
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The VoiceWebSockets.js file uses the error message constructor incorrectly in 3 cases. The constructor is called with an invalid key that causes an AssertionError which crashes node.js. I added two new error message keys and replaced the error messages with the keys accordingly. This will allow the error messages to be created normally without causing an AssertionError.


**Semantic versioning classification:** Patch
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
