### PR TITLE
Fix ClientUser#settings not showing up in the documentation

### DIFF
--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -78,7 +78,7 @@ class ClientUser extends User {
      * <warn>This is only filled when using a user account.</warn>
      * @type {?ClientUserSettings}
      */
-    if (data.user_settings) this.settings = new ClientUserSettings(this, data.user_settings);
+    this.settings = data.user_settings ? new ClientUserSettings(this, data.user_settings) : null;
 
     /**
      * All of the user's guild settings


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Currently the property is not visible in the docs.
This will make them appear there.

Alternatively it probably is possible to multi line the if to only assign the settings prop when data.user_settings is existing.
I went with this solution since other user only props are being handled that way too.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
