### PR TITLE
Init pause variable on VoiceBroadcast

### DIFF
--- a/src/client/voice/VoiceBroadcast.js
+++ b/src/client/voice/VoiceBroadcast.js
@@ -35,7 +35,7 @@ class VoiceBroadcast extends VolumeInterface {
     this.client = client;
     this._dispatchers = new Collection();
     this._encoders = new Collection();
-     /**
+    /**
      * Whether playing is paused
      * @type {boolean}
      */

--- a/src/client/voice/VoiceBroadcast.js
+++ b/src/client/voice/VoiceBroadcast.js
@@ -35,6 +35,11 @@ class VoiceBroadcast extends VolumeInterface {
     this.client = client;
     this._dispatchers = new Collection();
     this._encoders = new Collection();
+     /**
+     * Whether playing is paused
+     * @type {boolean}
+     */
+    this.paused = false;
     /**
      * The audio transcoder that this broadcast uses
      * @type {Prism}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Dispatchers have a way for you to check if something is paused, but it's not currently possible to check if a Broadcast is paused without any dispatchers in it and pausing it first. This just initiates the variable like a Dispatcher :P

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
