### PR TITLE
Fix MessageMentions#has not returning true for role mentions

### DIFF
--- a/src/structures/MessageMentions.js
+++ b/src/structures/MessageMentions.js
@@ -126,7 +126,7 @@ class MessageMentions {
   has(data, strict = true) {
     if (strict && this.everyone) return true;
     if (strict && data instanceof GuildMember) {
-      for (const role of this.roles) if (data.roles.has(role.id)) return true;
+      for (const role of this.roles.values()) if (data.roles.has(role.id)) return true;
     }
     const id = data.id || data;
     return this.users.has(id) || this.channels.has(id) || this.roles.has(id);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Missing `.values()` was passing a tuple to `Collection#has`, which would never return true here.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
