### PR TITLE
ClientUserGuildSettings: avoid uncaught exception and a bit of refactoring

### DIFF
--- a/src/client/websocket/packets/handlers/UserGuildSettingsUpdate.js
+++ b/src/client/websocket/packets/handlers/UserGuildSettingsUpdate.js
@@ -1,10 +1,13 @@
 const AbstractHandler = require('./AbstractHandler');
 const Constants = require('../../../../util/Constants');
+const ClientUserGuildSettings = require('../../../../structures/ClientUserGuildSettings');
 
 class UserGuildSettingsUpdateHandler extends AbstractHandler {
   handle(packet) {
     const client = this.packetManager.client;
-    client.user.guildSettings.get(packet.d.guild_id).patch(packet.d);
+    const settings = client.user.guildSettings.get(packet.d.guild_id);
+    if (settings) settings.patch(packet.d);
+    else client.user.guildSettings.set(packet.d.guild_id, new ClientUserGuildSettings(this.client, packet.d));
     client.emit(Constants.Events.USER_GUILD_SETTINGS_UPDATE, client.user.guildSettings.get(packet.d.guild_id));
   }
 }

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -84,7 +84,7 @@ class ClientUser extends User {
     this.guildSettings = new Collection();
     if (data.user_guild_settings) {
       for (const settings of data.user_guild_settings) {
-        this.guildSettings.set(settings.guild_id, new ClientUserGuildSettings(settings, this.client));
+        this.guildSettings.set(settings.guild_id, new ClientUserGuildSettings(this.client, settings));
       }
     }
   }

--- a/src/structures/ClientUserGuildSettings.js
+++ b/src/structures/ClientUserGuildSettings.js
@@ -6,7 +6,7 @@ const ClientUserChannelOverride = require('./ClientUserChannelOverride');
  * A wrapper around the ClientUser's guild settings.
  */
 class ClientUserGuildSettings {
-  constructor(data, client) {
+  constructor(client, data) {
     /**
      * The client that created the instance of the ClientUserGuildSettings
      * @name ClientUserGuildSettings#client

--- a/src/structures/ClientUserGuildSettings.js
+++ b/src/structures/ClientUserGuildSettings.js
@@ -33,8 +33,9 @@ class ClientUserGuildSettings {
       if (!data.hasOwnProperty(key)) continue;
       if (key === 'channel_overrides') {
         for (const channel of data[key]) {
-          this.channelOverrides.set(channel.channel_id,
-            new ClientUserChannelOverride(channel));
+          const override = this.channelOverrides.get(channel.channel_id);
+          if (override) override.patch(channel);
+          else this.channelOverrides.set(channel.channel_id, new ClientUserChannelOverride(channel));
         }
       } else if (typeof value === 'function') {
         this[value.name] = value(data[key]);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- avoid uncaught exception when patching user guild settings for newly joined guilds and group dms _(yes, user **guild** settings for group dms)_
- made the client for consistency first parameter in ClientUserGuildSettins' constructor
- patch the ClientUserChannelOverride instances if possible instead of creating a new one on every update

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
