### PR TITLE
Channel permissionLock support (syncing with category permissions)

### DIFF
--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -79,6 +79,7 @@ const Messages = {
   MESSAGE_SPLIT_MISSING: 'Message exceeds the max length and contains no split characters.',
 
   GUILD_CHANNEL_RESOLVE: 'Could not resolve channel to a guild channel.',
+  GUILD_CHANNEL_ORPHAN: 'Could not find a parent to this guild channel.',
   GUILD_OWNED: 'Guild is owned by the client.',
   GUILD_RESTRICTED: (state = false) => `Guild is ${state ? 'already' : 'not'} restricted.`,
   GUILD_MEMBERS_TIMEOUT: 'Members didn\'t arrive in time.',

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -206,6 +206,21 @@ class GuildChannel extends Channel {
   }
 
   /**
+   * Locks in the permission overwrites from the parent channel.
+   * @returns {Promise<GuildChannel>}
+   */
+  permisionLock() {
+    if (!this.parent) return Promise.reject('No Parent');
+    const permissionOverwrites = this.parent.permissionOverwrites.map(overwrite => ({
+      deny: overwrite.deny.bitfield,
+      allow: overwrite.allow.bitfield,
+      id: overwrite.id,
+      type: overwrite.type,
+    }));
+    return this.edit({ permissionOverwrites });
+  }
+
+  /**
    * A collection of members that can see this channel, mapped by their ID
    * @type {Collection<Snowflake, GuildMember>}
    * @readonly
@@ -253,6 +268,7 @@ class GuildChannel extends Channel {
         user_limit: data.userLimit != null ? data.userLimit : this.userLimit, // eslint-disable-line eqeqeq
         parent_id: data.parentID,
         lock_permissions: data.lockPermissions,
+        permission_overwrites: data.permissionOverwrites,
       },
       reason,
     }).then(newData => {

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -209,7 +209,7 @@ class GuildChannel extends Channel {
    * Locks in the permission overwrites from the parent channel.
    * @returns {Promise<GuildChannel>}
    */
-  permissionLock() {
+  lockPermissions() {
     if (!this.parent) return Promise.reject(new Error('GUILD_CHANNEL_ORPHAN'));
     const permissionOverwrites = this.parent.permissionOverwrites.map(overwrite => ({
       deny: overwrite.deny.bitfield,

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -6,7 +6,7 @@ const Util = require('../util/Util');
 const Permissions = require('../util/Permissions');
 const Collection = require('../util/Collection');
 const Constants = require('../util/Constants');
-const { TypeError } = require('../errors');
+const { Error, TypeError } = require('../errors');
 
 /**
  * Represents a guild channel (e.g. text channels and voice channels).
@@ -209,8 +209,8 @@ class GuildChannel extends Channel {
    * Locks in the permission overwrites from the parent channel.
    * @returns {Promise<GuildChannel>}
    */
-  permisionLock() {
-    if (!this.parent) return Promise.reject('No Parent');
+  permissionLock() {
+    if (!this.parent) return Promise.reject(new Error('GUILD_CHANNEL_ORPHAN'));
     const permissionOverwrites = this.parent.permissionOverwrites.map(overwrite => ({
       deny: overwrite.deny.bitfield,
       allow: overwrite.allow.bitfield,

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -263,7 +263,7 @@ class GuildChannel extends Channel {
       data: {
         name: (data.name || this.name).trim(),
         topic: data.topic,
-        position: data.position || this.position,
+        position: data.position || this.rawPosition,
         bitrate: data.bitrate || (this.bitrate ? this.bitrate * 1000 : undefined),
         user_limit: data.userLimit != null ? data.userLimit : this.userLimit, // eslint-disable-line eqeqeq
         parent_id: data.parentID,

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -71,7 +71,14 @@ class GuildChannel extends Channel {
    * @readonly
    */
   get permissionsLocked() {
-    return this.parent ? this.permissionOverwrites.equals(this.parent.permissionOverwrites) : null;
+    if (!this.parent) return null;
+    if (this.permissionOverwrites.size !== this.parent.permissionOverwrites.size) return false;
+    return !this.permissionOverwrites.find((value, key) => {
+      const testVal = this.parent.permissionOverwrites.get(key);
+      return testVal === undefined ||
+        testVal.denied.bitfield !== value.denied.bitfield ||
+        testVal.allowed.bitfield !== value.allowed.bitfield;
+    });
   }
 
   /**

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -66,6 +66,15 @@ class GuildChannel extends Channel {
   }
 
   /**
+   * If the permissionOverwrites match the parent channel, null if no parent
+   * @type {?boolean}
+   * @readonly
+   */
+  get permissionsLocked() {
+    return this.parent ? this.permissionOverwrites.equals(this.parent.permissionOverwrites) : null;
+  }
+
+  /**
    * The position of the channel
    * @type {number}
    * @readonly

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -212,8 +212,8 @@ class GuildChannel extends Channel {
   lockPermissions() {
     if (!this.parent) return Promise.reject(new Error('GUILD_CHANNEL_ORPHAN'));
     const permissionOverwrites = this.parent.permissionOverwrites.map(overwrite => ({
-      deny: overwrite.deny.bitfield,
-      allow: overwrite.allow.bitfield,
+      deny: overwrite.denied.bitfield,
+      allow: overwrite.allowed.bitfield,
       id: overwrite.id,
       type: overwrite.type,
     }));

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -252,6 +252,16 @@ class GuildChannel extends Channel {
    * @property {number} [userLimit] The user limit of the voice channel
    * @property {Snowflake} [parentID] The parent ID of the channel
    * @property {boolean} [lockPermissions] Lock the permissions of the channel to what the parent's permissions are
+   * @property {OverwriteData[]} [permissionOverwrites] An array of overwrites to set for the channel
+   */
+
+  /**
+   * The data for a permission overwrite
+   * @typedef {Object} OverwriteData
+   * @property {string} id The id of the overwrite
+   * @property {string} type The type of the overwrite, either role or member
+   * @property {number} allow The bitfield for the allowed permissions
+   * @property {number} deny The bitfield for the denied permissions
    */
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Adds a getter to test if the channel is locked (syncing with the category channel in the client);.
Adds a method to lock into the category channel's overwrites.

Fixes a bug where \<GuildChannel\>.edit was using the calculated position instead of the raw position to patch.

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
