### PR TITLE
Allow to set the new game types via ClientUser#setPresence and ClientUser#setGame

### DIFF
--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -212,7 +212,7 @@ class ClientUser extends User {
       }
 
       if (data.status) {
-        if (typeof data.status !== 'string') throw new TypeError('STATUS_TYPE');
+        if (typeof data.status !== 'string') throw new TypeError('INVALID_TYPE', 'status', 'string');
         if (this.bot) {
           status = data.status;
         } else {
@@ -223,13 +223,11 @@ class ClientUser extends User {
 
       if (data.game) {
         game = data.game;
-        if (typeof data.game.type === 'number') {
-          game.type = data.game.type;
-        } else if (typeof data.game.type === 'string') {
-          game.type = Constants.GameTypes.indexOf(data.game.type);
-          if (game.type === -1) {
-            throw new TypeError('INVALID_TYPE', 'type', 'GameType');
-          }
+        if (typeof game.type === 'number') {
+          game.type = game.type;
+        } else if (typeof game.type === 'string') {
+          game.type = Constants.GameTypes.indexOf(game.type);
+          if (game.type === -1) throw new TypeError('INVALID_TYPE', 'type', 'GameType');
         } else {
           game.type = game.url ? 1 : 0;
         }

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -187,6 +187,7 @@ class ClientUser extends User {
    * @property {boolean} [afk] Whether the user is AFK
    * @property {Object} [game] Game the user is playing
    * @property {string} [game.name] Name of the game
+   * @property {number} [game.type] Type of the game
    * @property {string} [game.url] Twitch stream URL
    */
 
@@ -222,7 +223,9 @@ class ClientUser extends User {
 
       if (data.game) {
         game = data.game;
-        if (game.url) game.type = 1;
+        if (typeof data.game.type === 'undefined') {
+          data.game.type = game.url ? 1 : 0;
+        }
       } else if (typeof data.game !== 'undefined') {
         game = null;
       }
@@ -266,15 +269,18 @@ class ClientUser extends User {
   /**
    * Sets the game the client user is playing.
    * @param {?string} game Game being played
-   * @param {string} [streamingURL] Twitch stream URL
+   * @param {Object} [options] Options for setting the game
+   * @param {string} [options.url] Twitch stream URL
+   * @param {number} [options.type] Type of the game
    * @returns {Promise<ClientUser>}
    */
-  setGame(game, streamingURL) {
+  setGame(game, { url, type }) {
     if (!game) return this.setPresence({ game: null });
     return this.setPresence({
       game: {
         name: game,
-        url: streamingURL,
+        type,
+        url,
       },
     });
   }

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -187,7 +187,7 @@ class ClientUser extends User {
    * @property {boolean} [afk] Whether the user is AFK
    * @property {Object} [game] Game the user is playing
    * @property {string} [game.name] Name of the game
-   * @property {number} [game.type] Type of the game
+   * @property {GameType|number} [game.type] Type of the game
    * @property {string} [game.url] Twitch stream URL
    */
 
@@ -223,8 +223,15 @@ class ClientUser extends User {
 
       if (data.game) {
         game = data.game;
-        if (typeof data.game.type === 'undefined') {
-          data.game.type = game.url ? 1 : 0;
+        if (typeof data.game.type === 'number') {
+          game.type = data.game.type;
+        } else if (typeof data.game.type === 'string') {
+          game.type = Constants.GameTypes.indexOf(data.game.type);
+          if (game.type === -1) {
+            throw new TypeError('INVALID_TYPE', 'type', 'GameType');
+          }
+        } else {
+          game.type = game.url ? 1 : 0;
         }
       } else if (typeof data.game !== 'undefined') {
         game = null;
@@ -271,10 +278,10 @@ class ClientUser extends User {
    * @param {?string} game Game being played
    * @param {Object} [options] Options for setting the game
    * @param {string} [options.url] Twitch stream URL
-   * @param {number} [options.type] Type of the game
+   * @param {GameType|number} [options.type] Type of the game
    * @returns {Promise<ClientUser>}
    */
-  setGame(game, { url, type }) {
+  setGame(game, { url, type } = {}) {
     if (!game) return this.setPresence({ game: null });
     return this.setPresence({
       game: {

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -223,12 +223,10 @@ class ClientUser extends User {
 
       if (data.game) {
         game = data.game;
-        if (typeof game.type === 'number') {
-          game.type = game.type;
-        } else if (typeof game.type === 'string') {
+        if (typeof game.type === 'string') {
           game.type = Constants.GameTypes.indexOf(game.type);
           if (game.type === -1) throw new TypeError('INVALID_TYPE', 'type', 'GameType');
-        } else {
+        } else if (typeof game.type !== 'number') {
           game.type = game.url ? 1 : 0;
         }
       } else if (typeof data.game !== 'undefined') {

--- a/src/structures/Presence.js
+++ b/src/structures/Presence.js
@@ -67,15 +67,6 @@ class Game {
   }
 
   /**
-   * Whether or not the game is being streamed
-   * @type {boolean}
-   * @readonly
-   */
-  get streaming() {
-    return this.type === Constants.GameTypes[1];
-  }
-
-  /**
    * Whether this game is equal to another game
    * @param {Game} game The game to compare with
    * @returns {boolean}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This will allow to set the new presence types `2` and `3` to be set using `ClientUser#setPresence` or `ClientUser#setGame`.

- `ClientUser#setGame` now accepts an `options` object as second paremeter with the keys `url` and `type`
- `ClientUser#setPresence` now additonaly accepts a `type` key under `data.game`


**Update:**
- The `type` key also accepts a string representation of a type
- Removed `Presence#streaming` getter as with now 4 types having just one or 4 (one for each) would be silly.
- Fixed an invalid presence type (not string) to throw an invalid message key error when attempting to throw a more descriptive error.

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
