### PR TITLE
refactor(Emoji): remove Guild#deleteEmoji in favour of Emoji#delete

### DIFF
--- a/src/structures/Emoji.js
+++ b/src/structures/Emoji.js
@@ -202,6 +202,16 @@ class Emoji extends Base {
   }
 
   /**
+   * Delete the emoji.
+   * @param {string} [reason] Reason for deleting the emoji
+   * @returns {Promise<Emoji>}
+   */
+  delete(reason) {
+    return this.client.api.guilds(this.guild.id).emojis(this.id).delete({ reason })
+      .then(() => this);
+  }
+
+  /**
    * Whether this emoji is the same as another one.
    * @param {Emoji|Object} other The emoji to compare it to
    * @returns {boolean} Whether the emoji is equal to the given emoji or not

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -1,6 +1,5 @@
 const Long = require('long');
 const Role = require('./Role');
-const Emoji = require('./Emoji');
 const Invite = require('./Invite');
 const GuildAuditLogs = require('./GuildAuditLogs');
 const Webhook = require('./Webhook');
@@ -1053,18 +1052,6 @@ class Guild extends Base {
 
     return this.client.resolver.resolveImage(attachment)
       .then(image => this.createEmoji(image, name, { roles, reason }));
-  }
-
-  /**
-   * Delete an emoji.
-   * @param {Emoji|string} emoji The emoji to delete
-   * @param {string} [reason] Reason for deleting the emoji
-   * @returns {Promise<Emoji>}
-   */
-  deleteEmoji(emoji, reason) {
-    if (!(emoji instanceof Emoji)) emoji = this.emojis.get(emoji);
-    return this.client.api.guilds(this.id).emojis(emoji.id).delete({ reason })
-      .then(() => this.client.actions.GuildEmojiDelete.handle(emoji).data);
   }
 
   /**


### PR DESCRIPTION
(Not sure whether refactor applies here, from the description it's the closest.)
**Please describe the changes this PR makes and why it should be merged:**

Moved the deletion of an emoji from `Guild` to its `Emoji` instance.
Looked wrong to not have `Emoji#delete` when it would totally make sense to have it.

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
