### PR TITLE
Allow Message#edit to accept a RichEmbed and fixed RichEmbed#file's type

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -1,6 +1,7 @@
 const Mentions = require('./MessageMentions');
 const Attachment = require('./MessageAttachment');
 const Embed = require('./MessageEmbed');
+const RichEmbed = require('./RichEmbed');
 const MessageReaction = require('./MessageReaction');
 const ReactionCollector = require('./ReactionCollector');
 const Util = require('../util/Util');
@@ -365,7 +366,7 @@ class Message {
   /**
    * Edit the content of the message.
    * @param {StringResolvable} [content] The new content for the message
-   * @param {MessageEditOptions} [options] The options to provide
+   * @param {MessageEditOptions|RichEmbed} [options] The options to provide
    * @returns {Promise<Message>}
    * @example
    * // Update the content of a message
@@ -380,6 +381,7 @@ class Message {
     } else if (!options) {
       options = {};
     }
+    if (options instanceof RichEmbed) options = { embed: options };
     return this.client.rest.methods.updateMessage(this, content, options);
   }
 

--- a/src/structures/RichEmbed.js
+++ b/src/structures/RichEmbed.js
@@ -69,7 +69,7 @@ class RichEmbed {
 
     /**
      * File to upload alongside this Embed
-     * @type {string}
+     * @type {FileOptions|string|Attachment}
      */
     this.file = data.file;
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Since `TextBasedChannel#send` accepts a `RichEmbed` as options parameter `Message#edit` should do that too.
Also fixed the `Richembed#file` type as it can be an Attachment, FileOptions or a string.

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
