### PR TITLE
Fix for emojis not being an EmojiStore

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -16,6 +16,7 @@ const UserStore = require('../stores/UserStore');
 const ChannelStore = require('../stores/ChannelStore');
 const GuildStore = require('../stores/GuildStore');
 const ClientPresenceStore = require('../stores/ClientPresenceStore');
+const EmojiStore = require('../stores/EmojiStore');
 const Constants = require('../util/Constants');
 const DataResolver = require('../util/DataResolver');
 const { Error, TypeError, RangeError } = require('../errors');
@@ -220,7 +221,7 @@ class Client extends BaseClient {
     for (const guild of this.guilds.values()) {
       if (guild.available) for (const emoji of guild.emojis.values()) emojis.set(emoji.id, emoji);
     }
-    return emojis;
+    return new EmojiStore({ client: this }, emojis);
   }
 
   /**

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -217,11 +217,11 @@ class Client extends BaseClient {
    * @readonly
    */
   get emojis() {
-    const emojis = new Collection();
+    const emojis = new EmojiStore({ client: this });
     for (const guild of this.guilds.values()) {
       if (guild.available) for (const emoji of guild.emojis.values()) emojis.set(emoji.id, emoji);
     }
-    return new EmojiStore({ client: this }, emojis);
+    return emojis;
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Just makes `client.emojis` be an EmojiStore.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
