### PR TITLE
Mark video property as readonly

### DIFF
--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -92,6 +92,7 @@ class MessageEmbed {
      * @property {string} url URL of this video
      * @property {number} height Height of this video
      * @property {number} width Width of this video
+     * @readonly
      */
     this.video = data.video;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Marks the video property of MessageEmbed as ready-only for documentation purposes

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
- [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
