### PR TITLE
Fixed DataStore, deprecation leftovers and a bit of Event Constants

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -365,7 +365,7 @@ class Client extends EventEmitter {
       throw new TypeError('CLIENT_INVALID_OPTION', 'Lifetime', 'a number');
     }
     if (lifetime <= 0) {
-      this.emit('debug', 'Didn\'t sweep messages - lifetime is unlimited');
+      this.emit(Constants.Events.DEBUG, 'Didn\'t sweep messages - lifetime is unlimited');
       return -1;
     }
 
@@ -386,7 +386,8 @@ class Client extends EventEmitter {
       }
     }
 
-    this.emit('debug', `Swept ${messages} messages older than ${lifetime} seconds in ${channels} text-based channels`);
+    this.emit(Constants.Events.DEBUG,
+      `Swept ${messages} messages older than ${lifetime} seconds in ${channels} text-based channels`);
     return messages;
   }
 

--- a/src/client/websocket/WebSocketManager.js
+++ b/src/client/websocket/WebSocketManager.js
@@ -37,7 +37,7 @@ class WebSocketManager extends EventEmitter {
    * @returns {void}
    */
   debug(message) {
-    return this.client.emit('debug', `[ws] ${message}`);
+    return this.client.emit(Constants.Events.DEBUG, `[ws] ${message}`);
   }
 
   /**

--- a/src/client/websocket/packets/handlers/Ready.js
+++ b/src/client/websocket/packets/handlers/Ready.js
@@ -1,5 +1,5 @@
 const AbstractHandler = require('./AbstractHandler');
-
+const Constants = require('../../../../util/Constants');
 const ClientUser = require('../../../../structures/ClientUser');
 
 class ReadyHandler extends AbstractHandler {
@@ -73,7 +73,7 @@ class ReadyHandler extends AbstractHandler {
 
     ws.sessionID = data.session_id;
     ws._trace = data._trace;
-    client.emit('debug', `READY ${ws._trace.join(' -> ')} ${ws.sessionID}`);
+    client.emit(Constants.Events.DEBUG, `READY ${ws._trace.join(' -> ')} ${ws.sessionID}`);
     ws.checkIfReady();
   }
 }

--- a/src/client/websocket/packets/handlers/RelationshipAdd.js
+++ b/src/client/websocket/packets/handlers/RelationshipAdd.js
@@ -5,11 +5,11 @@ class RelationshipAddHandler extends AbstractHandler {
     const client = this.packetManager.client;
     const data = packet.d;
     if (data.type === 1) {
-      client.fetchUser(data.id).then(user => {
+      client.users.fetch(data.id).then(user => {
         client.user.friends.set(user.id, user);
       });
     } else if (data.type === 2) {
-      client.fetchUser(data.id).then(user => {
+      client.users.fetch(data.id).then(user => {
         client.user.blocked.set(user.id, user);
       });
     }

--- a/src/client/websocket/packets/handlers/Resumed.js
+++ b/src/client/websocket/packets/handlers/Resumed.js
@@ -14,7 +14,7 @@ class ResumedHandler extends AbstractHandler {
     const replayed = ws.sequence - ws.closeSequence;
 
     ws.debug(`RESUMED ${ws._trace.join(' -> ')} | replayed ${replayed} events.`);
-    client.emit('resume', replayed);
+    client.emit(Constants.Events.RESUME, replayed);
     ws.heartbeat();
   }
 }

--- a/src/client/websocket/packets/handlers/Resumed.js
+++ b/src/client/websocket/packets/handlers/Resumed.js
@@ -14,14 +14,14 @@ class ResumedHandler extends AbstractHandler {
     const replayed = ws.sequence - ws.closeSequence;
 
     ws.debug(`RESUMED ${ws._trace.join(' -> ')} | replayed ${replayed} events.`);
-    client.emit(Constants.Events.RESUME, replayed);
+    client.emit(Constants.Events.RESUMED, replayed);
     ws.heartbeat();
   }
 }
 
 /**
- * Emitted whenever a WebSocket resumes.
- * @event Client#resume
+ * Emitted whenever a WebSocket resumed.
+ * @event Client#resumed
  * @param {number} replayed The number of events that were replayed
  */
 

--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -6,10 +6,8 @@ const Messages = {
   TOKEN_INVALID: 'An invalid token was provided.',
   TOKEN_MISSING: 'Request to use token, but token was unavailable to the client.',
 
-  FEATURE_BOT_ONLY: 'Only bot accounts are able to make use of this feature.',
   FEATURE_USER_ONLY: 'Only user accounts are able to make use of this feature.',
 
-  WS_BAD_MESSAGE: 'A bad message was received from the websocket; either bad compression, or not JSON.',
   WS_CONNECTION_EXISTS: 'There is already an existing WebSocket connection.',
   WS_NOT_OPEN: (data = 'data') => `Websocket not open to send ${data}`,
 
@@ -25,8 +23,6 @@ const Messages = {
   SHARDING_IN_PROCESS: 'Shards are still being spawned',
   SHARDING_ALREADY_SPAWNED: count => `Already spawned ${count} shards`,
 
-  SHARD_MESSAGE_FAILED: 'Failed to send message to master process.',
-
   COLOR_RANGE: 'Color must be within the range 0 - 16777215 (0xFFFFFF).',
   COLOR_CONVERT: 'Unable to convert color to a number.',
 
@@ -39,8 +35,6 @@ const Messages = {
 
   FILE_NOT_FOUND: file => `File could not be found: ${file}`,
 
-  USER_STATUS: 'User status must be a string',
-  USER_NOT_CACHED: 'User is not cached. Use Client.fetchUser first.',
   USER_NO_DMCHANNEL: 'No DM Channel exists!',
 
   VOICE_INVALID_HEARTBEAT: 'Tried to set voice heartbeat but no valid interval was specified.',
@@ -90,7 +84,6 @@ const Messages = {
   GUILD_MEMBERS_TIMEOUT: 'Members didn\'t arrive in time.',
 
   INVALID_TYPE: (name, expected, an = false) => `Supplied ${name} is not a${an ? 'n' : ''} ${expected}.`,
-
 
   WEBHOOK_MESSAGE: 'The message was not sent by a webhook.',
 

--- a/src/sharding/ShardClientUtil.js
+++ b/src/sharding/ShardClientUtil.js
@@ -1,4 +1,5 @@
 const Util = require('../util/Util');
+const Constants = require('../util/Constants');
 const { Error } = require('../errors');
 
 /**
@@ -123,7 +124,7 @@ class ShardClientUtil {
   _respond(type, message) {
     this.send(message).catch(err => {
       err.message = `Error when sending ${type} response to master process: ${err.message}`;
-      this.client.emit('error', err);
+      this.client.emit(Constants.Events.ERROR, err);
     });
   }
 
@@ -136,7 +137,8 @@ class ShardClientUtil {
     if (!this._singleton) {
       this._singleton = new this(client);
     } else {
-      client.emit('warn', 'Multiple clients created in child process; only the first will handle sharding helpers.');
+      client.emit(Constants.Events.WARN,
+        'Multiple clients created in child process; only the first will handle sharding helpers.');
     }
     return this._singleton;
   }

--- a/src/structures/DMChannel.js
+++ b/src/structures/DMChannel.js
@@ -38,9 +38,6 @@ class DMChannel extends Channel {
   // These are here only for documentation purposes - they are implemented by TextBasedChannel
   /* eslint-disable no-empty-function */
   send() {}
-  fetchMessage() {}
-  fetchMessages() {}
-  fetchPinnedMessages() {}
   search() {}
   startTyping() {}
   stopTyping() {}

--- a/src/structures/GroupDMChannel.js
+++ b/src/structures/GroupDMChannel.js
@@ -219,9 +219,6 @@ class GroupDMChannel extends Channel {
   // These are here only for documentation purposes - they are implemented by TextBasedChannel
   /* eslint-disable no-empty-function */
   send() {}
-  fetchMessage() {}
-  fetchMessages() {}
-  fetchPinnedMessages() {}
   search() {}
   startTyping() {}
   stopTyping() {}

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -285,7 +285,7 @@ class Message extends Base {
    */
 
   /**
-   * Similar to createCollector but in promise form.
+   * Similar to createMessageCollector but in promise form.
    * Resolves with a collection of reactions that pass the specified filter.
    * @param {CollectorFilter} filter The filter function to use
    * @param {AwaitReactionsOptions} [options={}] Optional options to pass to the internal collector

--- a/src/structures/TextChannel.js
+++ b/src/structures/TextChannel.js
@@ -73,9 +73,6 @@ class TextChannel extends GuildChannel {
   // These are here only for documentation purposes - they are implemented by TextBasedChannel
   /* eslint-disable no-empty-function */
   send() {}
-  fetchMessage() {}
-  fetchMessages() {}
-  fetchPinnedMessages() {}
   search() {}
   startTyping() {}
   stopTyping() {}

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -279,7 +279,9 @@ class TextBasedChannel {
    * @returns {Promise<Collection<Snowflake, Message>>} Deleted messages
    */
   bulkDelete(messages, filterOld = false) {
-    if (!isNaN(messages)) return this.fetchMessages({ limit: messages }).then(msgs => this.bulkDelete(msgs, filterOld));
+    if (!isNaN(messages)) {
+      return this.messages.fetch({ limit: messages }).then(msgs => this.bulkDelete(msgs, filterOld));
+    }
     if (messages instanceof Array || messages instanceof Collection) {
       let messageIDs = messages instanceof Collection ? messages.keyArray() : messages.map(m => m.id);
       if (filterOld) {

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -245,8 +245,8 @@ class TextBasedChannel {
    */
 
   /**
-   * Similar to createCollector but in promise form. Resolves with a collection of messages that pass the specified
-   * filter.
+   * Similar to createMessageCollector but in promise form.
+   * Resolves with a collection of messages that pass the specified filter.
    * @param {CollectorFilter} filter The filter function to use
    * @param {AwaitMessagesOptions} [options={}] Optional options to pass to the internal collector
    * @returns {Promise<Collection<Snowflake, Message>>}

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -196,7 +196,7 @@ exports.VoiceOPCodes = {
 
 exports.Events = {
   READY: 'ready',
-  RESUME: 'resume',
+  RESUMED: 'resumed',
   GUILD_CREATE: 'guildCreate',
   GUILD_DELETE: 'guildDelete',
   GUILD_UPDATE: 'guildUpdate',

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -196,6 +196,7 @@ exports.VoiceOPCodes = {
 
 exports.Events = {
   READY: 'ready',
+  RESUME: 'resume',
   GUILD_CREATE: 'guildCreate',
   GUILD_DELETE: 'guildDelete',
   GUILD_UPDATE: 'guildUpdate',


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes #1838 
- Replaced hopefully all `fetchUser`s and `fetchMessages` (couldn't find anything else) whith their respective Datastore method.
- Removed unused error messages.
- Removed no longer existing methods from Channel classes.
- Added `RESUMED` event constant
Also changed `Client#resume` to `Client#resumed` as that was a typo.
- Used event constants everywhere possible over hardcoded strings.
- Replaced mention ot `createCollector` with `createMessageCollector` as that method name was deprecated and already removed.


**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
