### PR TITLE
fix(WebhookClient): use applyToClass instead of multiple inheritance

### DIFF
--- a/src/client/WebhookClient.js
+++ b/src/client/WebhookClient.js
@@ -14,14 +14,16 @@ class WebhookClient extends BaseClient {
    * @example
    * // Create a new webhook and send a message
    * const hook = new Discord.WebhookClient('1234', 'abcdef');
-   * hook.sendMessage('This will send a message').catch(console.error);
+   * hook.send('This will send a message').catch(console.error);
    */
   constructor(id, token, options) {
     super(options);
-    Webhook.call(this, null, id, token);
+    Object.defineProperty(this, 'client', { value: this });
+    this.id = id;
+    this.token = token;
   }
 }
 
-Object.assign(WebhookClient.prototype, Object.create(Webhook.prototype));
+Webhook.applyToClass(WebhookClient);
 
 module.exports = WebhookClient;

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -8,21 +8,15 @@ const MessageEmbed = require('./MessageEmbed');
  * Represents a webhook.
  */
 class Webhook {
-  constructor(client, dataOrID, token) {
-    if (client) {
-      /**
-       * The client that instantiated the webhook
-       * @name Webhook#client
-       * @type {Client}
-       * @readonly
-       */
-      Object.defineProperty(this, 'client', { value: client });
-      if (dataOrID) this._patch(dataOrID);
-    } else {
-      this.id = dataOrID;
-      this.token = token;
-      Object.defineProperty(this, 'client', { value: this });
-    }
+  constructor(client, data) {
+    /**
+     * The client that instantiated the webhook
+     * @name Webhook#client
+     * @type {Client}
+     * @readonly
+     */
+    Object.defineProperty(this, 'client', { value: client });
+    if (data) this._patch(data);
   }
 
   _patch(data) {
@@ -273,6 +267,18 @@ class Webhook {
    */
   delete(reason) {
     return this.client.api.webhooks(this.id, this.token).delete({ reason });
+  }
+
+  static applyToClass(structure) {
+    for (const prop of [
+      'send',
+      'sendSlackMessage',
+      'edit',
+      'delete',
+    ]) {
+      Object.defineProperty(structure.prototype, prop,
+        Object.getOwnPropertyDescriptor(Webhook.prototype, prop));
+    }
   }
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixing a TypeError stating that class constructor's can't be called without using new by using a static applyToClass method.
Alos updated the example to no longer use a no longer existing method.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
