### PR TITLE
fix reply splitting

### DIFF
--- a/src/structures/shared/SendMessage.js
+++ b/src/structures/shared/SendMessage.js
@@ -15,6 +15,14 @@ module.exports = function sendMessage(channel, options) { // eslint-disable-line
     if (isNaN(nonce) || nonce < 0) throw new RangeError('MESSAGE_NONCE_TYPE');
   }
 
+  // Add the reply prefix
+  if (reply && !(channel instanceof User || channel instanceof GuildMember) && channel.type !== 'dm') {
+    const id = channel.client.resolver.resolveUserID(reply);
+    const mention = `<@${reply instanceof GuildMember && reply.nickname ? '!' : ''}${id}>`;
+    if (split) split.prepend = `${mention}, ${split.prepend || ''}`;
+    content = `${mention}${typeof content !== 'undefined' ? `, ${content}` : ''}`;
+  }
+
   if (content) {
     content = Util.resolveString(content);
     if (split && typeof split !== 'object') split = {};
@@ -34,14 +42,6 @@ module.exports = function sendMessage(channel, options) { // eslint-disable-line
     }
 
     if (split) content = Util.splitMessage(content, split);
-  }
-
-  // Add the reply prefix
-  if (reply && !(channel instanceof User || channel instanceof GuildMember) && channel.type !== 'dm') {
-    const id = channel.client.resolver.resolveUserID(reply);
-    const mention = `<@${reply instanceof GuildMember && reply.nickname ? '!' : ''}${id}>`;
-    if (split) split.prepend = `${mention}, ${split.prepend || ''}`;
-    content = `${mention}${typeof content !== 'undefined' ? `, ${content}` : ''}`;
   }
 
   if (content instanceof Array) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
replying and splitting would not work, as the lib would split before formatting the reply

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
