### PR TITLE
Change the documentation to have a "dot"

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -56,7 +56,7 @@ class Message extends Base {
     this.author = this.client.users.create(data.author);
 
     /**
-     * Represents the author of the message as a guild member
+     * Represents the author of the message as a guild member.
      * Only available if the message comes from a guild where the author is still a member
      * @type {?GuildMember}
      */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Makes the docs look.. uh.. better? by adding one dot.
Let me know if its intended or not, but the "dot" version looks better imo.
This: ![heh](https://auttaja-got.ratelimited.today/e241f1.png)
Looks better than this in my opinion:
![help](https://auttaja-got.ratelimited.today/81509e.png)

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
