### PR TITLE
Backporting Attachments

### DIFF
--- a/src/client/ClientDataResolver.js
+++ b/src/client/ClientDataResolver.js
@@ -235,6 +235,33 @@ class ClientDataResolver {
   }
 
   /**
+   * @external Stream
+   * @see {@link https://nodejs.org/api/stream.html}
+   */
+
+  /**
+   * Converts a Stream to a Buffer.
+   * @param {Stream} resource The stream to convert
+   * @returns {Promise<Buffer>}
+   */
+  resolveFile(resource) {
+    return resource ? this.resolveBuffer(resource)
+      .catch(() => {
+        if (resource.pipe && typeof resource.pipe === 'function') {
+          return new Promise((resolve, reject) => {
+            const buffers = [];
+            resource.once('error', reject);
+            resource.on('data', data => buffers.push(data));
+            resource.once('end', () => resolve(Buffer.concat(buffers)));
+          });
+        } else {
+          throw new TypeError('The resource must be a string, Buffer or a valid file stream.');
+        }
+      }) :
+      Promise.reject(new TypeError('The resource must be a string, Buffer or a valid file stream.'));
+  }
+
+  /**
    * Data that can be resolved to give an emoji identifier. This can be:
    * * The unicode representation of an emoji
    * * A custom emoji ID

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,7 @@ module.exports = {
   splitMessage: Util.splitMessage,
 
   // Structures
+  Attachment: require('./structures/Attachment'),
   Channel: require('./structures/Channel'),
   ClientUser: require('./structures/ClientUser'),
   ClientUserSettings: require('./structures/ClientUserSettings'),

--- a/src/structures/Attachment.js
+++ b/src/structures/Attachment.js
@@ -1,0 +1,74 @@
+/**
+ * Represents an attachment in a message.
+ * @param {BufferResolvable|Stream} file The file
+ * @param {string} [name] The name of the file, if any
+ */
+class Attachment {
+  constructor(file, name) {
+    this.file = null;
+    if (name) this.setAttachment(file, name);
+    else this._attach(file);
+  }
+
+  /**
+    * The name of the file
+    * @type {?string}
+    * @readonly
+    */
+  get name() {
+    return this.file.name;
+  }
+
+  /**
+    * The file
+    * @type {?BufferResolvable|Stream}
+    * @readonly
+    */
+  get attachment() {
+    return this.file.attachment;
+  }
+
+  /**
+    * Set the file of this attachment.
+    * @param {BufferResolvable|Stream} file The file
+    * @param {string} name The name of the file
+    * @returns {Attachment} This attachment
+    */
+  setAttachment(file, name) {
+    this.file = { attachment: file, name };
+    return this;
+  }
+
+  /**
+    * Set the file of this attachment.
+    * @param {BufferResolvable|Stream} attachment The file
+    * @returns {Attachment} This attachment
+    */
+  setFile(attachment) {
+    this.file = { attachment };
+    return this;
+  }
+
+  /**
+    * Set the name of this attachment.
+    * @param {string} name The name of the image
+    * @returns {Attachment} This attachment
+    */
+  setName(name) {
+    this.file.name = name;
+    return this;
+  }
+
+  /**
+    * Set the file of this attachment.
+    * @param {BufferResolvable|Stream} file The file
+    * @param {string} name The name of the file
+    * @private
+    */
+  _attach(file, name) {
+    if (typeof file === 'string') this.file = file;
+    else this.setAttachment(file, name);
+  }
+}
+
+module.exports = Attachment;

--- a/src/structures/RichEmbed.js
+++ b/src/structures/RichEmbed.js
@@ -1,4 +1,5 @@
-const ClientDataResolver = require('../client/ClientDataResolver');
+const Attachment = require('./Attachment');
+let ClientDataResolver;
 
 /**
  * A rich embed to be sent with a message with a fluent interface for creation.
@@ -113,6 +114,7 @@ class RichEmbed {
    * @returns {RichEmbed} This embed
    */
   setColor(color) {
+    if (!ClientDataResolver) ClientDataResolver = require('../client/ClientDataResolver');
     this.color = ClientDataResolver.resolveColor(color);
     return this;
   }
@@ -203,11 +205,13 @@ class RichEmbed {
   /**
    * Sets the file to upload alongside the embed. This file can be accessed via `attachment://fileName.extension` when
    * setting an embed image or author/footer icons. Only one file may be attached.
-   * @param {FileOptions|string} file Local path or URL to the file to attach, or valid FileOptions for a file to attach
+   * @param {FileOptions|string|Attachment} file Local path or URL to the file to attach,
+   * or valid FileOptions for a file to attach
    * @returns {RichEmbed} This embed
    */
   attachFile(file) {
     if (this.file) throw new RangeError('You may not upload more than one file at once.');
+    if (file instanceof Attachment) file = file.file;
     this.file = file;
     return this;
   }

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -1,4 +1,7 @@
 const path = require('path');
+const Util = require('../util/Util');
+const Attachment = require('./Attachment');
+const RichEmbed = require('./RichEmbed');
 
 /**
  * Represents a webhook.
@@ -76,11 +79,12 @@ class Webhook {
    * @property {string} [avatarURL] Avatar URL override for the message
    * @property {boolean} [tts=false] Whether or not the message should be spoken aloud
    * @property {string} [nonce=''] The nonce for the message
-   * @property {Object[]} [embeds] An array of embeds for the message
+   * @property {Array<RichEmbed|Object>} [embeds] An array of embeds for the message
    * (see [here](https://discordapp.com/developers/docs/resources/channel#embed-object) for more details)
    * @property {boolean} [disableEveryone=this.client.options.disableEveryone] Whether or not @everyone and @here
    * should be replaced with plain-text
-   * @property {FileOptions|string} [file] A file to send with the message
+   * @property {FileOptions|BufferResolvable|Attachment} [file] A file to send with the message **(deprecated)**
+   * @property {FileOptions[]|BufferResolvable[]|Attachment[]} [files] Files to send with the message
    * @property {string|boolean} [code] Language for optional codeblock formatting to apply
    * @property {boolean|SplitOptions} [split=false] Whether or not the message should be split into multiple messages if
    * it exceeds the character limit. If an object is provided, these are the options for splitting the message.
@@ -89,7 +93,8 @@ class Webhook {
   /**
    * Send a message with this webhook.
    * @param {StringResolvable} content The content to send
-   * @param {WebhookMessageOptions} [options={}] The options to provide
+   * @param {WebhookMessageOptions|Attachment|RichEmbed} [options] The options to provide
+   * can also be just a RichEmbed or Attachment
    * @returns {Promise<Message|Message[]>}
    * @example
    * // Send a message
@@ -97,39 +102,78 @@ class Webhook {
    *   .then(message => console.log(`Sent message: ${message.content}`))
    *   .catch(console.error);
    */
-  send(content, options) {
+  send(content, options) { // eslint-disable-line complexity
     if (!options && typeof content === 'object' && !(content instanceof Array)) {
       options = content;
       content = '';
     } else if (!options) {
       options = {};
     }
+
+    if (options instanceof Attachment) options = { files: [options] };
+    if (options instanceof RichEmbed) options = { embeds: [options] };
+
+    if (content) {
+      content = this.client.resolver.resolveString(content);
+      let { split, code, disableEveryone } = options;
+      if (split && typeof split !== 'object') split = {};
+      if (typeof code !== 'undefined' && (typeof code !== 'boolean' || code === true)) {
+        content = Util.escapeMarkdown(content, true);
+        content = `\`\`\`${typeof code !== 'boolean' ? code || '' : ''}\n${content}\n\`\`\``;
+        if (split) {
+          split.prepend = `\`\`\`${typeof code !== 'boolean' ? code || '' : ''}\n`;
+          split.append = '\n```';
+        }
+      }
+      if (disableEveryone || (typeof disableEveryone === 'undefined' && this.client.options.disableEveryone)) {
+        content = content.replace(/@(everyone|here)/g, '@\u200b$1');
+      }
+
+      if (split) content = Util.splitMessage(content, split);
+    }
+
     if (options.file) {
       if (options.files) options.files.push(options.file);
       else options.files = [options.file];
     }
 
+    if (options.embeds) {
+      const files = [];
+      for (const embed of options.embeds) {
+        if (embed.file) files.push(embed.file);
+      }
+      if (options.files) options.files.push(...files);
+      else options.files = files;
+    }
+
     if (options.files) {
       for (let i = 0; i < options.files.length; i++) {
         let file = options.files[i];
-        if (typeof file === 'string') file = { attachment: file };
+        if (typeof file === 'string' || Buffer.isBuffer(file)) file = { attachment: file };
         if (!file.name) {
           if (typeof file.attachment === 'string') {
             file.name = path.basename(file.attachment);
           } else if (file.attachment && file.attachment.path) {
             file.name = path.basename(file.attachment.path);
+          } else if (file instanceof Attachment) {
+            file = { attachment: file.file, name: path.basename(file.file) || 'file.jpg' };
           } else {
             file.name = 'file.jpg';
           }
+        } else if (file instanceof Attachment) {
+          file = file.file;
         }
+        options.files[i] = file;
       }
-      return this.client.resolver.resolveBuffer(options.file.attachment).then(file =>
-        this.client.rest.methods.sendWebhookMessage(this, content, options, {
-          file,
-          name: options.file.name,
+
+      return Promise.all(options.files.map(file =>
+        this.client.resolver.resolveFile(file.attachment).then(resource => {
+          file.file = resource;
+          return file;
         })
-      );
+      )).then(files => this.client.rest.methods.sendWebhookMessage(this, content, options, files));
     }
+
     return this.client.rest.methods.sendWebhookMessage(this, content, options);
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Relevant commits
- https://github.com/hydrabolt/discord.js/commit/62fc9fce6df9bca0401cdd9655c11104e8a32d3a
- https://github.com/hydrabolt/discord.js/commit/4520c801d370708bc1d914bfa2d9b61729dbdf1e

Other fixes
- Fixed a bunch of splitting issues, for example actually sending embeds and files with the last message.
- Implemented code and split options for webhook like they are stated in the docs; They were not present in the code at all.
- Some edge cases that would lead to overwriting file(s) key of the message options with embeds

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
