### PR TITLE
Fix copy paste

### DIFF
--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -171,7 +171,7 @@ class MessageEmbed {
     name = Util.resolveString(name);
     if (!String(name) || name.length > 256) throw new RangeError('EMBED_FIELD_NAME');
     value = Util.resolveString(value);
-    if (!String(name) || value.length > 1024) throw new RangeError('EMBED_FIELD_VALUE');
+    if (!String(value) || value.length > 1024) throw new RangeError('EMBED_FIELD_VALUE');
     this.fields.push({ name, value, inline });
     return this;
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes the small copy paste mistake I found in MessageEmbed about the field value, which would've returned if the name wasn't a string, or the field description length was greater, instead of erroring if the value isn't defined at all, or if its length is too big.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
