### PR TITLE
Fixed ClientUser#createGroupDM on user accounts and added some more GroupDMChannel stuff

### DIFF
--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -345,7 +345,6 @@ class ClientUser extends User {
    * An object containing either a user or access token, and an optional nickname.
    * @typedef {Object} GroupDMRecipientOptions
    * @property {UserResolvable} [user] User to add to the Group DM
-   * (only available if a user is creating the DM)
    * @property {string} [accessToken] Access token to use to add a user to the Group DM
    * (only available if a bot is creating the DM)
    * @property {string} [nick] Permanent nickname (only available if a bot is creating the DM)
@@ -365,7 +364,7 @@ class ClientUser extends User {
         if (r.nick) o[r.user ? r.user.id : r.id] = r.nick;
         return o;
       }, {}),
-    } : { recipients: recipients.map(u => this.client.resolver.resolveUserID(u)) };
+    } : { recipients: recipients.map(u => this.client.resolver.resolveUserID(u.user || u.id)) };
     return this.client.api.users('@me').channels.post({ data })
       .then(res => new GroupDMChannel(this.client, res));
   }

--- a/src/structures/GroupDMChannel.js
+++ b/src/structures/GroupDMChannel.js
@@ -135,7 +135,7 @@ class GroupDMChannel extends Channel {
     return this.client.api.channels[this.id].patch({
       data: {
         icon: data.icon,
-        name: name === null ? null : name.trim(),
+        name,
       },
       reason,
     }).then(() => this);
@@ -149,9 +149,11 @@ class GroupDMChannel extends Channel {
   setIcon(icon) {
     if (typeof icon === 'string' && icon.startsWith('data:')) {
       return this.edit({ icon });
+    } else if (!icon) {
+      return this.edit({ icon: null });
     } else {
-      return this.client.resolver.resolveBuffer(icon || Buffer.alloc(0))
-        .then(data => this.edit({ icon: this.client.resolver.resolveBase64(data) || null }));
+      return this.client.resolver.resolveBuffer(icon)
+        .then(data => this.edit({ icon: this.client.resolver.resolveBase64(data) }));
     }
   }
 
@@ -209,20 +211,20 @@ class GroupDMChannel extends Channel {
 
   // These are here only for documentation purposes - they are implemented by TextBasedChannel
   /* eslint-disable no-empty-function */
-  send() {}
-  fetchMessage() {}
-  fetchMessages() {}
-  fetchPinnedMessages() {}
-  search() {}
-  startTyping() {}
-  stopTyping() {}
-  get typing() {}
-  get typingCount() {}
-  createMessageCollector() {}
-  awaitMessages() {}
+  send() { }
+  fetchMessage() { }
+  fetchMessages() { }
+  fetchPinnedMessages() { }
+  search() { }
+  startTyping() { }
+  stopTyping() { }
+  get typing() { }
+  get typingCount() { }
+  createMessageCollector() { }
+  awaitMessages() { }
   // Doesn't work on Group DMs; bulkDelete() {}
-  acknowledge() {}
-  _cacheMessage() {}
+  acknowledge() { }
+  _cacheMessage() { }
 }
 
 TextBasedChannel.applyToClass(GroupDMChannel, true, ['bulkDelete']);

--- a/src/structures/GroupDMChannel.js
+++ b/src/structures/GroupDMChannel.js
@@ -1,6 +1,7 @@
 const Channel = require('./Channel');
 const TextBasedChannel = require('./interfaces/TextBasedChannel');
 const Collection = require('../util/Collection');
+const Constants = require('../util/Constants');
 
 /*
 { type: 3,
@@ -101,6 +102,18 @@ class GroupDMChannel extends Channel {
    */
   get owner() {
     return this.client.users.get(this.ownerID);
+  }
+
+  /**
+   * Gets the URL to this Group DM's icon
+   * @param {Object} [options={}] Options for the icon url
+   * @param {string} [options.format='webp'] One of `webp`, `png`, `jpg`
+   * @param {number} [options.size=128] One of `128`, '256', `512`, `1024`, `2048`
+   * @returns {?string}
+   */
+  iconURL({ format, size } = {}) {
+    if (!this.icon) return null;
+    return Constants.Endpoints.CDN(this.client.options.http.cdn).GDMIcon(this.id, this.icon, format, size);
   }
 
   /**

--- a/src/structures/GroupDMChannel.js
+++ b/src/structures/GroupDMChannel.js
@@ -142,7 +142,7 @@ class GroupDMChannel extends Channel {
   }
 
   /**
-   * Set a new icon for this Group DM.
+   * Sets a new icon for this Group DM.
    * @param {Base64Resolvable} icon The new icon of this Group DM
    * @returns {Promise<GroupDMChannel>}
    */

--- a/src/structures/GroupDMChannel.js
+++ b/src/structures/GroupDMChannel.js
@@ -131,11 +131,10 @@ class GroupDMChannel extends Channel {
    * @returns {Promise<GroupDMChannel>}
    */
   edit(data, reason) {
-    const name = data.name === null ? null : data.name || this.name;
     return this.client.api.channels[this.id].patch({
       data: {
         icon: data.icon,
-        name,
+        name: data.name === null ? null : data.name || this.name,
       },
       reason,
     }).then(() => this);

--- a/src/structures/GroupDMChannel.js
+++ b/src/structures/GroupDMChannel.js
@@ -210,20 +210,20 @@ class GroupDMChannel extends Channel {
 
   // These are here only for documentation purposes - they are implemented by TextBasedChannel
   /* eslint-disable no-empty-function */
-  send() { }
-  fetchMessage() { }
-  fetchMessages() { }
-  fetchPinnedMessages() { }
-  search() { }
-  startTyping() { }
-  stopTyping() { }
-  get typing() { }
-  get typingCount() { }
-  createMessageCollector() { }
-  awaitMessages() { }
+  send() {}
+  fetchMessage() {}
+  fetchMessages() {}
+  fetchPinnedMessages() {}
+  search() {}
+  startTyping() {}
+  stopTyping() {}
+  get typing() {}
+  get typingCount() {}
+  createMessageCollector() {}
+  awaitMessages() {}
   // Doesn't work on Group DMs; bulkDelete() {}
-  acknowledge() { }
-  _cacheMessage() { }
+  acknowledge() {}
+  _cacheMessage() {}
 }
 
 TextBasedChannel.applyToClass(GroupDMChannel, true, ['bulkDelete']);

--- a/src/structures/GroupDMChannel.js
+++ b/src/structures/GroupDMChannel.js
@@ -131,12 +131,28 @@ class GroupDMChannel extends Channel {
    * @returns {Promise<GroupDMChannel>}
    */
   edit(data, reason) {
+    const name = data.name === null ? null : data.name || this.name;
     return this.client.api.channels[this.id].patch({
       data: {
-        name: (data.name || this.name).trim(),
+        icon: data.icon,
+        name: name === null ? null : name.trim(),
       },
       reason,
     }).then(() => this);
+  }
+
+  /**
+   * Set a new icon for this Group DM.
+   * @param {Base64Resolvable} icon The new icon of this Group DM
+   * @returns {Promise<GroupDMChannel>}
+   */
+  setIcon(icon) {
+    if (typeof icon === 'string' && icon.startsWith('data:')) {
+      return this.edit({ icon });
+    } else {
+      return this.client.resolver.resolveBuffer(icon || Buffer.alloc(0))
+        .then(data => this.edit({ icon: this.client.resolver.resolveBase64(data) || null }));
+    }
   }
 
   /**

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -119,6 +119,10 @@ exports.Endpoints = {
         checkImage({ size, format });
         return `${root}/app-icons/${clientID}/${hash}.${format}${size ? `?size=${size}` : ''}`;
       },
+      GDMIcon: (channelID, hash, format = 'webp', size) => {
+        checkImage({ size, format });
+        return `${root}/channel-icons/${channelID}/${hash}.${format}${size ? `?size=${size}` : ''}`;
+      },
       Splash: (guildID, hash, format = 'webp', size) => {
         checkImage({ size, format });
         return `${root}/splashes/${guildID}/${hash}.${format}${size ? `?size=${size}` : ''}`;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes #1746
The method was expecting an array of `UserResolvable`s which is differently than the docs stated.
Going with an array of `GroupDMRecipientOptions` as it seems more natural.
Also removed an incorrect warning as the user property will be used on bot accounts.

Edit:
- Added `GroupDMChannel#setIcon`
- Fixed null handling for Group DM channel names, as they are nullable.

More commits:
- Added `GroupDMChannel#iconURL`

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
