### PR TITLE
Add Attachment structure

### DIFF
--- a/src/client/ClientDataResolver.js
+++ b/src/client/ClientDataResolver.js
@@ -230,9 +230,9 @@ class ClientDataResolver {
           .catch(() => {
             if (resource.pipe && typeof resource.pipe === 'function') {
               const buffers = [];
-              resource.on('error', reject);
+              resource.once('error', reject);
               resource.on('data', data => buffers.push(data));
-              resource.on('end', () => resolve(Buffer.concat(buffers)));
+              resource.once('end', () => resolve(Buffer.concat(buffers)));
             } else {
               reject(new TypeError('REQ_RESOURCE_TYPE'));
             }

--- a/src/client/ClientDataResolver.js
+++ b/src/client/ClientDataResolver.js
@@ -216,6 +216,26 @@ class ClientDataResolver {
   }
 
   /**
+   * Converts a Stream to a Buffer.
+   * @param {Stream} resource The stream to convert
+   * @returns {Promise<Buffer>}
+   */
+  resolveFile(resource) {
+    return new Promise((resolve, reject) => {
+      this.resolveBuffer(resource)
+        .then(result => resolve(result))
+        .catch(() => {
+          if (resource.pipe && typeof resource.pipe === 'function') {
+            const buffers = [];
+            resource.on('error', reject);
+            resource.on('data', data => buffers.push(data));
+            resource.on('end', () => resolve(Buffer.concat(buffers)));
+          } else { reject(new TypeError('REQ_RESOURCE_TYPE')); }
+        });
+    });
+  }
+
+  /**
    * Data that can be resolved to give an emoji identifier. This can be:
    * * The unicode representation of an emoji
    * * A custom emoji ID

--- a/src/client/ClientDataResolver.js
+++ b/src/client/ClientDataResolver.js
@@ -222,7 +222,9 @@ class ClientDataResolver {
    */
   resolveFile(resource) {
     return new Promise((resolve, reject) => {
-      if (!resource) { reject(new TypeError('REQ_RESOURCE_TYPE')); } else {
+      if (!resource) {
+        reject(new TypeError('REQ_RESOURCE_TYPE'));
+      } else {
         this.resolveBuffer(resource)
           .then(result => resolve(result))
           .catch(() => {

--- a/src/client/ClientDataResolver.js
+++ b/src/client/ClientDataResolver.js
@@ -222,16 +222,18 @@ class ClientDataResolver {
    */
   resolveFile(resource) {
     return new Promise((resolve, reject) => {
-      this.resolveBuffer(resource)
-        .then(result => resolve(result))
-        .catch(() => {
-          if (resource.pipe && typeof resource.pipe === 'function') {
-            const buffers = [];
-            resource.on('error', reject);
-            resource.on('data', data => buffers.push(data));
-            resource.on('end', () => resolve(Buffer.concat(buffers)));
-          } else { reject(new TypeError('REQ_RESOURCE_TYPE')); }
-        });
+      if (!resource) { reject(new TypeError('REQ_RESOURCE_TYPE')); } else {
+        this.resolveBuffer(resource)
+          .then(result => resolve(result))
+          .catch(() => {
+            if (resource.pipe && typeof resource.pipe === 'function') {
+              const buffers = [];
+              resource.on('error', reject);
+              resource.on('data', data => buffers.push(data));
+              resource.on('end', () => resolve(Buffer.concat(buffers)));
+            } else { reject(new TypeError('REQ_RESOURCE_TYPE')); }
+          });
+      }
     });
   }
 

--- a/src/client/ClientDataResolver.js
+++ b/src/client/ClientDataResolver.js
@@ -226,14 +226,16 @@ class ClientDataResolver {
         reject(new TypeError('REQ_RESOURCE_TYPE'));
       } else {
         this.resolveBuffer(resource)
-          .then(result => resolve(result))
+          .then(resolve)
           .catch(() => {
             if (resource.pipe && typeof resource.pipe === 'function') {
               const buffers = [];
               resource.on('error', reject);
               resource.on('data', data => buffers.push(data));
               resource.on('end', () => resolve(Buffer.concat(buffers)));
-            } else { reject(new TypeError('REQ_RESOURCE_TYPE')); }
+            } else {
+              reject(new TypeError('REQ_RESOURCE_TYPE'));
+            }
           });
       }
     });

--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -60,9 +60,6 @@ const Messages = {
   UDP_ADDRESS_MALFORMED: 'Malformed UDP address or port.',
   UDP_CONNECTION_EXISTS: 'There is already an existing UDP connection.',
 
-  ATTACHMENT_NO_FILE: 'There is no attachment file specified.',
-  ATTACHMENT_INVALID: 'The array of attachments is invalid.',
-
   REQ_BODY_TYPE: 'The response body isn\'t a Buffer.',
   REQ_RESOURCE_TYPE: 'The resource must be a string, Buffer or a valid file stream.',
 

--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -60,8 +60,11 @@ const Messages = {
   UDP_ADDRESS_MALFORMED: 'Malformed UDP address or port.',
   UDP_CONNECTION_EXISTS: 'There is already an existing UDP connection.',
 
+  ATTACHMENT_NO_FILE: 'There is no attachment file specified.',
+  ATTACHMENT_INVALID: 'The array of attachments is invalid.',
+
   REQ_BODY_TYPE: 'The response body isn\'t a Buffer.',
-  REQ_RESOURCE_TYPE: 'The resource must be a string or Buffer.',
+  REQ_RESOURCE_TYPE: 'The resource must be a string, Buffer or a valid file stream.',
 
   IMAGE_FORMAT: format => `Invalid image format: ${format}`,
   IMAGE_SIZE: size => `Invalid image size: ${size}`,

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,7 @@ module.exports = {
   splitMessage: Util.splitMessage,
 
   // Structures
+  Attachment: require('./structures/Attachment'),
   Channel: require('./structures/Channel'),
   ClientUser: require('./structures/ClientUser'),
   ClientUserSettings: require('./structures/ClientUserSettings'),

--- a/src/structures/Attachment.js
+++ b/src/structures/Attachment.js
@@ -1,12 +1,11 @@
 const { resolveString } = require('../util/Util');
-const { TypeError } = require('../errors');
 
 /**
  * Represents an attachment in a message
  */
 class Attachment {
   constructor(file, name) {
-    this.files = [];
+    this.file = {};
     this._attach(file, name);
   }
 
@@ -15,15 +14,15 @@ class Attachment {
     * @type {?string}
     */
   get name() {
-    return this.files[0] ? this.files[0].name : null;
+    return this.file.name;
   }
 
   /**
     * The file
     * @type {?BufferResolvable|Stream}
     */
-  get file() {
-    return this.files[0] ? this.files[0].attachment : null;
+  get attachment() {
+    return this.file.attachment;
   }
 
   /**
@@ -33,9 +32,9 @@ class Attachment {
     * @returns {Attachment} This attachment
     */
   setAttachment(file, name) {
-    if (!file) throw new TypeError('ATTACHMENT_NO_FILE');
-    this.files = [];
-    this._attach(file, name);
+    this.file = {};
+    this.file.attachment = file;
+    this.file.name = name ? resolveString(name) : name;
     return this;
   }
 
@@ -45,8 +44,7 @@ class Attachment {
     * @returns {Attachment} This attachment
     */
   setFile(attachment) {
-    if (!this.files.length) this.files = [{ attachment, name: null }];
-    else this.files[0].attachment = attachment;
+    this.file.attachment = attachment;
     return this;
   }
 
@@ -56,8 +54,7 @@ class Attachment {
     * @returns {Attachment} This attachment
     */
   setName(name) {
-    if (!this.files.length) this.files = [{ attachment: null, name: resolveString(name) }];
-    else this.files[0].name = name;
+    this.file.name = name ? resolveString(name) : name;
     return this;
   }
 
@@ -69,8 +66,11 @@ class Attachment {
     */
   _attach(file, name) {
     if (file) {
-      if (typeof file === 'string') this.files.push(resolveString(file));
-      else this.files.push({ attachment: file, name: name ? resolveString(name) : null });
+      if (typeof file === 'string') {
+        this.file = resolveString(file);
+      } else {
+        this.setAttachment(file, name);
+      }
     }
   }
 }

--- a/src/structures/Attachment.js
+++ b/src/structures/Attachment.js
@@ -1,0 +1,77 @@
+const { resolveString } = require('../util/Util');
+const { TypeError } = require('../errors');
+
+/**
+ * Represents an attachment in a message
+ */
+class Attachment {
+  constructor(file, name) {
+    this.files = [];
+    this._attach(file, name);
+  }
+
+  /**
+    * The name of the file
+    * @type {?string}
+    */
+  get name() {
+    return this.files[0] ? this.files[0].name : null;
+  }
+
+  /**
+    * The file
+    * @type {?BufferResolvable|Stream}
+    */
+  get file() {
+    return this.files[0] ? this.files[0].attachment : null;
+  }
+
+  /**
+    * Set the file of this attachment.
+    * @param {BufferResolvable|Stream} file The file
+	* @param {string} name The name of the file
+    * @returns {Attachment} This attachment
+    */
+  setAttachment(file, name) {
+    if (!file) throw new TypeError('ATTACHMENT_NO_FILE');
+    this.files = [];
+    this._attach(file, name);
+    return this;
+  }
+
+  /**
+    * Set the file of this attachment.
+    * @param {BufferResolvable|Stream} attachment The file
+    * @returns {Attachment} This attachment
+    */
+  setFile(attachment) {
+    if (!this.files.length) this.files = [{ attachment, name: null }];
+    else this.files[0].attachment = attachment;
+    return this;
+  }
+
+  /**
+    * Set the name of this attachment.
+    * @param {string} name The name of the image
+    * @returns {Attachment} This attachment
+    */
+  setName(name) {
+    if (!this.files.length) this.files = [{ attachment: null, name: resolveString(name) }];
+    else this.files[0].name = name;
+    return this;
+  }
+
+  /**
+    * Set the file of this attachment.
+    * @param {BufferResolvable|Stream} file The file
+    * @param {string} name The name of the file
+    */
+  _attach(file, name) {
+    if (file) {
+      if (typeof file === 'string') this.files.push(resolveString(file));
+      else this.files.push({ attachment: file, name: name ? resolveString(name) : null });
+    }
+  }
+}
+
+module.exports = Attachment;

--- a/src/structures/Attachment.js
+++ b/src/structures/Attachment.js
@@ -10,6 +10,7 @@ class Attachment {
   /**
     * The name of the file
     * @type {?string}
+	  * @readonly
     */
   get name() {
     return this.file.name;
@@ -18,6 +19,7 @@ class Attachment {
   /**
     * The file
     * @type {?BufferResolvable|Stream}
+    * @readonly
     */
   get attachment() {
     return this.file.attachment;

--- a/src/structures/Attachment.js
+++ b/src/structures/Attachment.js
@@ -29,7 +29,7 @@ class Attachment {
   /**
     * Set the file of this attachment.
     * @param {BufferResolvable|Stream} file The file
-	* @param {string} name The name of the file
+    * @param {string} name The name of the file
     * @returns {Attachment} This attachment
     */
   setAttachment(file, name) {
@@ -65,6 +65,7 @@ class Attachment {
     * Set the file of this attachment.
     * @param {BufferResolvable|Stream} file The file
     * @param {string} name The name of the file
+    * @private
     */
   _attach(file, name) {
     if (file) {

--- a/src/structures/Attachment.js
+++ b/src/structures/Attachment.js
@@ -10,7 +10,7 @@ class Attachment {
   /**
     * The name of the file
     * @type {?string}
-	  * @readonly
+    * @readonly
     */
   get name() {
     return this.file.name;

--- a/src/structures/Attachment.js
+++ b/src/structures/Attachment.js
@@ -1,11 +1,9 @@
-const { resolveString } = require('../util/Util');
-
 /**
  * Represents an attachment in a message
  */
 class Attachment {
   constructor(file, name) {
-    this.file = {};
+    this.file = null;
     this._attach(file, name);
   }
 
@@ -32,9 +30,7 @@ class Attachment {
     * @returns {Attachment} This attachment
     */
   setAttachment(file, name) {
-    this.file = {};
-    this.file.attachment = file;
-    this.file.name = name ? resolveString(name) : name;
+    this.file = { attachment: file, name };
     return this;
   }
 
@@ -54,7 +50,7 @@ class Attachment {
     * @returns {Attachment} This attachment
     */
   setName(name) {
-    this.file.name = name ? resolveString(name) : name;
+    this.file.name = name;
     return this;
   }
 
@@ -66,11 +62,8 @@ class Attachment {
     */
   _attach(file, name) {
     if (file) {
-      if (typeof file === 'string') {
-        this.file = resolveString(file);
-      } else {
-        this.setAttachment(file, name);
-      }
+      if (typeof file === 'string') this.file = file;
+      else this.setAttachment(file, name);
     }
   }
 }

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -138,7 +138,7 @@ class MessageEmbed {
 	*/
     this.files = data.files ?
       data.files.every(file => file instanceof Attachment) ?
-        data.files.map(item => item.files[0]) : data.files : null;
+        data.files.map(item => item.file) : data.files : null;
   }
 
   /**
@@ -194,7 +194,7 @@ class MessageEmbed {
   attachFiles(files) {
     if (this.files) this.files = this.files.concat(files);
     else this.files = files;
-    if (files.every(file => file instanceof Attachment)) this.files = files.map(item => item.files[0]);
+    if (files.every(file => file instanceof Attachment)) this.files = files.map(item => item.file);
     return this;
   }
 

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -300,6 +300,7 @@ class MessageEmbed {
   /**
    * Transforms the embed object to be processed.
    * @returns {Object} The raw data of this embed
+   * @private
    */
   _apiTransform() {
     return {

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -1,3 +1,4 @@
+const Attachment = require('./Attachment');
 const Util = require('../util/Util');
 const { RangeError } = require('../errors');
 
@@ -129,6 +130,15 @@ class MessageEmbed {
       iconURL: data.footer.iconURL || data.footer.icon_url,
       proxyIconURL: data.footer.proxyIconURL || data.footer.proxy_icon_url,
     } : null;
+
+    /**
+	* The files of this embed
+	* @type {?Object}
+	* @property {Array<FileOptions|string|Attachment>} files Files to attach
+	*/
+    this.files = data.files ?
+      data.files.every(file => file instanceof Attachment) ?
+        data.files.map(item => item.files[0]) : data.files : null;
   }
 
   /**
@@ -178,12 +188,13 @@ class MessageEmbed {
   /**
    * Sets the file to upload alongside the embed. This file can be accessed via `attachment://fileName.extension` when
    * setting an embed image or author/footer icons. Only one file may be attached.
-   * @param {Array<FileOptions|string>} files Files to attach
+   * @param {Array<FileOptions|string|Attachment>} files Files to attach
    * @returns {MessageEmbed} This embed
    */
   attachFiles(files) {
     if (this.files) this.files = this.files.concat(files);
     else this.files = files;
+    if (files.every(file => file instanceof Attachment)) this.files = files.map(item => item.files[0]);
     return this;
   }
 
@@ -286,6 +297,10 @@ class MessageEmbed {
     return this;
   }
 
+  /**
+   * Transforms the embed object to be processed.
+   * @returns {Object} The raw data of this embed
+   */
   _apiTransform() {
     return {
       title: this.title,

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -136,9 +136,11 @@ class MessageEmbed {
 	* @type {?Object}
 	* @property {Array<FileOptions|string|Attachment>} files Files to attach
 	*/
-    this.files = data.files ?
-      data.files.every(file => file instanceof Attachment) ?
-        data.files.map(item => item.file) : data.files : null;
+    if (data.files) {
+      for (let file of data.files) {
+        if (file instanceof Attachment) file = file.file;
+      }
+    } else { data.files = null; }
   }
 
   /**
@@ -194,7 +196,9 @@ class MessageEmbed {
   attachFiles(files) {
     if (this.files) this.files = this.files.concat(files);
     else this.files = files;
-    if (files.every(file => file instanceof Attachment)) this.files = files.map(item => item.file);
+    for (let file of files) {
+      if (file instanceof Attachment) file = file.file;
+    }
     return this;
   }
 

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -82,7 +82,7 @@ class Webhook {
    * (see [here](https://discordapp.com/developers/docs/resources/channel#embed-object) for more details)
    * @property {boolean} [disableEveryone=this.client.options.disableEveryone] Whether or not @everyone and @here
    * should be replaced with plain-text
-   * @property {FileOptions|string} [file] A file to send with the message
+   * @property {FileOptions|BufferResolvable} [file] A file to send with the message
    * @property {FileOptions[]|string[]} [files] Files to send with the message
    * @property {string|boolean} [code] Language for optional codeblock formatting to apply
    * @property {boolean|SplitOptions} [split=false] Whether or not the message should be split into multiple messages if
@@ -135,7 +135,7 @@ class Webhook {
     if (options.files) {
       for (let i = 0; i < options.files.length; i++) {
         let file = options.files[i];
-        if (typeof file === 'string') file = { attachment: file };
+        if (typeof file === 'string' || Buffer.isBuffer(file)) file = { attachment: file };
         if (!file.name) {
           if (typeof file.attachment === 'string') {
             file.name = path.basename(file.attachment);

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -114,7 +114,6 @@ class Webhook {
     if (options instanceof MessageEmbed) options = { embeds: [options] };
     if (options.embed) options = { embeds: [options.embed] };
 
-
     if (content instanceof Array || options instanceof Array) {
       const which = content instanceof Array ? content : options;
       const attachments = which.filter(item => item instanceof Attachment);

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -74,7 +74,7 @@ class TextBasedChannel {
    *  .then(message => console.log(`Sent message: ${message.content}`))
    *  .catch(console.error);
    */
-  send(content, options) {
+  send(content, options) { // eslint-disable-line complexity
     if (!options && typeof content === 'object' && !(content instanceof Array)) {
       options = content;
       content = '';
@@ -109,7 +109,7 @@ class TextBasedChannel {
           } else if (file.attachment && file.attachment.path) {
             file.name = path.basename(file.attachment.path);
           } else if (file instanceof Attachment) {
-            file = { name: 'file.jpg', attachment: file.files[0] };
+            file = { name: path.basename(file.files[0]) || 'file.jpg', attachment: file.files[0] };
           } else { file.name = 'file.jpg'; }
         } else if (file instanceof Attachment) { file = file.files[0]; }
         options.files[i] = file;

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -83,18 +83,12 @@ class TextBasedChannel {
       options = {};
     }
 
-    if (options instanceof Attachment) {
-      if (!options.files[0] || !options.files[0].attachment) throw new TypeError('ATTACHMENT_NO_FILE');
-    }
-
-    if (content instanceof Array) {
-      const attachments = content.filter(item => item instanceof Attachment);
+    if (content instanceof Array || options instanceof Array) {
+      const which = content instanceof Array ? content : options;
+      const attachments = which.filter(item => item instanceof Attachment);
       if (attachments.length) {
-        if (!attachments.every(item => item && item.files[0] && item.files[0].attachment)) {
-          throw new TypeError('ATTACHMENT_INVALID');
-        }
         options.files = attachments.map(item => item.files[0]);
-        content = '';
+        if (content instanceof Array) content = '';
       }
     }
 
@@ -114,10 +108,10 @@ class TextBasedChannel {
             file.name = path.basename(file.attachment);
           } else if (file.attachment && file.attachment.path) {
             file.name = path.basename(file.attachment.path);
-          } else {
-            file.name = 'file.jpg';
-          }
-        }
+          } else if (file instanceof Attachment) {
+            file = { name: 'file.jpg', attachment: file.files[0] };
+          } else { file.name = 'file.jpg'; }
+        } else if (file instanceof Attachment) { file = file.files[0]; }
         options.files[i] = file;
       }
 

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -89,7 +89,7 @@ class TextBasedChannel {
       const which = content instanceof Array ? content : options;
       const attachments = which.filter(item => item instanceof Attachment);
       if (attachments.length) {
-        options.files = attachments;
+        options = { files: attachments };
         if (content instanceof Array) content = '';
       }
     }

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -4,6 +4,7 @@ const Shared = require('../shared');
 const Collection = require('../../util/Collection');
 const Snowflake = require('../../util/Snowflake');
 const Attachment = require('../../structures/Attachment');
+const MessageEmbed = require('../../structures/MessageEmbed');
 const { Error, RangeError, TypeError } = require('../../errors');
 
 /**
@@ -77,6 +78,7 @@ class TextBasedChannel {
     if (!options && typeof content === 'object' && !(content instanceof Array)) {
       options = content;
       content = '';
+      if (options instanceof MessageEmbed) options.embed = options;
     } else if (!options) {
       options = {};
     }
@@ -86,9 +88,14 @@ class TextBasedChannel {
     }
 
     if (content instanceof Array) {
-      if (!content.every(item => item && item.attachment)) throw new TypeError('ATTACHMENT_INVALID');
-      options.files = content.map(item => item.files[0]);
-      content = '';
+      const attachments = content.filter(item => item instanceof Attachment);
+      if (attachments.length) {
+        if (!attachments.every(item => item && item.files[0] && item.files[0].attachment)) {
+          throw new TypeError('ATTACHMENT_INVALID');
+        }
+        options.files = attachments.map(item => item.files[0]);
+        content = '';
+      }
     }
 
     if (!options.content) options.content = content;

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -110,7 +110,9 @@ class TextBasedChannel {
             file.name = path.basename(file.attachment.path);
           } else if (file instanceof Attachment) {
             file = { name: path.basename(file.files[0]) || 'file.jpg', attachment: file.files[0] };
-          } else { file.name = 'file.jpg'; }
+          } else {
+            file.name = 'file.jpg';
+          }
         } else if (file instanceof Attachment) { file = file.files[0]; }
         options.files[i] = file;
       }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Adding on to #1451,  I have added an attachment structure, which enables seamless integration of files into send parameters and into embed options, removing a lot of ugliness there once was when uploading even one file.

```js
const buffer = canvas.toBuffer();
// You can insert streams now.
const pngStream = canvas.createPNGStream();

message.channel.send('Buffer test', new Attachment(buffer, 'file.jpg'));
message.channel.send('PNGStream test', new Attachment(pngStream, 'file.png'));

// You can also provide a path.
message.channel.send(new Attachment('../dog.png'));

// You may provide a buffer without any name, which will be assumed to be 'file.jpg'.
message.channel.send(new Attachment(buffer));

// You may also provide an array of attachments
message.channel.send([new Attachment(buffer, 'file.jpg'), new Attachment(pngStream, 'file.png')]);

// In this case an error will be thrown as one of the attachments lacks a file and proper path.
message.channel.send([new Attachment(buffer, 'file.jpg'), new Attachment(pngStream, 'file.png'), new Attachment('some name')]);

// You can instantiate an embed in object literal notation or use some handy new methods.
let embed = new MessageEmbed().setTitle('Attachment').attachFiles([new Attachment(buffer, 'kek.jpg')]).setImage('attachment://kek.jpg');
embed = new MessageEmbed({ title: 'hey', files: [ new Attachment(buffer, 'kek.jpg') ], image: { url: 'attachment://kek.jpg' } });

// You can also send embeds directly now.
message.channel.send(new MessageEmbed().setTitle('eyy there'))

// Additionally, you may send both embed and files directly.
const files = [new Attachment(path.join(__dirname, '..', '..', 'assets', 'pngStream.png'))];
const embed = new MessageEmbed().setTitle(';)');
message.channel.send({ files, embed });

// Webhooks are now updated to be able to utilize all of the aforementioned features. Additionally, you can directly insert an array of embeds.
const hook = new WebhookClient('channelid', 'token');
const embed = new MessageEmbed().setDescription(':D').setColor('RED');
const files = [new Attachment('./assets/pngStream.png'), new Attachment(buffer, 'kek.jpg')];
hook.send(embed);
hook.send(new Attachment('./assets/pngStream.png'));
hook.send({ files, embed });
hook.send({ files, embeds: [embed, embed] });
```

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
- [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.