### PR TITLE
Added resolveImage to reduce code duplication

### DIFF
--- a/jsdoc.json
+++ b/jsdoc.json
@@ -1,0 +1,3 @@
+{
+	"plugins": ["node_modules/jsdoc-strip-async-await"]
+}

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "types": "./typings/index.d.ts",
   "scripts": {
     "test": "npm run lint && npm run docs:test",
-    "docs": "docgen --source src --custom docs/index.yml --output docs/docs.json",
-    "docs:test": "docgen --source src --custom docs/index.yml",
+    "docs": "docgen --source src --custom docs/index.yml --output docs/docs.json --jsdoc jsdoc.json",
+    "docs:test": "docgen --source src --custom docs/index.yml --jsdoc jsdoc.json",
     "lint": "eslint src",
     "lint:fix": "eslint --fix src",
     "webpack": "parallel-webpack"
@@ -51,6 +51,7 @@
     "@types/node": "^8.0.0",
     "discord.js-docgen": "hydrabolt/discord.js-docgen",
     "eslint": "^4.0.0",
+    "jsdoc-strip-async-await": "^0.1.0",
     "parallel-webpack": "^2.0.0",
     "uglifyjs-webpack-plugin": "^1.0.0-beta.1",
     "webpack": "^3.0.0"

--- a/src/client/ClientDataResolver.js
+++ b/src/client/ClientDataResolver.js
@@ -178,6 +178,19 @@ class ClientDataResolver {
   }
 
   /**
+   * Resolves a Base64Resolvable, a string, or a BufferResolvable to a Base 64 image.
+   * @param {string|BufferResolvable|Base64Resolvable} image THe image to be resolved
+   * @returns {Promise<string>}
+   */
+  resolveImage(image) {
+    if (!image) return Promise.resolve(null);
+    if (typeof image === 'string' && image.startsWith('data:')) {
+      return Promise.resolve(image);
+    }
+    return this.resolveFile(image || Buffer.alloc(0)).then(this.resolveBase64);
+  }
+
+  /**
    * Data that resolves to give a Base64 string, typically for image uploading. This can be:
    * * A Buffer
    * * A base64 string

--- a/src/client/ClientDataResolver.js
+++ b/src/client/ClientDataResolver.js
@@ -179,7 +179,7 @@ class ClientDataResolver {
 
   /**
    * Resolves a Base64Resolvable, a string, or a BufferResolvable to a Base 64 image.
-   * @param {string|BufferResolvable|Base64Resolvable} image The image to be resolved
+   * @param {BufferResolvable|Base64Resolvable} image The image to be resolved
    * @returns {Promise<string>}
    */
   async resolveImage(image) {

--- a/src/client/ClientDataResolver.js
+++ b/src/client/ClientDataResolver.js
@@ -179,15 +179,16 @@ class ClientDataResolver {
 
   /**
    * Resolves a Base64Resolvable, a string, or a BufferResolvable to a Base 64 image.
-   * @param {string|BufferResolvable|Base64Resolvable} image THe image to be resolved
+   * @param {string|BufferResolvable|Base64Resolvable} image The image to be resolved
    * @returns {Promise<string>}
    */
-  resolveImage(image) {
-    if (!image) return Promise.resolve(null);
+  async resolveImage(image) {
+    if (!image) return null;
     if (typeof image === 'string' && image.startsWith('data:')) {
-      return Promise.resolve(image);
+      return image;
     }
-    return this.resolveFile(image || Buffer.alloc(0)).then(this.resolveBase64);
+    const file = await this.resolveFile(image);
+    return this.resolveBase64(file);
   }
 
   /**

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -171,9 +171,8 @@ class ClientUser extends User {
    *   .then(user => console.log(`New avatar set!`))
    *   .catch(console.error);
    */
-  setAvatar(avatar) {
-    return this.client.resolver.resolveImage(avatar)
-      .then(data => this.edit({ avatar: data }));
+  async setAvatar(avatar) {
+    return this.edit({ avatar: await this.client.resolver.resolveImage(avatar) });
   }
 
   /**

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -343,7 +343,7 @@ class ClientUser extends User {
           }, reject)
       );
     } else {
-      return this.client.resolver.resolveBuffer(icon)
+      return this.client.resolver.resolveFile(icon)
         .then(data => this.createGuild(name, { region, icon: this.client.resolver.resolveBase64(data) || null }));
     }
   }

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -146,7 +146,7 @@ class ClientUser extends User {
    * Changes the password for the client user's account.
    * <warn>This is only available when using a user account.</warn>
    * @param {string} newPassword New password to change to
-   * @param {Object|string} options Object containing an MFA code, password or both. 
+   * @param {Object|string} options Object containing an MFA code, password or both.
    * Can be just a string for the password.
    * @param {string} [options.oldPassword] Current password
    * @param {string} [options.mfaCode] Timed MFA Code
@@ -172,12 +172,8 @@ class ClientUser extends User {
    *   .catch(console.error);
    */
   setAvatar(avatar) {
-    if (typeof avatar === 'string' && avatar.startsWith('data:')) {
-      return this.edit({ avatar });
-    } else {
-      return this.client.resolver.resolveBuffer(avatar || Buffer.alloc(0))
-        .then(data => this.edit({ avatar: this.client.resolver.resolveBase64(data) || null }));
-    }
+    return this.client.resolver.resolveImage(avatar)
+      .then(data => this.edit({ avatar: data }));
   }
 
   /**

--- a/src/structures/GroupDMChannel.js
+++ b/src/structures/GroupDMChannel.js
@@ -160,14 +160,8 @@ class GroupDMChannel extends Channel {
    * @returns {Promise<GroupDMChannel>}
    */
   setIcon(icon) {
-    if (typeof icon === 'string' && icon.startsWith('data:')) {
-      return this.edit({ icon });
-    } else if (!icon) {
-      return this.edit({ icon: null });
-    } else {
-      return this.client.resolver.resolveBuffer(icon)
-        .then(data => this.edit({ icon: this.client.resolver.resolveBase64(data) }));
-    }
+    return this.client.resolver.resolveImage(icon)
+      .then(data => this.edit({ icon: data }));
   }
 
   /**

--- a/src/structures/GroupDMChannel.js
+++ b/src/structures/GroupDMChannel.js
@@ -159,9 +159,8 @@ class GroupDMChannel extends Channel {
    * @param {Base64Resolvable} icon The new icon of this Group DM
    * @returns {Promise<GroupDMChannel>}
    */
-  setIcon(icon) {
-    return this.client.resolver.resolveImage(icon)
-      .then(data => this.edit({ icon: data }));
+  async setIcon(icon) {
+    return this.edit({ icon: await this.client.resolver.resolveImage(icon) });
   }
 
   /**

--- a/src/structures/GroupDMChannel.js
+++ b/src/structures/GroupDMChannel.js
@@ -156,7 +156,7 @@ class GroupDMChannel extends Channel {
 
   /**
    * Sets a new icon for this Group DM.
-   * @param {Base64Resolvable} icon The new icon of this Group DM
+   * @param {Base64Resolvable|BufferResolvable} icon The new icon of this Group DM
    * @returns {Promise<GroupDMChannel>}
    */
   async setIcon(icon) {

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -792,9 +792,8 @@ class Guild {
    *  .then(updated => console.log('Updated the guild icon'))
    *  .catch(console.error);
    */
-  setIcon(icon, reason) {
-    return this.client.resolver.resolveImage(icon)
-      .then(data => this.edit({ icon: data }, reason));
+  async setIcon(icon, reason) {
+    return this.edit({ icon: await this.client.resolver.resolveImage(icon), reason });
   }
 
   /**
@@ -819,13 +818,12 @@ class Guild {
    * @returns {Promise<Guild>}
    * @example
    * // Edit the guild splash
-   * guild.setIcon(fs.readFileSync('./splash.png'))
+   * guild.setSplash(fs.readFileSync('./splash.png'))
    *  .then(updated => console.log('Updated the guild splash'))
    *  .catch(console.error);
    */
-  setSplash(splash, reason) {
-    return this.client.resolver.resolveImage(splash)
-      .then(data => this.edit({ splash: data }, reason));
+  async setSplash(splash, reason) {
+    return this.edit({ avatar: await this.client.resolver.resolveImage(splash), reason });
   }
 
   /**

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -788,7 +788,7 @@ class Guild {
    * @returns {Promise<Guild>}
    * @example
    * // Edit the guild icon
-   * guild.setIcon(fs.readFileSync('./icon.png'))
+   * guild.setIcon('./icon.png')
    *  .then(updated => console.log('Updated the guild icon'))
    *  .catch(console.error);
    */
@@ -818,7 +818,7 @@ class Guild {
    * @returns {Promise<Guild>}
    * @example
    * // Edit the guild splash
-   * guild.setSplash(fs.readFileSync('./splash.png'))
+   * guild.setSplash('./splash.png')
    *  .then(updated => console.log('Updated the guild splash'))
    *  .catch(console.error);
    */

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -783,7 +783,7 @@ class Guild {
 
   /**
    * Set a new guild icon.
-   * @param {Base64Resolvable} icon The new icon of the guild
+   * @param {Base64Resolvable|BufferResolvable} icon The new icon of the guild
    * @param {string} [reason] Reason for changing the guild's icon
    * @returns {Promise<Guild>}
    * @example
@@ -813,7 +813,7 @@ class Guild {
 
   /**
    * Set a new guild splash screen.
-   * @param {Base64Resolvable} splash The new splash screen of the guild
+   * @param {Base64Resolvable|BufferResolvable} splash The new splash screen of the guild
    * @param {string} [reason] Reason for changing the guild's splash screen
    * @returns {Promise<Guild>}
    * @example

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -823,7 +823,7 @@ class Guild {
    *  .catch(console.error);
    */
   async setSplash(splash, reason) {
-    return this.edit({ avatar: await this.client.resolver.resolveImage(splash), reason });
+    return this.edit({ splash: await this.client.resolver.resolveImage(splash), reason });
   }
 
   /**

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -793,7 +793,8 @@ class Guild {
    *  .catch(console.error);
    */
   setIcon(icon, reason) {
-    return this.edit({ icon }, reason);
+    return this.client.resolver.resolveImage(icon)
+      .then(data => this.edit({ icon: data }, reason));
   }
 
   /**
@@ -823,7 +824,8 @@ class Guild {
    *  .catch(console.error);
    */
   setSplash(splash, reason) {
-    return this.edit({ splash }, reason);
+    return this.client.resolver.resolveImage(splash)
+      .then(data => this.edit({ splash: data }, reason));
   }
 
   /**

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -1119,7 +1119,7 @@ class Guild {
         .then(emoji => this.client.actions.GuildEmojiCreate.handle(this, emoji).emoji);
     }
 
-    return this.client.resolver.resolveBuffer(attachment)
+    return this.client.resolver.resolveFile(attachment)
       .then(data => {
         const dataURI = this.client.resolver.resolveBase64(data);
         return this.createEmoji(dataURI, name, { roles, reason });

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -676,9 +676,9 @@ class Guild {
     if (data.afkChannel) _data.afk_channel_id = this.client.resolver.resolveChannel(data.afkChannel).id;
     if (data.systemChannel) _data.system_channel_id = this.client.resolver.resolveChannel(data.systemChannel).id;
     if (data.afkTimeout) _data.afk_timeout = Number(data.afkTimeout);
-    if (data.icon) _data.icon = this.client.resolver.resolveBase64(data.icon);
+    if (data.icon) _data.icon = data.icon;
     if (data.owner) _data.owner_id = this.client.resolver.resolveUser(data.owner).id;
-    if (data.splash) _data.splash = this.client.resolver.resolveBase64(data.splash);
+    if (data.splash) _data.splash = data.splash;
     if (typeof data.explicitContentFilter !== 'undefined') {
       _data.explicit_content_filter = Number(data.explicitContentFilter);
     }

--- a/src/structures/TextChannel.js
+++ b/src/structures/TextChannel.js
@@ -64,7 +64,7 @@ class TextChannel extends GuildChannel {
         name, avatar,
       }, reason }).then(data => new Webhook(this.client, data));
     } else {
-      return this.client.resolver.resolveBuffer(avatar).then(data =>
+      return this.client.resolver.resolveFile(avatar).then(data =>
         this.createWebhook(name, this.client.resolver.resolveBase64(data) || null));
     }
   }

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -254,7 +254,7 @@ class Webhook {
    */
   edit({ name = this.name, avatar }, reason) {
     if (avatar && (typeof avatar === 'string' && !avatar.startsWith('data:'))) {
-      return this.client.resolver.resolveBuffer(avatar).then(file => {
+      return this.client.resolver.resolveFile(avatar).then(file => {
         const dataURI = this.client.resolver.resolveBase64(file);
         return this.edit({ name, avatar: dataURI }, reason);
       });


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Removes a lot of duplicate code regarding setting images for the Guild, ClientUser and GroupDMChannel classes.
Guild#setIcon and Guild#setSplash now accept remote URLs.
Also fixed unintentional breaking change with resolveFile (no longer breaking).

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.