### PR TITLE
updated docs for <ReactionEmoji>.toString() so it now uses send instead sendMessage in example

### DIFF
--- a/src/structures/ReactionEmoji.js
+++ b/src/structures/ReactionEmoji.js
@@ -38,7 +38,7 @@ class ReactionEmoji {
    * Creates the text required to form a graphical emoji on Discord.
    * @example
    * // Send the emoji used in a reaction to the channel the reaction is part of
-   * reaction.message.channel.sendMessage(`The emoji used is ${reaction.emoji}`);
+   * reaction.message.channel.send(`The emoji used is ${reaction.emoji}`);
    * @returns {string}
    */
   toString() {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
because we should not use deleted/deprecated methods in docs 🤔 

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
