### PR TITLE
Remove default channel resolving from guild input.

### DIFF
--- a/src/client/ClientDataResolver.js
+++ b/src/client/ClientDataResolver.js
@@ -141,7 +141,6 @@ class ClientDataResolver {
     if (channel instanceof Channel) return channel;
     if (typeof channel === 'string') return this.client.channels.get(channel) || null;
     if (channel instanceof Message) return channel.channel;
-    if (channel instanceof Guild) return channel.channels.get(channel.id) || null;
     return null;
   }
 

--- a/src/client/ClientDataResolver.js
+++ b/src/client/ClientDataResolver.js
@@ -154,7 +154,6 @@ class ClientDataResolver {
     if (channel instanceof Channel) return channel.id;
     if (typeof channel === 'string') return channel;
     if (channel instanceof Message) return channel.channel.id;
-    if (channel instanceof Guild) return channel.defaultChannel.id;
     return null;
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Removes guild as a possible parameter from resolveChannelID as default channels aren't in the API anymore (or won't be) idk.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
