### PR TITLE
Add support for new game types

### DIFF
--- a/src/structures/Presence.js
+++ b/src/structures/Presence.js
@@ -1,3 +1,5 @@
+const Constants = require('../util/Constants');
+
 /**
  * Represents a user's presence.
  */
@@ -53,9 +55,9 @@ class Game {
 
     /**
      * The type of the game status
-     * @type {number}
+     * @type {GameType}
      */
-    this.type = data.type;
+    this.type = Constants.GameTypes[data.type];
 
     /**
      * If the game is being streamed, a link to the stream
@@ -70,7 +72,7 @@ class Game {
    * @readonly
    */
   get streaming() {
-    return this.type === 1;
+    return this.type === Constants.GameTypes[1];
   }
 
   /**

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -349,6 +349,21 @@ exports.MessageTypes = [
   'GUILD_MEMBER_JOIN',
 ];
 
+/**
+ * The type of a game of a users presence, e.g. `PLAYING`. Here are the available types:
+ * - PLAYING
+ * - STREAMING
+ * - LISTENING
+ * - WATCHING
+ * @typedef {string} GameType
+ */
+exports.GameTypes = [
+  'PLAYING',
+  'STREAMING',
+  'LISTENING',
+  'WATCHING',
+];
+
 exports.ExplicitContentFilterTypes = [
   'DISABLED',
   'NON_FRIENDS',


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- Added `GameType` typdef
- `Game#type` is now the string representation of the game type rather than its numeric value

Should I remove the `Game#streaming` getter as there are now more than two types or let it as is?

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
