### PR TITLE
Fix Client hanging after Client.destroy is invoked

### DIFF
--- a/src/client/rest/handlers/RequestHandler.js
+++ b/src/client/rest/handlers/RequestHandler.js
@@ -65,6 +65,10 @@ class RequestHandler {
     this.globallyLimited = false;
     this.remaining = 1;
   }
+
+  destroy() {
+    this.queue = [];
+  }
 }
 
 module.exports = RequestHandler;

--- a/src/client/websocket/WebSocketConnection.js
+++ b/src/client/websocket/WebSocketConnection.js
@@ -82,7 +82,7 @@ class WebSocketConnection extends EventEmitter {
     this.ratelimit = {
       queue: [],
       remaining: 120,
-      resetTime: -1,
+      resetTimer: -1,
     };
     this.connect(gateway);
 
@@ -276,6 +276,7 @@ class WebSocketConnection extends EventEmitter {
     this.packetManager.handleQueue();
     this.ws = null;
     this.status = Constants.Status.DISCONNECTED;
+    clearTimeout(this.ratelimit.resetTimer);
     return true;
   }
 

--- a/src/client/websocket/WebSocketConnection.js
+++ b/src/client/websocket/WebSocketConnection.js
@@ -275,8 +275,8 @@ class WebSocketConnection extends EventEmitter {
     ws.close(1000);
     this.packetManager.handleQueue();
     this.ws = null;
-    this.status = Constants.Status.DISCONNECTED;
     clearTimeout(this.ratelimit.resetTimer);
+    this.status = Constants.Status.DISCONNECTED;
     return true;
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes #1685 by clearing the timeout for `resetTimer` after the Status is set to DISCONNECTED.
I don't know if there's a better way to do this, but I tested it and it instantly closed after login failed (that is, if nothing else is happening in the backround)

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
