### PR TITLE
Fix whitespace in 11.2.0 welcome docs.

### DIFF
--- a/docs/general/welcome.md
+++ b/docs/general/welcome.md
@@ -30,11 +30,11 @@ discord.js is a powerful [node.js](https://nodejs.org) module that allows you to
 - 100% coverage of the Discord API
 
 ## Installation
-**Node.js 6.0.0 or newer is required.**
+**Node.js 6.0.0 or newer is required.**  
 Ignore any warnings about unmet peer dependencies, as they're all optional.
 
-Without voice support: `npm install discord.js --save`
-With voice support ([node-opus](https://www.npmjs.com/package/node-opus)): `npm install discord.js node-opus --save`
+Without voice support: `npm install discord.js --save`  
+With voice support ([node-opus](https://www.npmjs.com/package/node-opus)): `npm install discord.js node-opus --save`  
 With voice support ([opusscript](https://www.npmjs.com/package/opusscript)): `npm install discord.js opusscript --save`
 
 ### Audio engines
@@ -79,7 +79,7 @@ client.login('your token');
 
 ## Contributing
 Before creating an issue, please ensure that it hasn't already been reported/suggested, and double-check the
-[documentation](https://discord.js.org/#/docs).
+[documentation](https://discord.js.org/#/docs).  
 See [the contribution guide](https://github.com/hydrabolt/discord.js/blob/master/.github/CONTRIBUTING.md) if you'd like to submit a PR.
 
 ## Help


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

![](https://cdn.discordapp.com/attachments/222197033908436994/354151983168356362/rip.PNG)

11.2.0 docs were missing a few line breaks now that trailing whitespace was removed from them in 4778a47.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
