### PR TITLE
Fix .npmrc to not create package-lock.json

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-package-json=false
+package-lock=false


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
fix .npmrc to *actually* not create package-lock.json

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
