### PR TITLE
fix(MessageStore): Fix fetchPinned method and add notice.

### DIFF
--- a/src/stores/MessageStore.js
+++ b/src/stores/MessageStore.js
@@ -61,10 +61,12 @@ class MessageStore extends DataStore {
 
   /**
    * Fetches the pinned messages of this channel and returns a collection of them.
+   * <info>The returned Collection does not contain the reactions of the messages. 
+   * Those need to be fetched seperately.</info>
    * @returns {Promise<Collection<Snowflake, Message>>}
    */
   fetchPinned() {
-    return this.client.api.channels[this.message.channel.id].pins.get().then(data => {
+    return this.client.api.channels[this.channel.id].pins.get().then(data => {
       const messages = new Collection();
       for (const message of data) messages.set(message.id, this.create(message));
       return messages;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The fetchPinned method of the MessageStore was broken, refering a non-existing ``message`` property of the MessageStore. It now properly references the channel property instead.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.