### PR TITLE
API change

### DIFF
--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -271,8 +271,11 @@ class ClientUser extends User {
    */
   setGame(game, streamingURL) {
     if (!game) return this.setPresence({ game: null });
+    let gameType = 0;
+    if(streamingURL) gameType = 1;
     return this.setPresence({
       game: {
+        type: gameType,
         name: game,
         url: streamingURL,
       },


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This pull request will adapt the `<ClientUser>.setGame` method with the API requirements.
On August 16th, the Discord API changed about presences and now the `type` value of the game isn't longer optional. The current method doesn't set the type value.
Currently when we run the method, no error is returned but the game isn't set or updated.

The `gameType` var is set to 0 (game), if there's a streamingURL we set the `gameType` var to 1 (streaming).

**Semantic versioning classification:**  
- [X] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
