### PR TITLE
Fixed a bunch of ClientUserGuildSettings stuff and its docs

### DIFF
--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -88,9 +88,7 @@ class ClientUser extends User {
     this.guildSettings = new Collection();
     if (data.user_guild_settings) {
       for (const settings of data.user_guild_settings) {
-        settings.client = this.client;
-        const guild = this.client.guilds.get(settings.guild_id);
-        this.guildSettings.set(settings.guild_id, new ClientUserGuildSettings(settings, guild));
+        this.guildSettings.set(settings.guild_id, new ClientUserGuildSettings(settings, this.client));
       }
     }
   }

--- a/src/structures/ClientUserChannelOverride.js
+++ b/src/structures/ClientUserChannelOverride.js
@@ -4,8 +4,7 @@ const Constants = require('../util/Constants');
  * A wrapper around the ClientUser's channel overrides.
  */
 class ClientUserChannelOverride {
-  constructor(user, data) {
-    this.user = user;
+  constructor(data) {
     this.patch(data);
   }
 
@@ -14,8 +13,7 @@ class ClientUserChannelOverride {
    * @param {Object} data Data to patch this with
    */
   patch(data) {
-    for (const key of Object.keys(Constants.UserChannelOverrideMap)) {
-      const value = Constants.UserChannelOverrideMap[key];
+    for (const [key, value] of Object.entries(Constants.UserChannelOverrideMap)) {
       if (!data.hasOwnProperty(key)) continue;
       if (typeof value === 'function') {
         this[value.name] = value(data[key]);

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -316,6 +316,7 @@ class Guild {
    * The position of this guild
    * <warn>This is only available when using a user account.</warn>
    * @type {?number}
+   * @readonly
    */
   get position() {
     if (this.client.user.bot) return null;
@@ -327,6 +328,7 @@ class Guild {
    * Whether the guild is muted
    * <warn>This is only available when using a user account.</warn>
    * @type {?boolean}
+   * @readonly
    */
   get muted() {
     if (this.client.user.bot) return null;
@@ -341,7 +343,8 @@ class Guild {
    * The type of message that should notify you
    * one of `EVERYTHING`, `MENTIONS`, `NOTHING`
    * <warn>This is only available when using a user account.</warn>
-   * @type {string}
+   * @type {?string}
+   * @readonly
    */
   get messageNotifications() {
     if (this.client.user.bot) return null;
@@ -355,7 +358,8 @@ class Guild {
   /**
    * Whether to receive mobile push notifications
    * <warn>This is only available when using a user account.</warn>
-   * @type {boolean}
+   * @type {?boolean}
+   * @readonly
    */
   get mobilePush() {
     if (this.client.user.bot) return null;
@@ -369,9 +373,11 @@ class Guild {
   /**
    * Whether to suppress everyone messages
    * <warn>This is only available when using a user account.</warn>
-   * @type {boolean}
+   * @type {?boolean}
+   * @readonly
    */
   get suppressEveryone() {
+    if (this.client.user.bot) return null;
     try {
       return this.client.user.guildSettings.get(this.id).suppressEveryone;
     } catch (err) {

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -365,10 +365,11 @@ class GuildChannel extends Channel {
   }
 
   /**
- * Whether the channel is muted
- * <warn>This is only available when using a user account.</warn>
- * @type {boolean}
- */
+   * Whether the channel is muted
+   * <warn>This is only available when using a user account.</warn>
+   * @type {?boolean}
+   * @readonly
+   */
   get muted() {
     if (this.client.user.bot) return null;
     try {
@@ -382,7 +383,8 @@ class GuildChannel extends Channel {
    * The type of message that should notify you
    * one of `EVERYTHING`, `MENTIONS`, `NOTHING`, `INHERIT`
    * <warn>This is only available when using a user account.</warn>
-   * @type {string}
+   * @type {?string}
+   * @readonly
    */
   get messageNotifications() {
     if (this.client.user.bot) return null;

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -14,7 +14,7 @@ class User {
     /**
      * The client that created the instance of the the user
      * @name User#client
-     * @type {}
+     * @type {Client}
      * @readonly
      */
     Object.defineProperty(this, 'client', { value: client });

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -534,14 +534,14 @@ exports.UserChannelOverrideMap = {
     /**
      * The type of message that should notify you
      * one of `EVERYTHING`, `MENTIONS`, `NOTHING`, `INHERIT`
-     * @name ClientUserChannelOverrides#messageNotifications
+     * @name ClientUserChannelOverride#messageNotifications
      * @type {string}
      */
     return exports.MessageNotificationTypes[type];
   },
   /**
    * Whether the guild is muted or not
-   * @name ClientUserChannelOverrides#muted
+   * @name ClientUserChannelOverride#muted
    * @type {boolean}
    */
   muted: 'muted',


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- Used `Object.entries` over `Object.keys` as v12 is requiring node 8 and it is nicer.
- Defined and documented `ClientUserGuildSettings#Client` properly
- Removed obsolete `ClientUserChannelOverride#user` prop, which was always null anyway
- `ClientUserGuildSettings#guild` was always `undefined` as the guild object was not created when the class get instantiated.
  Replaced it with `ClientUserGuildSettings#guildID`.
- `ClientUserGuildSettings#update` now uses the correct endpoint to patch
- Marked getters as `@readonly`, nullable and fixed indent wherever applicable
- Changed `ClientUserChannelOverrides` to `ClientUserChannelOverride` (singular) to make them appear in the docs in the Constants file
- Added type for `User#Client`

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
