### PR TITLE
fix(Webhook): avatar override not working sometimes

### DIFF
--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -121,7 +121,7 @@ class Webhook {
 
     if (!options.username) options.username = this.name;
     if (options.avatarURL) {
-      options.avatar_url = options.avatarURL;
+      options.avatar_url = options.avatarURL.replace(/^(.+)\?size=.+$/, '$1');
       options.avatarURL = null;
     }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Somewhat of an edge case fix where the provided URL was too big for the actual avatar size, which would cause a blank/see-through avatar to show up as the overridden Webhook's avatar.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
