### PR TITLE
fix(EmojiStore): return super.create in the create method

### DIFF
--- a/src/stores/EmojiStore.js
+++ b/src/stores/EmojiStore.js
@@ -14,7 +14,7 @@ class EmojiStore extends DataStore {
   }
 
   create(data, cache) {
-    super.create(data, cache, { extras: [this.guild] });
+    return super.create(data, cache, { extras: [this.guild] });
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

EmojiStore#create is currently returning undefined which results in `Client#emojiCreate` and `Guild#createEmoji` emitting/returning undefined instead of an emoji.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
