### PR TITLE
deprecate Guild#defaultChannel

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-json=false

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -1,3 +1,4 @@
+const util = require('util');
 const Long = require('long');
 const User = require('./User');
 const Role = require('./Role');
@@ -289,15 +290,6 @@ class Guild {
   get voiceConnection() {
     if (this.client.browser) return null;
     return this.client.voice.connections.get(this.id) || null;
-  }
-
-  /**
-   * The `#general` TextChannel of the guild
-   * @type {TextChannel}
-   * @readonly
-   */
-  get defaultChannel() {
-    return this.channels.get(this.id);
   }
 
   /**
@@ -1092,5 +1084,17 @@ class Guild {
     );
   }
 }
+
+/**
+ * The `#general` TextChannel of the guild
+ * @name Guild#defaultChannel
+ * @type {TextChannel}
+ * @readonly
+ */
+Object.defineProperty(Guild.prototype, 'defaultChannel', {
+  get: util.deprecate(function defaultChannel() {
+    return this.channels.get(this.id);
+  }, 'Guild#defaultChannel: This property is obsolete, will be removed in v12.0.0, and may not function as expected.'),
+});
 
 module.exports = Guild;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
deprecate because it is removed in v12

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
