### PR TITLE
Readded permissions to Role#edit's payload

### DIFF
--- a/src/structures/Role.js
+++ b/src/structures/Role.js
@@ -205,9 +205,10 @@ class Role {
     return this.client.api.guilds[this.guild.id].roles[this.id].patch({
       data: {
         name: data.name || this.name,
-        position: typeof data.position !== 'undefined' ? data.position : this.position,
         color: Util.resolveColor(data.color || this.color),
         hoist: typeof data.hoist !== 'undefined' ? data.hoist : this.hoist,
+        position: typeof data.position !== 'undefined' ? data.position : this.position,
+        permissions: data.permissions,
         mentionable: typeof data.mentionable !== 'undefined' ? data.mentionable : this.mentionable,
       },
       reason,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes #1759 
The permissions property was missing in the data when patching a role.
Also sorted them the same way as the typedef and docs.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
