### PR TITLE
Mutual guilds implementation on the User class

### DIFF
--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -119,6 +119,14 @@ class User extends Base {
   get defaultAvatarURL() {
     return Constants.Endpoints.CDN(this.client.options.http.cdn).DefaultAvatar(this.discriminator % 5);
   }
+  
+  /**
+   * A collection of mutual guilds shared between the user and the client.
+   * @type {Collection}
+   */
+  get mutualGuilds() {
+    return this.client.guilds.filter(g => g.members.has(this.id));
+  }
 
   /**
    * A link to the user's avatar if they have one.

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -119,7 +119,7 @@ class User extends Base {
   get defaultAvatarURL() {
     return Constants.Endpoints.CDN(this.client.options.http.cdn).DefaultAvatar(this.discriminator % 5);
   }
-  
+
   /**
    * A collection of mutual guilds shared between the user and the client.
    * @type {Collection}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR implements a `mutualGuilds` property in the User class.
How it works: it returns the guilds collection containing guilds where the User is on.
I know we can get the same thing in the `fetchProfile` method but that's something we would like to get implemented on d.js because it is already in a lot of other librairies for Discord without needing of fetching profile (so having a user account).

**Semantic versioning classification:**  
- [X] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
