### PR TITLE
Simplified image resolving and used an options object when creating webhooks

### DIFF
--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -341,10 +341,10 @@ class ClientUser extends User {
             return undefined;
           }, reject)
       );
-    } else {
-      return this.client.resolver.resolveFile(icon)
-        .then(data => this.createGuild(name, { region, icon: this.client.resolver.resolveBase64(data) || null }));
     }
+
+    return this.client.resolver.resolveImage(icon)
+      .then(data => this.createGuild(name, { region, icon: data || null }));
   }
 
   /**

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -1044,11 +1044,8 @@ class Guild extends Base {
         .then(emoji => this.client.actions.GuildEmojiCreate.handle(this, emoji).emoji);
     }
 
-    return this.client.resolver.resolveFile(attachment)
-      .then(data => {
-        const dataURI = this.client.resolver.resolveBase64(data);
-        return this.createEmoji(dataURI, name, { roles, reason });
-      });
+    return this.client.resolver.resolveImage(attachment)
+      .then(image => this.createEmoji(image, name, { roles, reason }));
   }
 
   /**

--- a/src/structures/TextChannel.js
+++ b/src/structures/TextChannel.js
@@ -51,23 +51,23 @@ class TextChannel extends GuildChannel {
   /**
    * Create a webhook for the channel.
    * @param {string} name The name of the webhook
-   * @param {BufferResolvable|Base64Resolvable} avatar The avatar for the webhook
-   * @param {string} [reason] Reason for creating this webhook
+   * @param {Object} [options] Options for creating the webhook
+   * @param {BufferResolvable|Base64Resolvable} [options.avatar] Avatar for the webhook
+   * @param {string} [options.reason] Reason for creating the webhook
    * @returns {Promise<Webhook>} webhook The created webhook
    * @example
    * channel.createWebhook('Snek', 'https://i.imgur.com/mI8XcpG.jpg')
    *   .then(webhook => console.log(`Created webhook ${webhook}`))
    *   .catch(console.error)
    */
-  createWebhook(name, avatar, reason) {
+  createWebhook(name, { avatar, reason } = {}) {
     if (typeof avatar === 'string' && avatar.startsWith('data:')) {
       return this.client.api.channels[this.id].webhooks.post({ data: {
         name, avatar,
       }, reason }).then(data => new Webhook(this.client, data));
-    } else {
-      return this.client.resolver.resolveFile(avatar).then(data =>
-        this.createWebhook(name, this.client.resolver.resolveBase64(data) || null));
     }
+    return this.client.resolver.resolveImage(avatar).then(image =>
+      this.createWebhook(name, { avatar: image, reason }));
   }
 
   // These are here only for documentation purposes - they are implemented by TextBasedChannel

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -254,10 +254,9 @@ class Webhook {
    */
   edit({ name = this.name, avatar }, reason) {
     if (avatar && (typeof avatar === 'string' && !avatar.startsWith('data:'))) {
-      return this.client.resolver.resolveFile(avatar).then(file => {
-        const dataURI = this.client.resolver.resolveBase64(file);
-        return this.edit({ name, avatar: dataURI }, reason);
-      });
+      return this.client.resolver.resolveImage(avatar).then(image =>
+        this.edit({ name, avatar: image }, reason)
+      );
     }
     return this.client.api.webhooks(this.id, this.token).patch({
       data: { name, avatar },


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Simplified `resolveFile` -> `resolveBase64` by using `resolveImage` wherever possible.

Also made `TextChannel#createWebhook` accept an options object as `avatar` and `reason` are both optional.

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
