### PR TITLE
No longer double increment the reaction count when the client reacts

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -548,8 +548,10 @@ class Message {
       reaction = new MessageReaction(this, emoji, 0, user.id === this.client.user.id);
       this.reactions.set(emojiID, reaction);
     }
-    if (!reaction.users.has(user.id)) reaction.users.set(user.id, user);
-    reaction.count++;
+    if (!reaction.users.has(user.id)) {
+      reaction.users.set(user.id, user);
+      reaction.count++;
+    }
     return reaction;
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

When adding a reaction via `Message#react` the count of the added reaction will be incremented twice, as the method itself calls the handler and the WebSocket event does too.

This will only increment if that user didn't reacted previously.
It should only fire twice for the client however.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
