### PR TITLE
fix removal of Guild#afk/system channels and icon

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -610,7 +610,7 @@ class Guild extends Base {
       _data.system_channel_id = channel ? channel.id : null;
     }
     if (data.afkTimeout) _data.afk_timeout = Number(data.afkTimeout);
-    if (data.icon) _data.icon = data.icon;
+    if (typeof data.icon !== 'undefined') _data.icon = data.icon;
     if (data.owner) _data.owner_id = this.client.resolver.resolveUser(data.owner).id;
     if (data.splash) _data.splash = data.splash;
     if (typeof data.explicitContentFilter !== 'undefined') {

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -602,12 +602,10 @@ class Guild extends Base {
     if (data.region) _data.region = data.region;
     if (typeof data.verificationLevel !== 'undefined') _data.verification_level = Number(data.verificationLevel);
     if (typeof data.afkChannel !== 'undefined') {
-      const channel = this.client.resolver.resolveChannel(data.afkChannel);
-      _data.afk_channel_id = channel ? channel.id : null;
+      _data.afk_channel_id = this.client.resolver.resolveChannelID(data.afkChannel);
     }
     if (typeof data.systemChannel !== 'undefined') {
-      const channel = this.client.resolver.resolveChannel(data.systemChannel);
-      _data.system_channel_id = channel ? channel.id : null;
+      _data.system_channel_id = this.client.resolver.resolveChannelID(data.systemChannel);
     }
     if (data.afkTimeout) _data.afk_timeout = Number(data.afkTimeout);
     if (typeof data.icon !== 'undefined') _data.icon = data.icon;

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -300,7 +300,7 @@ class Guild extends Base {
    * @readonly
    */
   get afkChannel() {
-    return this.client.channels.get(this.afkChannelID);
+    return this.client.channels.get(this.afkChannelID) || null;
   }
 
   /**
@@ -309,7 +309,7 @@ class Guild extends Base {
    * @readonly
    */
   get systemChannel() {
-    return this.client.channels.get(this.systemChannelID);
+    return this.client.channels.get(this.systemChannelID) || null;
   }
 
   /**
@@ -601,8 +601,14 @@ class Guild extends Base {
     if (data.name) _data.name = data.name;
     if (data.region) _data.region = data.region;
     if (typeof data.verificationLevel !== 'undefined') _data.verification_level = Number(data.verificationLevel);
-    if (data.afkChannel) _data.afk_channel_id = this.client.resolver.resolveChannel(data.afkChannel).id;
-    if (data.systemChannel) _data.system_channel_id = this.client.resolver.resolveChannel(data.systemChannel).id;
+    if (typeof data.afkChannel !== 'undefined') {
+      const channel = this.client.resolver.resolveChannel(data.afkChannel);
+      _data.afk_channel_id = channel ? channel.id : null;
+    }
+    if (typeof data.systemChannel !== 'undefined') {
+      const channel = this.client.resolver.resolveChannel(data.systemChannel);
+      _data.system_channel_id = channel ? channel.id : null;
+    }
     if (data.afkTimeout) _data.afk_timeout = Number(data.afkTimeout);
     if (data.icon) _data.icon = data.icon;
     if (data.owner) _data.owner_id = this.client.resolver.resolveUser(data.owner).id;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixed issue where passing null to Guild#setAFKChannel, Guild#setSystemChannel and Guild#setIcon would resolve and do nothing, since the edit method was checking for truthy. Also makes the getters for each one return null if it is not set, in order to be consistent with similar getters.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.