### PR TITLE
Consistently store message reactions keyed under their unicode

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -536,7 +536,7 @@ class Message {
   }
 
   _addReaction(emoji, user) {
-    const emojiID = emoji.id ? `${emoji.name}:${emoji.id}` : encodeURIComponent(emoji.name);
+    const emojiID = emoji.id ? `${emoji.name}:${emoji.id}` : emoji.name;
     let reaction;
     if (this.reactions.has(emojiID)) {
       reaction = this.reactions.get(emojiID);
@@ -553,7 +553,7 @@ class Message {
   }
 
   _removeReaction(emoji, user) {
-    const emojiID = emoji.id ? `${emoji.name}:${emoji.id}` : encodeURIComponent(emoji.name);
+    const emojiID = emoji.id ? `${emoji.name}:${emoji.id}` : emoji.name;
     if (this.reactions.has(emojiID)) {
       const reaction = this.reactions.get(emojiID);
       if (reaction.users.has(user.id)) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

If fetched via api the reactions are mapped by their unicode's as names, if from ws (or faked via `Message#react` they are mapped by their uri encoded value.

This will now key them always under their unicode.

Obviuosly only for default reactions.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
