### PR TITLE
feat/fix: add DiscordAPIError#path and fixed Burst request handler handling api errors

### DIFF
--- a/src/client/rest/DiscordAPIError.js
+++ b/src/client/rest/DiscordAPIError.js
@@ -3,11 +3,17 @@
  * @extends Error
  */
 class DiscordAPIError extends Error {
-  constructor(error) {
+  constructor(path, error) {
     super();
     const flattened = this.constructor.flattenErrors(error.errors || error).join('\n');
     this.name = 'DiscordAPIError';
     this.message = error.message && flattened ? `${error.message}\n${flattened}` : error.message || flattened;
+
+    /**
+     * The path of the request relative to the HTTP endpoint
+     * @type {string}
+     */
+    this.path = path;
 
     /**
      * HTTP error code returned by Discord

--- a/src/client/rest/RequestHandlers/Burst.js
+++ b/src/client/rest/RequestHandlers/Burst.js
@@ -47,7 +47,7 @@ class BurstRequestHandler extends RequestHandler {
             this.resetTimeout = null;
           }, 1e3 + this.client.options.restTimeOffset);
         } else {
-          item.reject(err.status === 400 ? new DiscordAPIError(res.body) : err);
+          item.reject(err.status >= 400 && err.status < 500 ? new DiscordAPIError(res.request.path, res.body) : err);
           this.handle();
         }
       } else {

--- a/src/client/rest/RequestHandlers/Sequential.js
+++ b/src/client/rest/RequestHandlers/Sequential.js
@@ -68,7 +68,7 @@ class SequentialRequestHandler extends RequestHandler {
             this.queue.unshift(item);
             this.restManager.client.setTimeout(resolve, 1e3 + this.client.options.restTimeOffset);
           } else {
-            item.reject(err.status >= 400 && err.status < 500 ? new DiscordAPIError(res.body) : err);
+            item.reject(err.status >= 400 && err.status < 500 ? new DiscordAPIError(res.request.path, res.body) : err);
             resolve(err);
           }
         } else {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Backported `DiscordAPIError#path` from #1577.

And fixed the burst request handler which was rejecting with the raw error instead of an DiscordAPIError when the response code was not `400`, for example a permission error which responds with `403`.

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
