### PR TITLE
fix: made options.type optional in ClientUser#setActivity

### DIFF
--- a/src/stores/ClientPresenceStore.js
+++ b/src/stores/ClientPresenceStore.js
@@ -2,6 +2,7 @@ const PresenceStore = require('./PresenceStore');
 const Collection = require('../util/Collection');
 const Constants = require('../util/Constants');
 const { Presence } = require('../structures/Presence');
+const { TypeError } = require('../errors');
 
 class ClientPresenceStore extends PresenceStore {
   constructor(...args) {
@@ -14,7 +15,10 @@ class ClientPresenceStore extends PresenceStore {
     });
   }
 
-  async setClientPresence({ status, since, afk, activity }) {
+  async setClientPresence({ status, since, afk, activity }) { // eslint-disable-line complexity
+    if (typeof activity.name === 'number') throw new TypeError('INVALID_TYPE', 'name', 'string');
+    if (activity.name && !activity.type) activity.type = 0;
+    if (activity.url && !activity.type) activity.type = 1;
     const applicationID = activity && (activity.application ? activity.application.id || activity.application : null);
     let assets = new Collection();
     if (activity && activity.assets && applicationID) {

--- a/src/stores/ClientPresenceStore.js
+++ b/src/stores/ClientPresenceStore.js
@@ -16,9 +16,8 @@ class ClientPresenceStore extends PresenceStore {
   }
 
   async setClientPresence({ status, since, afk, activity }) { // eslint-disable-line complexity
-    if (typeof activity.name === 'number') throw new TypeError('INVALID_TYPE', 'name', 'string');
-    if (activity.name && !activity.type) activity.type = 0;
-    if (activity.url && !activity.type) activity.type = 1;
+    if (typeof activity.name !== 'string') throw new TypeError('INVALID_TYPE', 'name', 'string');
+    if (!activity.type) activity.type = 0;
     const applicationID = activity && (activity.application ? activity.application.id || activity.application : null);
     let assets = new Collection();
     if (activity && activity.assets && applicationID) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
When providing only a name. the type wasn't automatically set for you, as the docs declared it, so this picks up the type depending on the input. The type will be defaulted to 0.
Additionally, if the developer passes in a number for the name parameter, it will reject with an error.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
