### PR TITLE
fix: coerce setGame(name) to string

### DIFF
--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -266,7 +266,7 @@ class ClientUser extends User {
 
   /**
    * Sets the game the client user is playing.
-   * @param {?string} game Game being played
+   * @param {?string|number} game Game being played
    * @param {Object} [options] Options for setting the game
    * @param {string} [options.url] Twitch stream URL
    * @param {GameType|number} [options.type] Type of the game
@@ -276,7 +276,7 @@ class ClientUser extends User {
     if (!game) return this.setPresence({ game: null });
     return this.setPresence({
       game: {
-        name: game,
+        name: String(game),
         type,
         url,
       },


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
ClientUser#setGame(number) would silently fail if a number was passed. This will coerce it to a string.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.