### PR TITLE
Fix resolveID typo in guild.unban

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -842,7 +842,7 @@ class Guild extends Base {
    *   .catch(console.error);
    */
   unban(user, reason) {
-    const id = this.client.users.resolverID(user);
+    const id = this.client.users.resolveID(user);
     if (!id) throw new Error('BAN_RESOLVE_ID');
     return this.client.api.guilds(this.id).bans[id].delete({ reason })
       .then(() => user);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixes a typo in `guild.unban`, which had `resolverID` instead of `resolveID`.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
