### PR TITLE
refactor/fix(DataStores): move instantiating of store related classes into their date stores

### DIFF
--- a/src/client/actions/GuildSync.js
+++ b/src/client/actions/GuildSync.js
@@ -7,7 +7,7 @@ class GuildSync extends Action {
     const guild = client.guilds.get(data.id);
     if (guild) {
       if (data.presences) {
-        for (const presence of data.presences) guild._setPresence(presence.user.id, presence);
+        for (const presence of data.presences) guild.presences.create(presence);
       }
 
       if (data.members) {

--- a/src/client/rest/RESTManager.js
+++ b/src/client/rest/RESTManager.js
@@ -2,6 +2,7 @@ const UserAgentManager = require('./UserAgentManager');
 const handlers = require('./handlers');
 const APIRequest = require('./APIRequest');
 const routeBuilder = require('./APIRouter');
+const Constants = require('../../util/Constants');
 const { Error } = require('../../errors');
 
 class RESTManager {
@@ -15,6 +16,10 @@ class RESTManager {
 
   get api() {
     return routeBuilder(this);
+  }
+
+  get cdn() {
+    return Constants.Endpoints.CDN(this.client.options.http.cdn);
   }
 
   destroy() {

--- a/src/client/websocket/packets/handlers/PresenceUpdate.js
+++ b/src/client/websocket/packets/handlers/PresenceUpdate.js
@@ -35,17 +35,17 @@ class PresenceUpdateHandler extends AbstractHandler {
       }
       if (member) {
         if (client.listenerCount(Constants.Events.PRESENCE_UPDATE) === 0) {
-          guild._setPresence(user.id, data);
+          guild.presences.create(data);
           return;
         }
         const oldMember = member._clone();
         if (member.presence) {
           oldMember.frozenPresence = member.presence._clone();
         }
-        guild._setPresence(user.id, data);
+        guild.presences.create(data);
         client.emit(Constants.Events.PRESENCE_UPDATE, oldMember, member);
       } else {
-        guild._setPresence(user.id, data);
+        guild.presences.create(data);
       }
     }
   }

--- a/src/client/websocket/packets/handlers/Ready.js
+++ b/src/client/websocket/packets/handlers/Ready.js
@@ -29,11 +29,7 @@ class ReadyHandler extends AbstractHandler {
       }
     }
 
-    data.presences = data.presences || [];
-    for (const presence of data.presences) {
-      client.users.create(presence.user);
-      client._setPresence(presence.user.id, presence);
-    }
+    for (const presence of data.presences || []) client.presences.create(presence);
 
     if (data.notes) {
       for (const user in data.notes) {
@@ -52,7 +48,7 @@ class ReadyHandler extends AbstractHandler {
         avatar: 'https://discordapp.com/assets/f78426a064bc9dd24847519259bc42af.png',
         bot: true,
         status: 'online',
-        game: null,
+        activity: null,
         verified: true,
       });
     }

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,7 @@ module.exports = {
   splitMessage: Util.splitMessage,
 
   // Structures
+  Activity: require('./structures/Presence').Activity,
   Attachment: require('./structures/Attachment'),
   Channel: require('./structures/Channel'),
   ClientUser: require('./structures/ClientUser'),
@@ -33,7 +34,6 @@ module.exports = {
   Collector: require('./structures/interfaces/Collector'),
   DMChannel: require('./structures/DMChannel'),
   Emoji: require('./structures/Emoji'),
-  Game: require('./structures/Presence').Game,
   GroupDMChannel: require('./structures/GroupDMChannel'),
   Guild: require('./structures/Guild'),
   GuildAuditLogs: require('./structures/GuildAuditLogs'),

--- a/src/stores/ChannelStore.js
+++ b/src/stores/ChannelStore.js
@@ -11,8 +11,8 @@ const lruable = ['group', 'dm'];
  * @extends {DataStore}
  */
 class ChannelStore extends DataStore {
-  constructor(client, options = {}) {
-    super(client);
+  constructor(client, iterable, options = {}) {
+    super(client, iterable);
 
     if (options.lru) {
       const lru = this[kLru] = [];

--- a/src/stores/ChannelStore.js
+++ b/src/stores/ChannelStore.js
@@ -11,8 +11,12 @@ const lruable = ['group', 'dm'];
  * @extends {DataStore}
  */
 class ChannelStore extends DataStore {
-  constructor(client, iterable, options = {}) {
-    super(client, iterable);
+  constructor(client, iterableOrOptions = {}, options) {
+    if (!options && typeof iterableOrOptions[Symbol.iterator] !== 'function') {
+      options = iterableOrOptions;
+      iterableOrOptions = undefined;
+    }
+    super(client, iterableOrOptions);
 
     if (options.lru) {
       const lru = this[kLru] = [];

--- a/src/stores/ChannelStore.js
+++ b/src/stores/ChannelStore.js
@@ -12,8 +12,8 @@ const lruable = ['group', 'dm'];
  * @extends {DataStore}
  */
 class ChannelStore extends DataStore {
-  constructor(iterable, options = {}) {
-    super(iterable);
+  constructor(client, options = {}) {
+    super(client);
 
     if (options.lru) {
       const lru = this[kLru] = [];

--- a/src/stores/ChannelStore.js
+++ b/src/stores/ChannelStore.js
@@ -1,6 +1,5 @@
 const DataStore = require('./DataStore');
-const DMChannel = require('../structures/DMChannel');
-const GroupDMChannel = require('../structures/GroupDMChannel');
+const Channel = require('../structures/Channel');
 const Constants = require('../util/Constants');
 
 const kLru = Symbol('LRU');
@@ -52,22 +51,11 @@ class ChannelStore extends DataStore {
     const existing = this.get(data.id);
     if (existing) return existing;
 
-    let channel;
-    switch (data.type) {
-      case Constants.ChannelTypes.DM:
-        channel = new DMChannel(this.client, data);
-        break;
-      case Constants.ChannelTypes.GROUP:
-        channel = new GroupDMChannel(this.client, data);
-        break;
-      default: // eslint-disable-line no-case-declarations
-        guild = guild || this.client.guilds.get(data.guild_id);
-        if (!guild) {
-          this.client.emit(Constants.Events.DEBUG, `Failed to find guild for channel ${data.id} ${data.type}`);
-          return null;
-        }
-        channel = guild.channels.create(data, cache);
-        break;
+    const channel = Channel.create(this.client, data, guild);
+
+    if (!channel) {
+      this.client.emit(Constants.Events.DEBUG, `Failed to find guild for channel ${data.id} ${data.type}`);
+      return null;
     }
 
     if (cache) this.set(channel.id, channel);

--- a/src/stores/ClientPresenceStore.js
+++ b/src/stores/ClientPresenceStore.js
@@ -2,6 +2,7 @@ const PresenceStore = require('./PresenceStore');
 const Collection = require('../util/Collection');
 const Constants = require('../util/Constants');
 const { Presence } = require('../structures/Presence');
+const { TypeError } = require('../errors');
 
 class ClientPresenceStore extends PresenceStore {
   constructor(...args) {
@@ -14,7 +15,9 @@ class ClientPresenceStore extends PresenceStore {
     });
   }
 
-  async setClientPresence({ status, since, afk, activity }) {
+  async setClientPresence({ status, since, afk, activity }) { // eslint-disable-line complexity
+    if (typeof activity.name !== 'string') throw new TypeError('INVALID_TYPE', 'name', 'string');
+    if (!activity.type) activity.type = 0;
     const applicationID = activity && (activity.application ? activity.application.id || activity.application : null);
     let assets = new Collection();
     if (activity && activity.assets && applicationID) {

--- a/src/stores/ClientPresenceStore.js
+++ b/src/stores/ClientPresenceStore.js
@@ -16,15 +16,17 @@ class ClientPresenceStore extends PresenceStore {
   }
 
   async setClientPresence({ status, since, afk, activity }) { // eslint-disable-line complexity
-    if (typeof activity.name !== 'string') throw new TypeError('INVALID_TYPE', 'name', 'string');
-    if (!activity.type) activity.type = 0;
     const applicationID = activity && (activity.application ? activity.application.id || activity.application : null);
     let assets = new Collection();
-    if (activity && activity.assets && applicationID) {
-      try {
-        const a = await this.client.api.oauth2.applications(applicationID).assets.get();
-        for (const asset of a) assets.set(asset.name, asset.id);
-      } catch (err) {} // eslint-disable-line no-empty
+    if (activity) {
+      if (typeof activity.name !== 'string') throw new TypeError('INVALID_TYPE', 'name', 'string');
+      if (!activity.type) activity.type = 0;
+      if (activity.assets && applicationID) {
+        try {
+          const a = await this.client.api.oauth2.applications(applicationID).assets.get();
+          for (const asset of a) assets.set(asset.name, asset.id);
+        } catch (err) { } // eslint-disable-line no-empty
+      }
     }
 
     const packet = {

--- a/src/stores/ClientPresenceStore.js
+++ b/src/stores/ClientPresenceStore.js
@@ -1,0 +1,57 @@
+const PresenceStore = require('./PresenceStore');
+const Collection = require('../util/Collection');
+const Constants = require('../util/Constants');
+const { Presence } = require('../structures/Presence');
+
+class ClientPresenceStore extends PresenceStore {
+  constructor(...args) {
+    super(...args);
+    this.clientPresence = new Presence(this.client, {
+      status: 'online',
+      afk: false,
+      since: null,
+      activity: null,
+    });
+  }
+
+  async setClientPresence({ status, since, afk, activity }) {
+    const applicationID = activity && (activity.application ? activity.application.id || activity.application : null);
+    let assets = new Collection();
+    if (activity && activity.assets && applicationID) {
+      try {
+        const a = await this.client.api.oauth2.applications(applicationID).assets.get();
+        for (const asset of a) assets.set(asset.name, asset.id);
+      } catch (err) {} // eslint-disable-line no-empty
+    }
+
+    const packet = {
+      afk: afk != null ? afk : false, // eslint-disable-line eqeqeq
+      since: since != null ? since : null, // eslint-disable-line eqeqeq
+      status: status || this.clientPresence.status,
+      game: activity ? {
+        type: typeof activity.type === 'number' ? activity.type : Constants.ActivityTypes.indexOf(activity.type),
+        name: activity.name,
+        url: activity.url,
+        details: activity.details || undefined,
+        state: activity.state || undefined,
+        assets: activity.assets ? {
+          large_text: activity.assets.largeText || undefined,
+          small_text: activity.assets.smallText || undefined,
+          large_image: assets.get(activity.assets.largeImage) || activity.assets.largeImage,
+          small_image: assets.get(activity.assets.smallImage) || activity.assets.smallImage,
+        } : undefined,
+        timestamps: activity.timestamps || undefined,
+        party: activity.party || undefined,
+        application_id: applicationID || undefined,
+        secrets: activity.secrets || undefined,
+        instance: activity.instance || undefined,
+      } : null,
+    };
+
+    this.clientPresence.patch(packet);
+    this.client.ws.send({ op: Constants.OPCodes.STATUS_UPDATE, d: packet });
+    return this.clientPresence;
+  }
+}
+
+module.exports = ClientPresenceStore;

--- a/src/stores/DataStore.js
+++ b/src/stores/DataStore.js
@@ -7,8 +7,8 @@ const Collection = require('../util/Collection');
 class DataStore extends Collection {
   constructor(client, iterable) {
     super();
-    if (iterable) for (const item of iterable) this.create(item);
     Object.defineProperty(this, 'client', { value: client });
+    if (iterable) for (const item of iterable) this.create(item);
   }
 
   // Stubs

--- a/src/stores/GuildChannelStore.js
+++ b/src/stores/GuildChannelStore.js
@@ -1,7 +1,6 @@
 const DataStore = require('./DataStore');
-const TextChannel = require('../structures/TextChannel');
-const VoiceChannel = require('../structures/VoiceChannel');
-const Constants = require('../util/Constants');
+const Channel = require('../structures/Channel');
+
 /**
  * Stores guild channels.
  * @private
@@ -13,15 +12,11 @@ class GuildChannelStore extends DataStore {
     this.guild = guild;
   }
 
-  create(data, cache = true) {
+  create(data) {
     const existing = this.get(data.id);
     if (existing) return existing;
 
-    const ChannelModel = data.type === Constants.ChannelTypes.TEXT ? TextChannel : VoiceChannel;
-    const channel = new ChannelModel(this.guild, data);
-    if (cache) this.set(channel.id, channel);
-
-    return channel;
+    return Channel.create(this.client, data, this.guild);
   }
 }
 

--- a/src/stores/GuildMemberStore.js
+++ b/src/stores/GuildMemberStore.js
@@ -99,7 +99,9 @@ class GuildMemberStore extends DataStore {
         for (const member of members.values()) {
           if (query || limit) fetchedMembers.set(member.id, member);
         }
-        if (this.guild.memberCount === this.size || ((query || limit) && members.size < 1000)) {
+        if (this.guild.memberCount <= this.size ||
+          ((query || limit) && members.size < 1000) ||
+          (limit && fetchedMembers.size >= limit)) {
           this.guild.client.removeListener(Constants.Events.GUILD_MEMBERS_CHUNK, handler);
           resolve(query || limit ? fetchedMembers : this);
         }

--- a/src/stores/GuildStore.js
+++ b/src/stores/GuildStore.js
@@ -6,12 +6,12 @@ const Guild = require('../structures/Guild');
  * @extends {DataStore}
  */
 class GuildStore extends DataStore {
-  create(data) {
+  create(data, cache = true) {
     const existing = this.get(data.id);
     if (existing) return existing;
 
     const guild = new Guild(this.client, data);
-    this.set(guild.id, guild);
+    if (cache) this.set(guild.id, guild);
 
     return guild;
   }

--- a/src/stores/PresenceStore.js
+++ b/src/stores/PresenceStore.js
@@ -1,0 +1,15 @@
+const DataStore = require('./DataStore');
+const { Presence } = require('../structures/Presence');
+
+class PresenceStore extends DataStore {
+  create(data) {
+    if (this.has(data.user.id)) {
+      this.get(data.user.id).patch(data);
+    } else {
+      this.set(data.user.id, new Presence(this.client, data));
+    }
+    return this.get(data.user.id);
+  }
+}
+
+module.exports = PresenceStore;

--- a/src/stores/UserStore.js
+++ b/src/stores/UserStore.js
@@ -6,12 +6,12 @@ const User = require('../structures/User');
  * @extends {DataStore}
  */
 class UserStore extends DataStore {
-  create(data) {
+  create(data, cache = true) {
     const existing = this.get(data.id);
     if (existing) return existing;
 
     const user = new User(this.client, data);
-    this.set(user.id, user);
+    if (cache) this.set(user.id, user);
     return user;
   }
 
@@ -26,9 +26,7 @@ class UserStore extends DataStore {
     const existing = this.get(id);
     if (existing) return Promise.resolve(existing);
 
-    return this.client.api.users(id).get().then(data =>
-      cache ? this.create(data) : new User(this.client, data)
-    );
+    return this.client.api.users(id).get().then(data => this.create(data, cache));
   }
 }
 

--- a/src/structures/Channel.js
+++ b/src/structures/Channel.js
@@ -63,6 +63,37 @@ class Channel extends Base {
   delete() {
     return this.client.api.channels(this.id).delete().then(() => this);
   }
+
+  static create(client, data, guild) {
+    const DMChannel = require('./DMChannel');
+    const GroupDMChannel = require('./GroupDMChannel');
+    const TextChannel = require('./TextChannel');
+    const VoiceChannel = require('./VoiceChannel');
+    const GuildChannel = require('./GuildChannel');
+    const types = Constants.ChannelTypes;
+    let channel;
+    if (data.type === types.DM) {
+      channel = new DMChannel(client, data);
+    } else if (data.type === types.GROUP) {
+      channel = new GroupDMChannel(client, data);
+    } else {
+      guild = guild || client.guilds.get(data.guild_id);
+      if (guild) {
+        switch (data.type) {
+          case types.TEXT:
+            channel = new TextChannel(guild, data);
+            break;
+          case types.VOICE:
+            channel = new VoiceChannel(guild, data);
+            break;
+          default:
+            channel = new GuildChannel(guild, data);
+        }
+        guild.channels.set(channel.id, channel);
+      }
+    }
+    return channel;
+  }
 }
 
 module.exports = Channel;

--- a/src/structures/Channel.js
+++ b/src/structures/Channel.js
@@ -63,37 +63,6 @@ class Channel extends Base {
   delete() {
     return this.client.api.channels(this.id).delete().then(() => this);
   }
-
-  static create(client, data, guild) {
-    const DMChannel = require('./DMChannel');
-    const GroupDMChannel = require('./GroupDMChannel');
-    const TextChannel = require('./TextChannel');
-    const VoiceChannel = require('./VoiceChannel');
-    const GuildChannel = require('./GuildChannel');
-    const types = Constants.ChannelTypes;
-    let channel;
-    if (data.type === types.DM) {
-      channel = new DMChannel(client, data);
-    } else if (data.type === types.GROUP) {
-      channel = new GroupDMChannel(client, data);
-    } else {
-      guild = guild || client.guilds.get(data.guild_id);
-      if (guild) {
-        switch (data.type) {
-          case types.TEXT:
-            channel = new TextChannel(guild, data);
-            break;
-          case types.VOICE:
-            channel = new VoiceChannel(guild, data);
-            break;
-          default:
-            channel = new GuildChannel(guild, data);
-        }
-        guild.channels.set(channel.id, channel);
-      }
-    }
-    return channel;
-  }
 }
 
 module.exports = Channel;

--- a/src/structures/ClientApplication.js
+++ b/src/structures/ClientApplication.js
@@ -127,7 +127,7 @@ class ClientApplication extends Base {
    */
   iconURL({ format, size } = {}) {
     if (!this.icon) return null;
-    return Constants.Endpoints.CDN(this.client.options.http.cdn).AppIcon(this.id, this.icon, { format, size });
+    return this.client.rest.cdn.AppIcon(this.id, this.icon, { format, size });
   }
 
   /**

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -7,7 +7,6 @@ const Util = require('../util/Util');
 const Guild = require('./Guild');
 const Message = require('./Message');
 const GroupDMChannel = require('./GroupDMChannel');
-const { TypeError } = require('../errors');
 
 /**
  * Represents the logged in client's Discord user.
@@ -28,7 +27,6 @@ class ClientUser extends User {
      * @type {string}
      */
     this.email = data.email;
-    this.localPresence = {};
     this._typing = new Map();
 
     /**
@@ -91,6 +89,15 @@ class ClientUser extends User {
         this.guildSettings.set(settings.guild_id, new ClientUserGuildSettings(settings, this.client));
       }
     }
+  }
+
+  /**
+   * ClientUser's presence
+   * @readonly
+   * @type {Presence}
+   */
+  get presence() {
+    return this.client.presences.clientPresence;
   }
 
   edit(data, passcode) {
@@ -180,70 +187,19 @@ class ClientUser extends User {
    * @typedef {Object} PresenceData
    * @property {PresenceStatus} [status] Status of the user
    * @property {boolean} [afk] Whether the user is AFK
-   * @property {Object} [game] Game the user is playing
-   * @property {string} [game.name] Name of the game
-   * @property {GameType|number} [game.type] Type of the game
-   * @property {string} [game.url] Twitch stream URL
+   * @property {Object} [activity] activity the user is playing
+   * @property {string} [activity.name] Name of the activity
+   * @property {ActivityType|number} [activity.type] Type of the activity
+   * @property {string} [activity.url] Stream url
    */
 
   /**
    * Sets the full presence of the client user.
    * @param {PresenceData} data Data for the presence
-   * @returns {Promise<ClientUser>}
+   * @returns {Promise<Presence>}
    */
   setPresence(data) {
-    // {"op":3,"d":{"status":"dnd","since":0,"game":null,"afk":false}}
-    return new Promise(resolve => {
-      let status = this.localPresence.status || this.presence.status;
-      let game = this.localPresence.game;
-      let afk = this.localPresence.afk || this.presence.afk;
-
-      if (!game && this.presence.game) {
-        game = {
-          name: this.presence.game.name,
-          type: this.presence.game.type,
-          url: this.presence.game.url,
-        };
-      }
-
-      if (data.status) {
-        if (typeof data.status !== 'string') throw new TypeError('INVALID_TYPE', 'status', 'string');
-        if (this.bot) {
-          status = data.status;
-        } else {
-          this.settings.update(Constants.UserSettingsMap.status, data.status);
-          status = 'invisible';
-        }
-      }
-
-      if (data.game) {
-        game = data.game;
-        if (typeof game.type === 'string') {
-          game.type = Constants.GameTypes.indexOf(game.type);
-          if (game.type === -1) throw new TypeError('INVALID_TYPE', 'type', 'GameType');
-        } else if (typeof game.type !== 'number') {
-          game.type = game.url ? 1 : 0;
-        }
-      } else if (typeof data.game !== 'undefined') {
-        game = null;
-      }
-
-      if (typeof data.afk !== 'undefined') afk = data.afk;
-      afk = Boolean(afk);
-
-      this.localPresence = { status, game, afk };
-      this.localPresence.since = 0;
-      this.localPresence.game = this.localPresence.game || null;
-
-      this.client.ws.send({
-        op: 3,
-        d: this.localPresence,
-      });
-
-      this.client._setPresence(this.id, this.localPresence);
-
-      resolve(this);
-    });
+    return this.client.presences.setClientPresence(data);
   }
 
   /**
@@ -258,35 +214,31 @@ class ClientUser extends User {
   /**
    * Sets the status of the client user.
    * @param {PresenceStatus} status Status to change to
-   * @returns {Promise<ClientUser>}
+   * @returns {Promise<Presence>}
    */
   setStatus(status) {
     return this.setPresence({ status });
   }
 
   /**
-   * Sets the game the client user is playing.
-   * @param {?string} game Game being played
-   * @param {Object} [options] Options for setting the game
+   * Sets the activity the client user is playing.
+   * @param {?string} name Activity being played
+   * @param {Object} [options] Options for setting the activity
    * @param {string} [options.url] Twitch stream URL
-   * @param {GameType|number} [options.type] Type of the game
-   * @returns {Promise<ClientUser>}
+   * @param {ActivityType|number} [options.type] Type of the activity
+   * @returns {Promise<Presence>}
    */
-  setGame(game, { url, type } = {}) {
-    if (!game) return this.setPresence({ game: null });
+  setActivity(name, { url, type } = {}) {
+    if (!name) return this.setPresence({ activity: null });
     return this.setPresence({
-      game: {
-        name: game,
-        type,
-        url,
-      },
+      activity: { name, type, url },
     });
   }
 
   /**
    * Sets/removes the AFK flag for the client user.
    * @param {boolean} afk Whether or not the user is AFK
-   * @returns {Promise<ClientUser>}
+   * @returns {Promise<Presence>}
    */
   setAFK(afk) {
     return this.setPresence({ afk });

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -5,10 +5,6 @@ const ClientUserGuildSettings = require('./ClientUserGuildSettings');
 const Constants = require('../util/Constants');
 const Util = require('../util/Util');
 const Guild = require('./Guild');
-<<<<<<< HEAD
-=======
-const { TypeError } = require('../errors');
->>>>>>> DataStores
 
 /**
  * Represents the logged in client's Discord user.

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -5,8 +5,6 @@ const ClientUserGuildSettings = require('./ClientUserGuildSettings');
 const Constants = require('../util/Constants');
 const Util = require('../util/Util');
 const Guild = require('./Guild');
-const Message = require('./Message');
-const GroupDMChannel = require('./GroupDMChannel');
 
 /**
  * Represents the logged in client's Discord user.
@@ -258,7 +256,7 @@ class ClientUser extends User {
     Util.mergeDefault({ limit: 25, roles: true, everyone: true, guild: null }, options);
 
     return this.client.api.users('@me').mentions.get({ query: options })
-      .then(data => data.map(m => new Message(this.client.channels.get(m.channel_id), m, this.client)));
+      .then(data => data.map(m => this.client.channels.get(m.channel_id).messages.create(m, false)));
   }
 
   /**
@@ -324,7 +322,7 @@ class ClientUser extends User {
       }, {}),
     } : { recipients: recipients.map(u => this.client.resolver.resolveUserID(u.user || u.id)) };
     return this.client.api.users('@me').channels.post({ data })
-      .then(res => new GroupDMChannel(this.client, res));
+      .then(res => this.client.channels.create(res));
   }
 }
 

--- a/src/structures/Emoji.js
+++ b/src/structures/Emoji.js
@@ -201,6 +201,16 @@ class Emoji extends Base {
   }
 
   /**
+   * Delete the emoji.
+   * @param {string} [reason] Reason for deleting the emoji
+   * @returns {Promise<Emoji>}
+   */
+  delete(reason) {
+    return this.client.api.guilds(this.guild.id).emojis(this.id).delete({ reason })
+      .then(() => this);
+  }
+
+  /**
    * Whether this emoji is the same as another one.
    * @param {Emoji|Object} other The emoji to compare it to
    * @returns {boolean} Whether the emoji is equal to the given emoji or not

--- a/src/structures/Emoji.js
+++ b/src/structures/Emoji.js
@@ -1,4 +1,3 @@
-const Constants = require('../util/Constants');
 const Collection = require('../util/Collection');
 const Snowflake = require('../util/Snowflake');
 const Base = require('./Base');
@@ -85,7 +84,7 @@ class Emoji extends Base {
    * @readonly
    */
   get url() {
-    return Constants.Endpoints.CDN(this.client.options.http.cdn).Emoji(this.id);
+    return this.client.rest.cdn.Emoji(this.id);
   }
 
   /**

--- a/src/structures/GroupDMChannel.js
+++ b/src/structures/GroupDMChannel.js
@@ -2,7 +2,6 @@ const Channel = require('./Channel');
 const TextBasedChannel = require('./interfaces/TextBasedChannel');
 const Collection = require('../util/Collection');
 const MessageStore = require('../stores/MessageStore');
-const Constants = require('../util/Constants');
 
 /*
 { type: 3,
@@ -115,7 +114,7 @@ class GroupDMChannel extends Channel {
    */
   iconURL({ format, size } = {}) {
     if (!this.icon) return null;
-    return Constants.Endpoints.CDN(this.client.options.http.cdn).GDMIcon(this.id, this.icon, format, size);
+    return this.client.rest.cdn.GDMIcon(this.id, this.icon, format, size);
   }
 
   /**

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -1,6 +1,5 @@
 const Long = require('long');
 const Role = require('./Role');
-const Emoji = require('./Emoji');
 const Invite = require('./Invite');
 const GuildAuditLogs = require('./GuildAuditLogs');
 const Webhook = require('./Webhook');
@@ -1053,18 +1052,6 @@ class Guild extends Base {
 
     return this.client.resolver.resolveImage(attachment)
       .then(image => this.createEmoji(image, name, { roles, reason }));
-  }
-
-  /**
-   * Delete an emoji.
-   * @param {Emoji|string} emoji The emoji to delete
-   * @param {string} [reason] Reason for deleting the emoji
-   * @returns {Promise<Emoji>}
-   */
-  deleteEmoji(emoji, reason) {
-    if (!(emoji instanceof Emoji)) emoji = this.emojis.get(emoji);
-    return this.client.api.guilds(this.id).emojis(emoji.id).delete({ reason })
-      .then(() => this.client.actions.GuildEmojiDelete.handle(emoji).data);
   }
 
   /**

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -4,7 +4,6 @@ const Emoji = require('./Emoji');
 const Invite = require('./Invite');
 const GuildAuditLogs = require('./GuildAuditLogs');
 const Webhook = require('./Webhook');
-const { Presence } = require('./Presence');
 const GuildChannel = require('./GuildChannel');
 const GuildMember = require('./GuildMember');
 const VoiceRegion = require('./VoiceRegion');
@@ -18,6 +17,7 @@ const GuildMemberStore = require('../stores/GuildMemberStore');
 const RoleStore = require('../stores/RoleStore');
 const EmojiStore = require('../stores/EmojiStore');
 const GuildChannelStore = require('../stores/GuildChannelStore');
+const PresenceStore = require('../stores/PresenceStore');
 const Base = require('./Base');
 const { Error, TypeError } = require('../errors');
 
@@ -51,9 +51,9 @@ class Guild extends Base {
 
     /**
      * A collection of presences in this guild
-     * @type {Collection<Snowflake, Presence>}
+     * @type {PresenceStore<Snowflake, Presence>}
      */
-    this.presences = new Collection();
+    this.presences = new PresenceStore(this.client);
 
     if (!data) return;
     if (data.unavailable) {
@@ -201,7 +201,7 @@ class Guild extends Base {
 
     if (data.presences) {
       for (const presence of data.presences) {
-        this._setPresence(presence.user.id, presence);
+        this.presences.create(presence);
       }
     }
 
@@ -261,7 +261,7 @@ class Guild extends Base {
    */
   iconURL({ format, size } = {}) {
     if (!this.icon) return null;
-    return Constants.Endpoints.CDN(this.client.options.http.cdn).Icon(this.id, this.icon, format, size);
+    return this.client.rest.cdn.Icon(this.id, this.icon, format, size);
   }
 
   /**
@@ -282,7 +282,7 @@ class Guild extends Base {
    */
   splashURL({ format, size } = {}) {
     if (!this.splash) return null;
-    return Constants.Endpoints.CDN(this.client.options.http.cdn).Splash(this.id, this.splash, format, size);
+    return this.client.rest.cdn.Splash(this.id, this.splash, format, size);
   }
 
   /**
@@ -1157,14 +1157,6 @@ class Guild extends Base {
        */
       this.client.emit(Constants.Events.GUILD_MEMBER_SPEAKING, member, speaking);
     }
-  }
-
-  _setPresence(id, presence) {
-    if (this.presences.get(id)) {
-      this.presences.get(id).update(presence);
-      return;
-    }
-    this.presences.set(id, new Presence(presence));
   }
 
   /**

--- a/src/structures/Invite.js
+++ b/src/structures/Invite.js
@@ -13,13 +13,11 @@ class Invite extends Base {
   }
 
   _patch(data) {
-    const Guild = require('./Guild');
-    const Channel = require('./Channel');
     /**
      * The guild the invite is for
      * @type {Guild}
      */
-    this.guild = this.client.guilds.get(data.guild.id) || new Guild(this.client, data.guild);
+    this.guild = this.client.guilds.create(data.guild, false);
 
     /**
      * The code for this invite
@@ -87,7 +85,7 @@ class Invite extends Base {
      * The channel the invite is for
      * @type {GuildChannel}
      */
-    this.channel = this.client.channels.get(data.channel.id) || Channel.create(this.client, data.channel, this.guild);
+    this.channel = this.client.channels.create(data.channel, this.guild, false);
 
     /**
      * The timestamp the invite was created at

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -1,7 +1,6 @@
 const Mentions = require('./MessageMentions');
 const Attachment = require('./MessageAttachment');
 const Embed = require('./MessageEmbed');
-const MessageReaction = require('./MessageReaction');
 const ReactionCollector = require('./ReactionCollector');
 const ClientApplication = require('./ClientApplication');
 const Util = require('../util/Util');
@@ -118,8 +117,7 @@ class Message extends Base {
     this.reactions = new ReactionStore(this);
     if (data.reactions && data.reactions.length > 0) {
       for (const reaction of data.reactions) {
-        const id = reaction.emoji.id ? `${reaction.emoji.name}:${reaction.emoji.id}` : reaction.emoji.name;
-        this.reactions.set(id, new MessageReaction(this, reaction.emoji, reaction.count, reaction.me));
+        this.reactions.create(reaction);
       }
     }
 

--- a/src/structures/Presence.js
+++ b/src/structures/Presence.js
@@ -4,33 +4,33 @@ const Constants = require('../util/Constants');
  * Represents a user's presence.
  */
 class Presence {
-  constructor(data = {}) {
+  constructor(client, data = {}) {
+    Object.defineProperty(this, 'client', { value: client });
+    this.patch(data);
+  }
+
+  patch(data) {
     /**
      * The status of the presence:
      *
      * * **`online`** - user is online
      * * **`offline`** - user is offline or invisible
      * * **`idle`** - user is AFK
-     * * **`dnd`** - user is in Do not Disturb
+     * * **`dnd`** - user is in Do Not Disturb
      * @type {string}
      */
-    this.status = data.status || 'offline';
-
-    /**
-     * The game that the user is playing
-     * @type {?Game}
-     */
-    this.game = data.game ? new Game(data.game) : null;
-  }
-
-  update(data) {
     this.status = data.status || this.status;
-    this.game = data.game ? new Game(data.game) : null;
+
+    const activity = data.game || data.activity;
+    /**
+     * @type {?Activity}
+     */
+    this.activity = activity ? new Activity(this, activity) : null;
   }
 
   _clone() {
     const clone = Object.assign(Object.create(this), this);
-    if (this.game) clone.game = this.game._clone();
+    if (this.activity) clone.activity = this.activity._clone();
     return clone;
   }
 
@@ -43,46 +43,91 @@ class Presence {
     return this === presence || (
       presence &&
       this.status === presence.status &&
-      this.game ? this.game.equals(presence.game) : !presence.game
+      this.activity ? this.activity.equals(presence.activity) : !presence.activity
     );
   }
 }
 
 /**
- * Represents a game that is part of a user's presence.
+ * Represents an activity that is part of a user's presence.
  */
-class Game {
-  constructor(data) {
+class Activity {
+  constructor(presence, data) {
+    Object.defineProperty(this, 'presence', { value: presence });
+
     /**
-     * The name of the game being played
+     * The name of the activity being played
      * @type {string}
      */
     this.name = data.name;
 
     /**
-     * The type of the game status
-     * @type {GameType}
+     * The type of the activity status
+     * @type {ActivityType}
      */
-    this.type = Constants.GameTypes[data.type];
+    this.type = Constants.ActivityTypes[data.type];
 
     /**
-     * If the game is being streamed, a link to the stream
+     * If the activity is being streamed, a link to the stream
      * @type {?string}
      */
     this.url = data.url || null;
+
+    /**
+     * Details about the activity
+     * @type {?string}
+     */
+    this.details = data.details || null;
+
+    /**
+     * State of the activity
+     * @type {?string}
+     */
+    this.state = data.state || null;
+
+    /**
+     * Application ID associated with this activity
+     * @type {?Snowflake}
+     */
+    this.applicationID = data.application_id || null;
+
+    /**
+     * Timestamps for the activity
+     * @type {?Object}
+     * @prop {?Date} start When the activity started
+     * @prop {?Date} end When the activity will end
+     */
+    this.timestamps = data.timestamps ? {
+      start: data.timestamps.start ? new Date(data.timestamps.start) : null,
+      end: data.timestamps.end ? new Date(data.timestamps.end) : null,
+    } : null;
+
+    /**
+     * Party of the activity
+     * @type {?Object}
+     * @prop {?string} id ID of the party
+     * @prop {Number[]} size Size of the party as `[current, max]`
+     */
+    this.party = data.party || null;
+
+    /**
+     * Assets for rich presence
+     * @type {?RichPresenceAssets}
+     */
+    this.assets = data.assets ? new RichPresenceAssets(this, data.assets) : null;
   }
 
   /**
-   * Whether this game is equal to another game.
-   * @param {Game} game The game to compare with
+   * Whether this activity is equal to another activity.
+   * @param {Activity} activity The activity to compare with
    * @returns {boolean}
    */
-  equals(game) {
-    return this === game || (
-      game &&
-      this.name === game.name &&
-      this.type === game.type &&
-      this.url === game.url
+  equals(activity) {
+    return this === activity || (
+      activity &&
+      this.name === activity.name &&
+      this.type === activity.type &&
+      this.url === activity.url
     );
   }
 
@@ -91,5 +136,61 @@ class Game {
   }
 }
 
+/**
+ * Assets for a rich presence
+ */
+class RichPresenceAssets {
+  constructor(activity, assets) {
+    Object.defineProperty(this, 'activity', { value: activity });
+
+    /**
+     * Hover text for large image
+     * @type {?string}
+     */
+    this.largeText = assets.large_text || null;
+
+    /**
+     * Hover text for small image
+     * @type {?string}
+     */
+    this.smallText = assets.small_text || null;
+
+    /**
+     * ID of large image asset
+     * @type {?string}
+     */
+    this.largeImage = assets.large_image || null;
+
+    /**
+     * ID of small image asset
+     * @type {?string}
+     */
+    this.smallImage = assets.small_image || null;
+  }
+
+  /**
+   * @param  {string} format Format of the image
+   * @param  {number} size Size of the iamge
+   * @returns {?string} small image url
+   */
+  smallImageURL({ format, size } = {}) {
+    if (!this.smallImage) return null;
+    return this.activity.presence.client.rest.cdn
+      .AppAsset(this.activity.applicationID, this.smallImage, { format, size });
+  }
+
+  /**
+   * @param  {string} format Format of the image
+   * @param  {number} size Size of the iamge
+   * @returns {?string} large image url
+   */
+  largeImageURL({ format, size } = {}) {
+    if (!this.largeImage) return null;
+    return this.activity.presence.client.rest.cdn
+      .AppAsset(this.activity.applicationID, this.largeImage, { format, size });
+  }
+}
+
 exports.Presence = Presence;
-exports.Game = Game;
+exports.Activity = Activity;
+exports.RichPresenceAssets = RichPresenceAssets;

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -1,5 +1,4 @@
 const TextBasedChannel = require('./interfaces/TextBasedChannel');
-const Constants = require('../util/Constants');
 const { Presence } = require('./Presence');
 const UserProfile = require('./UserProfile');
 const Snowflake = require('../util/Snowflake');
@@ -108,7 +107,7 @@ class User extends Base {
    */
   avatarURL({ format, size } = {}) {
     if (!this.avatar) return null;
-    return Constants.Endpoints.CDN(this.client.options.http.cdn).Avatar(this.id, this.avatar, format, size);
+    return this.client.rest.cdn.Avatar(this.id, this.avatar, format, size);
   }
 
   /**
@@ -117,7 +116,7 @@ class User extends Base {
    * @readonly
    */
   get defaultAvatarURL() {
-    return Constants.Endpoints.CDN(this.client.options.http.cdn).DefaultAvatar(this.discriminator % 5);
+    return this.client.rest.cdn.DefaultAvatar(this.discriminator % 5);
   }
 
   /**

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -126,7 +126,7 @@ class User extends Base {
    * @param {Object} [options={}] Options for the avatar url
    * @param {string} [options.format='webp'] One of `webp`, `png`, `jpg`, `gif`. If no format is provided,
    * it will be `gif` for animated avatars or otherwise `webp`
-   * @param {number} [options.size=128] One of `128`, '256', `512`, `1024`, `2048`
+   * @param {number} [options.size=128] One of `128`, `256`, `512`, `1024`, `2048`
    * @returns {string}
    */
   displayAvatarURL(options) {

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -210,8 +210,7 @@ class Webhook {
       auth: false,
     }).then(data => {
       if (!this.client.channels) return data;
-      const Message = require('./Message');
-      return new Message(this.client.channels.get(data.channel_id), data, this.client);
+      return this.client.channels.get(data.channel_id).messages.create(data, false);
     });
   }
 
@@ -239,8 +238,7 @@ class Webhook {
       data: body,
     }).then(data => {
       if (!this.client.channels) return data;
-      const Message = require('./Message');
-      return new Message(this.client.channels.get(data.channel_id), data, this.client);
+      return this.client.channels.get(data.channel_id).messages.create(data, false);
     });
   }
 

--- a/src/structures/shared/Search.js
+++ b/src/structures/shared/Search.js
@@ -84,14 +84,13 @@ module.exports = function search(target, options) {
   // Lazy load these because some of them use util
   const Channel = require('../Channel');
   const Guild = require('../Guild');
-  const Message = require('../Message');
 
   if (!(target instanceof Channel || target instanceof Guild)) throw new TypeError('SEARCH_CHANNEL_TYPE');
 
   let endpoint = target.client.api[target instanceof Channel ? 'channels' : 'guilds'](target.id).messages().search;
   return endpoint.get({ query: options }).then(body => {
     const results = body.messages.map(x =>
-      x.map(m => new Message(target.client.channels.get(m.channel_id), m, target.client))
+      x.map(m => target.client.channels.get(m.channel_id).messages.create(m, false))
     );
     return {
       total: body.total_results,

--- a/src/util/Collection.js
+++ b/src/util/Collection.js
@@ -238,19 +238,23 @@ class Collection extends Map {
 
   /**
    * Searches for the existence of a single item where its specified property's value is identical to the given value
-   * (`item[prop] === value`).
+   * (`item[prop] === value`), or the given function returns a truthy value.
    * <warn>Do not use this to check for an item by its ID. Instead, use `collection.has(id)`. See
    * [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/has) for details.</warn>
-   * @param {string} prop The property to test against
-   * @param {*} value The expected value
+   * @param {string|Function} propOrFn The property to test against, or the function to test with
+   * @param {*} [value] The expected value - only applicable and required if using a property for the first argument
    * @returns {boolean}
    * @example
    * if (collection.exists('username', 'Bob')) {
    *  console.log('user here!');
    * }
+   * @example 
+   * if (collection.exists(user => user.username === 'Bob')) {
+   *  console.log('user here!');
+   * }
    */
-  exists(prop, value) {
-    return Boolean(this.find(prop, value));
+  exists(propOrFn, value) {
+    return Boolean(this.find(propOrFn, value));
   }
 
   /**

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -117,6 +117,8 @@ exports.Endpoints = {
         makeImageUrl(`${root}/icons/${guildID}/${hash}`, { format, size }),
       AppIcon: (clientID, hash, { format = 'webp', size } = {}) =>
         makeImageUrl(`${root}/app-icons/${clientID}/${hash}`, { size, format }),
+      AppAsset: (clientID, hash, { format = 'webp', size } = {}) =>
+        makeImageUrl(`${root}/app-assets/${clientID}/${hash}`, { size, format }),
       GDMIcon: (channelID, hash, format = 'webp', size) =>
         makeImageUrl(`${root}/channel-icons/${channelID}/${hash}`, { size, format }),
       Splash: (guildID, hash, format = 'webp', size) =>
@@ -345,14 +347,14 @@ exports.MessageTypes = [
 ];
 
 /**
- * The type of a game of a users presence, e.g. `PLAYING`. Here are the available types:
+ * The type of an activity of a users presence, e.g. `PLAYING`. Here are the available types:
  * * PLAYING
  * * STREAMING
  * * LISTENING
  * * WATCHING
- * @typedef {string} GameType
+ * @typedef {string} ActivityType
  */
-exports.GameTypes = [
+exports.ActivityTypes = [
   'PLAYING',
   'STREAMING',
   'LISTENING',

--- a/test/tester1000.js
+++ b/test/tester1000.js
@@ -25,6 +25,7 @@ const commands = {
     }
     message.channel.send(res, { code: 'js' });
   },
+  ping: message => message.reply('pong'),
 };
 
 client.on('message', message => {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

**Data Store:**
- Defined `client` property in the `DataStore`'s constructor before iterating the eventual passed iterable to avoid the client property being undefined when executing `create`.
- Moved other instantiating of store related classes into their data stores (added optional cache parameter where needed)

**(Guild)Channel Store:**
- Moved Channel instantiating to static `Channel#create` over instantiating in Channel Stores / any other files.
- `ChannelStore`'s iterable parameter in the constructor is actually a `Client`, renamed for clarity.
- Added an optional `iterable` parameter.

**GuildMember Store:**
- Fixed fetching of a single member without caching it (resolving of `FetchMemberOptions#user`)
- Marked `GuildMemberStore` as public class so `GuildMemberStore#fetch` can be found in the docs.
- `GuildMemberStore#_fetchMany` now rejects with the intended error message, rather then its key.
- `GuildMemberStore#_fetchMany` now resolves when the limit of fetched members is reached or the full member count has been reached.

~~Regarding `GuildMemberStore#_fetchMany`:
How is fetching with a limit / query expected to work?
Fetching with a limit of 1000 fetches those 1000 but doesn't resolve the promies, which will time out and reject then.~~
~~The condition seems off here since `members.size` will (or should) never be `< 1000`.
See DiscordAPI [docs](https://discordapp.com/developers/docs/topics/gateway#gateway-request-guild-members): `up to 1000 members per chunk` (My bad, > and < are hard to read :^))~~
~~I am not sure how to fix this.~~

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
