### PR TITLE
Remove .end and default to .destroy

### DIFF
--- a/src/client/voice/dispatcher/StreamDispatcher.js
+++ b/src/client/voice/dispatcher/StreamDispatcher.js
@@ -280,10 +280,11 @@ class StreamDispatcher extends VolumeInterface {
 
   /**
    * Stops the current stream permanently.
-   * @param {string} [type='end'] The type of ending. 'end' will emit the `end` event.
-   * @param {string} [reason='user'] An optional reason for stopping the dispatcher
+   * @param {Object} [options] Options for the destruction
+   * @param {string} [options.type='end'] The type of ending. 'end' will emit the `end` event.
+   * @param {string} [options.reason='user'] A reason for stopping the dispatcher
    */
-  destroy(type = 'end', reason = 'user') {
+  destroy({ type = 'end', reason = 'user' } = {}) {
     if (this.destroyed) return;
     this.destroyed = true;
     this.setSpeaking(false);

--- a/src/client/voice/dispatcher/StreamDispatcher.js
+++ b/src/client/voice/dispatcher/StreamDispatcher.js
@@ -98,15 +98,6 @@ class StreamDispatcher extends VolumeInterface {
    */
   resume() { this.setPaused(false); }
 
-
-  /**
-   * Stops the current stream permanently and emits an `end` event.
-   * @param {string} [reason='user'] An optional reason for stopping the dispatcher
-   */
-  end(reason = 'user') {
-    this.destroy('end', reason);
-  }
-
   setSpeaking(value) {
     if (this.speaking === value) return;
     if (this.player.voiceConnection.status !== Constants.VoiceStatus.CONNECTED) return;
@@ -287,8 +278,12 @@ class StreamDispatcher extends VolumeInterface {
     data.timestamp = data.timestamp + 4294967295 ? data.timestamp + 960 : 0;
   }
 
-  destroy(type, reason) {
-    if (this.destroyed) return;
+  /**
+   * Stops the current stream permanently.
+   * @param {string} [type='end'] The type of ending. 'end' will emit the `end` event.
+   * @param {string} [reason='user'] An optional reason for stopping the dispatcher
+   */
+  destroy(type = 'end', reason = 'user') {
     this.destroyed = true;
     this.setSpeaking(false);
     this.emit(type, reason);

--- a/src/client/voice/dispatcher/StreamDispatcher.js
+++ b/src/client/voice/dispatcher/StreamDispatcher.js
@@ -284,6 +284,7 @@ class StreamDispatcher extends VolumeInterface {
    * @param {string} [reason='user'] An optional reason for stopping the dispatcher
    */
   destroy(type = 'end', reason = 'user') {
+    if (this.destroyed) return;
     this.destroyed = true;
     this.setSpeaking(false);
     this.emit(type, reason);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
It seems kind of unnecessary to create a custom .end, when you could easily default it to destroy without having to have the extra method. Would be easy cleanup and looks a lot better.

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
