### PR TITLE
Always send a type now when updating own presence

### DIFF
--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -190,7 +190,7 @@ class ClientUser extends User {
 
       if (data.game) {
         game = data.game;
-        if (game.url) game.type = 1;
+        game.type = game.url ? 1 : 0;
       } else if (typeof data.game !== 'undefined') {
         game = null;
       }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Friendly reminder: This PR is for the `11.1-dev` branch. (Just to avoid confusion)

Discord changed validation for presence updates, a type for the game is now always required.
This will now send `type: 0` when no url is present rather than omitting the field.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
