### PR TITLE
Allow Message#edit to accept a MessageEmbed as options parameter

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -354,7 +354,7 @@ class Message extends Base {
   /**
    * Edit the content of the message.
    * @param {StringResolvable} [content] The new content for the message
-   * @param {MessageEditOptions} [options] The options to provide
+   * @param {MessageEditOptions|MessageEmbed} [options] The options to provide
    * @returns {Promise<Message>}
    * @example
    * // Update the content of a message
@@ -369,6 +369,8 @@ class Message extends Base {
     } else if (!options) {
       options = {};
     }
+    if (options instanceof Embed) options = { embed: options };
+
     if (typeof options.content !== 'undefined') content = options.content;
 
     if (typeof content !== 'undefined') content = Util.resolveString(content);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Make `Message#edit` also accept an `MessageEmbed` as direct options paremeter since `TextBasedChannel#send` does that too.

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
