### PR TITLE
Implementing `iconURL` method in `PartialGuild`

### DIFF
--- a/src/structures/PartialGuild.js
+++ b/src/structures/PartialGuild.js
@@ -48,7 +48,7 @@ class PartialGuild {
      */
     this.splash = data.splash;
   }
-     
+
   /**
    * Gets the URL to this guild's icon
    * @param {Object} [options={}] Options for the icon url

--- a/src/structures/PartialGuild.js
+++ b/src/structures/PartialGuild.js
@@ -1,3 +1,5 @@
+const Constants = require('../util/Constants');
+
 /*
 { splash: null,
      id: '123123123',

--- a/src/structures/PartialGuild.js
+++ b/src/structures/PartialGuild.js
@@ -45,18 +45,18 @@ class PartialGuild {
      * @type {?string}
      */
     this.splash = data.splash;
-       
-    /**
-     * Gets the URL to this guild's icon
-     * @param {Object} [options={}] Options for the icon url
-     * @param {string} [options.format='webp'] One of `webp`, `png`, `jpg`
-     * @param {number} [options.size=128] One of `128`, '256', `512`, `1024`, `2048`
-     * @returns {?string}
-     */
-    iconURL({ format, size } = {}) {
-      if (!this.icon) return null;
-      return Constants.Endpoints.CDN(this.client.options.http.cdn).Icon(this.id, this.icon, format, size);
-    }
+  }
+     
+  /**
+   * Gets the URL to this guild's icon
+   * @param {Object} [options={}] Options for the icon url
+   * @param {string} [options.format='webp'] One of `webp`, `png`, `jpg`
+   * @param {number} [options.size=128] One of `128`, '256', `512`, `1024`, `2048`
+   * @returns {?string}
+   */
+  iconURL({ format, size } = {}) {
+    if (!this.icon) return null;
+    return Constants.Endpoints.CDN(this.client.options.http.cdn).Icon(this.id, this.icon, format, size);
   }
 }
 

--- a/src/structures/PartialGuild.js
+++ b/src/structures/PartialGuild.js
@@ -45,6 +45,18 @@ class PartialGuild {
      * @type {?string}
      */
     this.splash = data.splash;
+       
+    /**
+     * Gets the URL to this guild's icon
+     * @param {Object} [options={}] Options for the icon url
+     * @param {string} [options.format='webp'] One of `webp`, `png`, `jpg`
+     * @param {number} [options.size=128] One of `128`, '256', `512`, `1024`, `2048`
+     * @returns {?string}
+     */
+    iconURL({ format, size } = {}) {
+      if (!this.icon) return null;
+      return Constants.Endpoints.CDN(this.client.options.http.cdn).Icon(this.id, this.icon, format, size);
+    }
   }
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

• Adding `iconURL` method from `Guild` in `PartialGuild` to make the task easier (we must do `https://cdn.discordapp.com/icons/<Guild ID>/<Guild icon>.<format>?size=<size>` currently).

• It should be merged because there's no reason for why it shouldn't be, it would make the dev life easier and clean the code and it can't make conflict with other things.


**Semantic versioning classification:**  
- [X] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
