### PR TITLE
ClientUser Fixes

### DIFF
--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -95,7 +95,19 @@ class ClientUser extends User {
     }
   }
 
-  edit(data, password) {
+  edit(data, password, mfaCode) {
+    if (!this.bot) {
+      data.code = mfaCode;
+      data.password = password;
+    }
+
+    return this.client.api.users('@me').patch({ data })
+      .then(newData => {
+        this.client.token = newData.token;
+        return this.client.actions.UserUpdate.handle(newData).updated;
+      });
+
+    /* Old code
     const _data = {};
     _data.username = data.username || this.username;
     _data.avatar = this.client.resolver.resolveBase64(data.avatar);
@@ -107,7 +119,7 @@ class ClientUser extends User {
     }
 
     return this.client.api.users('@me').patch({ data })
-      .then(newData => this.client.actions.UserUpdate.handle(newData).updated);
+      .then(newData => this.client.actions.UserUpdate.handle(newData).updated);*/
   }
 
   /**
@@ -148,6 +160,7 @@ class ClientUser extends User {
    * <warn>This is only available when using a user account.</warn>
    * @param {string} newPassword New password to change to
    * @param {string} oldPassword Current password
+   * @param {string} mfaCode Timed MFA Code
    * @returns {Promise<ClientUser>}
    * @example
    * // Set password
@@ -155,8 +168,8 @@ class ClientUser extends User {
    *  .then(user => console.log('New password set!'))
    *  .catch(console.error);
    */
-  setPassword(newPassword, oldPassword) {
-    return this.edit({ password: newPassword }, oldPassword);
+  setPassword(newPassword, oldPassword, mfaCode) {
+    return this.edit({ new_password: newPassword }, oldPassword, mfaCode);
   }
 
   /**

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -148,7 +148,7 @@ class ClientUser extends User {
    * Changes the password for the client user's account.
    * <warn>This is only available when using a user account.</warn>
    * @param {string} newPassword New password to change to
-   * @param {?Object} options Options object containing either an MFA code, password or both.
+   * @param {(Object|string)} options Options object containing either an MFA code, password or both. Can be just a string for password
    * @param {string} [options.oldPassword] Current password
    * @param {string} [options.mfaCode] Timed MFA Code
    * @returns {Promise<ClientUser>}

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -106,20 +106,6 @@ class ClientUser extends User {
         this.client.token = newData.token;
         return this.client.actions.UserUpdate.handle(newData).updated;
       });
-
-    /* Old code
-    const _data = {};
-    _data.username = data.username || this.username;
-    _data.avatar = this.client.resolver.resolveBase64(data.avatar);
-
-    if (!this.bot) {
-      _data.email = data.email || this.email;
-      _data.password = password;
-      if (data.new_password) _data.new_password = data.newPassword;
-    }
-
-    return this.client.api.users('@me').patch({ data })
-      .then(newData => this.client.actions.UserUpdate.handle(newData).updated);*/
   }
 
   /**

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -148,8 +148,9 @@ class ClientUser extends User {
    * Changes the password for the client user's account.
    * <warn>This is only available when using a user account.</warn>
    * @param {string} newPassword New password to change to
+   * @param {?Object} options Options object containing either an MFA code, password or both.
    * @param {string} [options.oldPassword] Current password
-   * @param {string} [options.mfaCode] Timed MFA Code or Backup Code
+   * @param {string} [options.mfaCode] Timed MFA Code
    * @returns {Promise<ClientUser>}
    * @example
    * // Set password

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -95,12 +95,15 @@ class ClientUser extends User {
     }
   }
 
-  edit(data, password, mfaCode) {
+  edit(data, passcode) {
     if (!this.bot) {
-      data.code = mfaCode;
-      data.password = password;
+      if (typeof passcode !== 'object') {
+        data.password = passcode;
+      } else {
+        data.code = passcode.mfaCode;
+        data.password = passcode.password;
+      }
     }
-
     return this.client.api.users('@me').patch({ data })
       .then(newData => {
         this.client.token = newData.token;
@@ -145,8 +148,8 @@ class ClientUser extends User {
    * Changes the password for the client user's account.
    * <warn>This is only available when using a user account.</warn>
    * @param {string} newPassword New password to change to
-   * @param {string} oldPassword Current password
-   * @param {string} mfaCode Timed MFA Code
+   * @param {string} [options.oldPassword] Current password
+   * @param {string} [options.mfaCode] Timed MFA Code or Backup Code
    * @returns {Promise<ClientUser>}
    * @example
    * // Set password
@@ -154,8 +157,8 @@ class ClientUser extends User {
    *  .then(user => console.log('New password set!'))
    *  .catch(console.error);
    */
-  setPassword(newPassword, oldPassword, mfaCode) {
-    return this.edit({ new_password: newPassword }, oldPassword, mfaCode);
+  setPassword(newPassword, options) {
+    return this.edit({ new_password: newPassword }, { password: options.oldPassword, mfaCode: options.mfaCode });
   }
 
   /**

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -148,7 +148,8 @@ class ClientUser extends User {
    * Changes the password for the client user's account.
    * <warn>This is only available when using a user account.</warn>
    * @param {string} newPassword New password to change to
-   * @param {(Object|string)} options Options object containing either an MFA code, password or both. Can be just a string for password
+   * @param {Object|string} options Object containing an MFA code, password or both. 
+   * Can be just a string for the password.
    * @param {string} [options.oldPassword] Current password
    * @param {string} [options.mfaCode] Timed MFA Code
    * @returns {Promise<ClientUser>}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This fixes #1702 by correctly applying the password to the data object sent to the Discord API
This also fixes `<ClientUser>.setPassword` for MFA-enabled accounts by allowing the user to pass an MFA Code to the method
This also updates the token stored in `client.token` when any security related method is used on the clientUser


**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
