### PR TITLE
fix(Client): apply shardId and shardCount to the correct options object

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -31,8 +31,10 @@ class Client extends BaseClient {
     super(Object.assign({ _tokenType: 'Bot' }, options));
 
     // Obtain shard details from environment
-    if (!options.shardId && 'SHARD_ID' in process.env) options.shardId = Number(process.env.SHARD_ID);
-    if (!options.shardCount && 'SHARD_COUNT' in process.env) options.shardCount = Number(process.env.SHARD_COUNT);
+    if (!this.options.shardId && 'SHARD_ID' in process.env) this.options.shardId = Number(process.env.SHARD_ID);
+    if (!this.options.shardCount && 'SHARD_COUNT' in process.env) {
+      this.options.shardCount = Number(process.env.SHARD_COUNT);
+    }
 
     this._validateOptions();
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The sharding variables were assigned to the copied from options paremeter which is not referenced by `this.options` in the client.
Now assigning to `this.options` instead.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
