### PR TITLE
Implemented GroupDMChannel#setIcon as a usable method

### DIFF
--- a/src/structures/GroupDMChannel.js
+++ b/src/structures/GroupDMChannel.js
@@ -148,6 +148,26 @@ class GroupDMChannel extends Channel {
     return this.edit({ name });
   }
 
+
+  /**
+   * Sets a new GroupDM channel icon.
+   * @param {Base64Resolvable} icon The new icon for the Channel
+   * @returns {Promise<GroupDMChannel>}
+   * @example
+   * // Edit the guild icon
+   * groupDM.setIcon(fs.readFileSync('./icon.png'))
+   *  .then(updated => console.log('Updated the channel icon for', updated.name || updated.id))
+   *  .catch(console.error);
+   */
+  setIcon(icon) {
+    if (icon instanceof Buffer) icon = icon.toString('base64');
+    return this.client.api.channels[this.id].patch({
+      data: {
+        icon: icon.includes('data:image/png;base64,') ? icon : `data:image/png;base64,${icon}`,
+      },
+    }).then(() => this);
+  }
+
   /**
    * Adds an user to this Group DM.
    * @param {Object} options Options for this method


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Added `setIcon` for a group DM as a usable method, albeit not mentioned on official discord documentation.
Acceptes a base64 hash string, a buffer, or a string with `data:image/png;base64,` already prefixed.
This is implemented for the ease of accessability, and adds or makes no breaking changes.

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
