### PR TITLE
Fix VoiceChannel#setName and ChannelData#userLimit is a only voice thing

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -202,7 +202,7 @@ class GuildChannel extends Channel {
    * @property {number} [position] The position of the channel
    * @property {string} [topic] The topic of the text channel
    * @property {number} [bitrate] The bitrate of the voice channel
-   * @property {number} [userLimit] The user limit of the channel
+   * @property {number} [userLimit] The user limit of voice the channel
    */
 
   /**
@@ -222,7 +222,7 @@ class GuildChannel extends Channel {
         name: (data.name || this.name).trim(),
         topic: data.topic || this.topic,
         position: data.position || this.position,
-        bitrate: data.bitrate || this.bitrate,
+        bitrate: data.bitrate || (this.bitrate ? this.bitrate * 1000 : undefined),
         user_limit: data.userLimit || this.userLimit,
       },
       reason,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes #1769 
Multiply the local bitrate by thousand when patching a VoiceChannel as discord wants the bitrate in bits and not in kilobits.
I used  ternary here because sending `NaN` as bitrate when patching a TextChannel seems incorrect.

Also clarified that `userLimit` is for VoiceChannels only and not for GuildChannels in general.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
