### PR TITLE
Fixed DiscordAPIError#message sometimes being undefined

### DIFF
--- a/src/client/rest/DiscordAPIError.js
+++ b/src/client/rest/DiscordAPIError.js
@@ -5,9 +5,9 @@
 class DiscordAPIError extends Error {
   constructor(path, error) {
     super();
-    const flattened = error.errors ? `\n${this.constructor.flattenErrors(error.errors).join('\n')}` : '';
+    const flattened = this.constructor.flattenErrors(error.errors || error).join('\n');
     this.name = 'DiscordAPIError';
-    this.message = `${error.message}${flattened}`;
+    this.message = error.message && flattened ? `${error.message}\n${flattened}` : error.message || flattened;
 
     /**
      * The path of the request relative to the HTTP endpoint
@@ -33,12 +33,15 @@ class DiscordAPIError extends Error {
     let messages = [];
 
     for (const [k, v] of Object.entries(obj)) {
+      if (k === 'message') continue;
       const newKey = key ? isNaN(k) ? `${key}.${k}` : `${key}[${k}]` : k;
 
       if (v._errors) {
         messages.push(`${newKey}: ${v._errors.map(e => e.message).join(' ')}`);
       } else if (v.code || v.message) {
         messages.push(`${v.code ? `${v.code}: ` : ''}${v.message}`.trim());
+      } else if (typeof v === 'string') {
+        messages.push(v);
       } else {
         messages = messages.concat(this.flattenErrors(v, newKey));
       }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes #1725 

Allows the errors to be under a different key than `errors`.

Note to #1554: 
This looks pretty much abandoned to me, as it is broken in its current state for almost a month now.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
