### PR TITLE
Rip, fixes a bug we didn't even know to look for... 1870 lives on.

### DIFF
--- a/src/stores/GuildMemberStore.js
+++ b/src/stores/GuildMemberStore.js
@@ -90,17 +90,18 @@ class GuildMemberStore extends DataStore {
    */
   fetch(options) {
     if (!options) return this._fetchMany();
-    const user = this.resolveID(options);
+    const user = this.client.users.resolveID(options);
     if (user) return this._fetchSingle({ user, cache: true });
     if (options.user) {
-      options.user = this.resolveID(options.user);
+      options.user = this.client.users.resolveID(options.user);
       if (options.user) return this._fetchSingle(options);
     }
     return this._fetchMany(options);
   }
 
   _fetchSingle({ user, cache }) {
-    if (this.has(user)) return Promise.resolve(this.get(user));
+    const existing = this.get(user);
+    if (existing) return Promise.resolve(existing);
     return this.client.api.guilds(this.guild.id).members(user).get()
       .then(data => this.create(data, cache));
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
~~Tries to resolve a member, which is uncached, so \<MemberStore\>resolveID returns null if using anything but an id, forcing fetch to move on and fetchmany the whole guild, instead of the one missing member we were looking for.~~

Fails at fixing 1870, but fixes member resolving as null, and instead of fetching the single member, it fetches the whole guild. This changes resolving to a user resolvable instead of member, so that the single user can be fetched instead of the whole guild. (matching current and past documentation suggesting the arg should be a user resolvable)

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
