### PR TITLE
Use uws instead of ws for websockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ For production bots, using node-opus should be considered a necessity, especiall
 - One of the following packages can be installed for faster voice packet encryption and decryption:
     - [sodium](https://www.npmjs.com/package/sodium) (`npm install sodium --save`)
     - [libsodium.js](https://www.npmjs.com/package/libsodium-wrappers) (`npm install libsodium-wrappers --save`)
-- [uws](https://www.npmjs.com/package/uws) for a much faster WebSocket connection (`npm install uws --save`)
 
 ## Example usage
 ```js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord.js",
-  "version": "12.0.0-dev",
+  "version": "12.0.1-dev",
   "description": "A powerful library for interacting with the Discord API",
   "main": "./src/index",
   "types": "./typings/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
   "dependencies": {
     "long": "^3.2.0",
     "prism-media": "^0.0.1",
-    "snekfetch": "^3.2.0",
+    "snekfetch": "^3.2.4",
     "tweetnacl": "^1.0.0",
-    "ws": "^3.0.0"
+    "uws": "^8.14.0"
   },
   "peerDependencies": {
     "bufferutil": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord.js",
-  "version": "12.0.1-dev",
+  "version": "12.0.0-dev",
   "description": "A powerful library for interacting with the Discord API",
   "main": "./src/index",
   "types": "./typings/index.d.ts",

--- a/src/client/voice/VoiceWebSocket.js
+++ b/src/client/voice/VoiceWebSocket.js
@@ -3,12 +3,7 @@ const SecretKey = require('./util/SecretKey');
 const EventEmitter = require('events');
 const { Error } = require('../../errors');
 
-let WebSocket;
-try {
-  WebSocket = require('uws');
-} catch (err) {
-  WebSocket = require('ws');
-}
+const WebSocket = require('uws');
 
 /**
  * Represents a Voice Connection's WebSocket.

--- a/src/client/websocket/WebSocketConnection.js
+++ b/src/client/websocket/WebSocketConnection.js
@@ -15,11 +15,7 @@ const erlpack = (function findErlpack() {
 
 const WebSocket = (function findWebSocket() {
   if (browser) return window.WebSocket; // eslint-disable-line no-undef
-  try {
-    return require('uws');
-  } catch (e) {
-    return require('ws');
-  }
+  return require('uws');
 }());
 
 /**


### PR DESCRIPTION
## Description

This pull request makes `[uws](https://npmjs.com/package/uws)` the default websockets module instead of `[ws](https://npmjs.com/package/ws)`.

## Why?

Not only does `[uws](https://npmjs.com/package/uws)` have fewer dependencies, but it is a lot faster.

## Semantic versioning classification

- This pull request does not cause any changes visible to the developer
- Minor version incremented in `package.json`