### PR TITLE
Fixes #1693

### DIFF
--- a/src/client/voice/player/AudioPlayer.js
+++ b/src/client/voice/player/AudioPlayer.js
@@ -77,6 +77,7 @@ class AudioPlayer extends EventEmitter {
       dispatcher.destroy('end');
     }
     this.currentStream = {};
+    this.streamingData.pausedTime = 0;
   }
 
   /**

--- a/src/client/voice/player/AudioPlayer.js
+++ b/src/client/voice/player/AudioPlayer.js
@@ -78,6 +78,7 @@ class AudioPlayer extends EventEmitter {
     }
     this.currentStream = {};
     this.streamingData.pausedTime = 0;
+    this.streamingData.timestamp = 0;
   }
 
   /**


### PR DESCRIPTION
Resets the pausedTime property to 0 when the current stream is destroyed.  #1693 


**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
