### PR TITLE
fix(DataStore): make resolveID work properly

### DIFF
--- a/src/stores/DataStore.js
+++ b/src/stores/DataStore.js
@@ -41,7 +41,7 @@ class DataStore extends Collection {
    */
   resolveID(idOrInstance) {
     if (idOrInstance instanceof this.holds) return idOrInstance.id;
-    if (typeof channel === 'string') return idOrInstance;
+    if (typeof idOrInstance === 'string') return idOrInstance;
     return null;
   }
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The DataStore resolveID method was for some reason using a non-existing ``channel`` variable and thus it always errored if the parameter was a string. This PR fixes the method to use the correct variable.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
