### PR TITLE
Fix leftover resolveBuffer calls

### DIFF
--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -175,7 +175,7 @@ class ClientUser extends User {
     if (typeof avatar === 'string' && avatar.startsWith('data:')) {
       return this.edit({ avatar });
     } else {
-      return this.client.resolver.resolveBuffer(avatar || Buffer.alloc(0))
+      return this.client.resolver.resolveFile(avatar || Buffer.alloc(0))
         .then(data => this.edit({ avatar: this.client.resolver.resolveBase64(data) || null }));
     }
   }
@@ -347,7 +347,7 @@ class ClientUser extends User {
           }, reject)
       );
     } else {
-      return this.client.resolver.resolveBuffer(icon)
+      return this.client.resolver.resolveFile(icon)
         .then(data => this.createGuild(name, { region, icon: this.client.resolver.resolveBase64(data) || null }));
     }
   }

--- a/src/structures/GroupDMChannel.js
+++ b/src/structures/GroupDMChannel.js
@@ -165,7 +165,7 @@ class GroupDMChannel extends Channel {
     } else if (!icon) {
       return this.edit({ icon: null });
     } else {
-      return this.client.resolver.resolveBuffer(icon)
+      return this.client.resolver.resolveFile(icon)
         .then(data => this.edit({ icon: this.client.resolver.resolveBase64(data) }));
     }
   }

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -1117,7 +1117,7 @@ class Guild {
         .then(emoji => this.client.actions.GuildEmojiCreate.handle(this, emoji).emoji);
     }
 
-    return this.client.resolver.resolveBuffer(attachment)
+    return this.client.resolver.resolveFile(attachment)
       .then(data => {
         const dataURI = this.client.resolver.resolveBase64(data);
         return this.createEmoji(dataURI, name, { roles, reason });

--- a/src/structures/TextChannel.js
+++ b/src/structures/TextChannel.js
@@ -64,7 +64,7 @@ class TextChannel extends GuildChannel {
         name, avatar,
       }, reason }).then(data => new Webhook(this.client, data));
     } else {
-      return this.client.resolver.resolveBuffer(avatar).then(data =>
+      return this.client.resolver.resolveFile(avatar).then(data =>
         this.createWebhook(name, this.client.resolver.resolveBase64(data) || null));
     }
   }

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -254,7 +254,7 @@ class Webhook {
    */
   edit({ name = this.name, avatar }, reason) {
     if (avatar && (typeof avatar === 'string' && !avatar.startsWith('data:'))) {
-      return this.client.resolver.resolveBuffer(avatar).then(file => {
+      return this.client.resolver.resolveFile(avatar).then(file => {
         const dataURI = this.client.resolver.resolveBase64(file);
         return this.edit({ name, avatar: dataURI }, reason);
       });


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`ClientDataResolver.resolveBuffer` was merged into `ClientDataResolver.resolveFile`
This commit points all instances of `resolveBuffer` to `resolveFile`

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
