### PR TITLE
docs: Fix some small typos or "missing" docs

### DIFF
--- a/src/client/BaseClient.js
+++ b/src/client/BaseClient.js
@@ -95,7 +95,7 @@ class BaseClient extends EventEmitter {
   /**
    * Sets an interval that will be automatically cancelled if the client is destroyed.
    * @param {Function} fn Function to execute
-   * @param {number} delay Time to wait before executing (in milliseconds)
+   * @param {number} delay Time to wait between executions (in milliseconds)
    * @param {...*} args Arguments for the function
    * @returns {Timeout}
    */

--- a/src/client/BaseClient.js
+++ b/src/client/BaseClient.js
@@ -25,14 +25,14 @@ class BaseClient extends EventEmitter {
     this.rest = new RESTManager(this, options._tokenType);
 
     /**
-     * Timeouts set by {@link WebhookClient#setTimeout} that are still active
+     * Timeouts set by {@link BaseClient#setTimeout} that are still active
      * @type {Set<Timeout>}
      * @private
      */
     this._timeouts = new Set();
 
     /**
-     * Intervals set by {@link WebhookClient#setInterval} that are still active
+     * Intervals set by {@link BaseClient#setInterval} that are still active
      * @type {Set<Timeout>}
      * @private
      */

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -213,7 +213,7 @@ class Client extends BaseClient {
 
   /**
    * All custom emojis that the client has access to, mapped by their IDs
-   * @type {Collection<Snowflake, Emoji>}
+   * @type {EmojiStore<Snowflake, Emoji>}
    * @readonly
    */
   get emojis() {

--- a/src/stores/ClientPresenceStore.js
+++ b/src/stores/ClientPresenceStore.js
@@ -4,6 +4,11 @@ const Constants = require('../util/Constants');
 const { Presence } = require('../structures/Presence');
 const { TypeError } = require('../errors');
 
+/**
+ * Stores the client presence and other presences.
+ * @extends {PresenceStore}
+ * @private
+ */
 class ClientPresenceStore extends PresenceStore {
   constructor(...args) {
     super(...args);

--- a/src/stores/GuildChannelStore.js
+++ b/src/stores/GuildChannelStore.js
@@ -21,10 +21,10 @@ class GuildChannelStore extends DataStore {
   }
 
   /**
-   * Data that can be resolved to give a Channel object. This can be:
+   * Data that can be resolved to give a Guild Channel object. This can be:
    * * A GuildChannel object
    * * A Snowflake
-   * @typedef {Channel|Snowflake} GuildChannelResolvable
+   * @typedef {GuildChannel|Snowflake} GuildChannelResolvable
    */
 
   /**

--- a/src/stores/GuildMemberStore.js
+++ b/src/stores/GuildMemberStore.js
@@ -22,7 +22,7 @@ class GuildMemberStore extends DataStore {
    * Data that resolves to give a GuildMember object. This can be:
    * * A GuildMember object
    * * A User resolvable
-   * @typedef {GuildMember|UserResolveable} GuildMemberResolvable
+   * @typedef {GuildMember|UserResolvable} GuildMemberResolvable
    */
 
   /**

--- a/src/stores/PresenceStore.js
+++ b/src/stores/PresenceStore.js
@@ -19,9 +19,9 @@ class PresenceStore extends DataStore {
   /**
    * Data that can be resolved to a Presence object. This can be:
    * * A Presence
-   * * A UserResolveable
+   * * A UserResolvable
    * * A Snowflake
-   * @typedef {Presence|UserResolveable|Snowflake} PresenceResolvable
+   * @typedef {Presence|UserResolvable|Snowflake} PresenceResolvable
    */
 
   /**

--- a/src/structures/CategoryChannel.js
+++ b/src/structures/CategoryChannel.js
@@ -7,7 +7,7 @@ const GuildChannel = require('./GuildChannel');
 class CategoryChannel extends GuildChannel {
   /**
    * The channels that are part of this category
-   * @type {?Collection}
+   * @type {?Collection<Snowflake, GuildChannel>}
    * @readonly
    */
   get children() {

--- a/src/structures/GuildAuditLogs.js
+++ b/src/structures/GuildAuditLogs.js
@@ -96,7 +96,7 @@ class GuildAuditLogs {
    * * MESSAGE
    * @typedef {string} TargetType
    */
-  
+
   /**
    * The target for an audit log entry. It can be one of:
    * * A guild

--- a/src/structures/GuildAuditLogs.js
+++ b/src/structures/GuildAuditLogs.js
@@ -259,7 +259,7 @@ class GuildAuditLogsEntry {
     if (targetType === Targets.UNKNOWN) {
       /**
        * The target of this entry
-       * @type {TargetType}
+       * @type {?Object|Guild|User|Role|Emoji|Invite|Webhook}
        */
       this.target = this.changes.reduce((o, c) => {
         o[c.key] = c.new || c.old;

--- a/src/structures/GuildAuditLogs.js
+++ b/src/structures/GuildAuditLogs.js
@@ -96,6 +96,18 @@ class GuildAuditLogs {
    * * MESSAGE
    * @typedef {string} TargetType
    */
+  
+  /**
+   * The target for an audit log entry. It can be one of:
+   * * A guild
+   * * A user
+   * * A role
+   * * An emoji
+   * * An invite
+   * * A webhook
+   * * An object where the keys represent either the new value or the old value
+   * @typedef {?Object|Guild|User|Role|Emoji|Invite|Webhook} EntryTarget
+   */
 
   /**
    * Find target type from entry action.
@@ -259,7 +271,7 @@ class GuildAuditLogsEntry {
     if (targetType === Targets.UNKNOWN) {
       /**
        * The target of this entry
-       * @type {?Object|Guild|User|Role|Emoji|Invite|Webhook}
+       * @type {EntryTarget}
        */
       this.target = this.changes.reduce((o, c) => {
         o[c.key] = c.new || c.old;

--- a/src/structures/Presence.js
+++ b/src/structures/Presence.js
@@ -109,7 +109,7 @@ class Activity {
      * Party of the activity
      * @type {?Object}
      * @prop {?string} id ID of the party
-     * @prop {Number[]} size Size of the party as `[current, max]`
+     * @prop {number[]} size Size of the party as `[current, max]`
      */
     this.party = data.party || null;
 

--- a/src/structures/Presence.js
+++ b/src/structures/Presence.js
@@ -23,6 +23,7 @@ class Presence {
 
     const activity = data.game || data.activity;
     /**
+     * The activity of the presence
      * @type {?Activity}
      */
     this.activity = activity ? new Activity(this, activity) : null;

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -131,12 +131,12 @@ exports.Endpoints = {
 
 /**
  * The current status of the client. Here are the available statuses:
- * * READY
- * * CONNECTING
- * * RECONNECTING
- * * IDLE
- * * NEARLY
- * * DISCONNECTED
+ * * READY: 0
+ * * CONNECTING: 1
+ * * RECONNECTING: 2
+ * * IDLE: 3
+ * * NEARLY: 4
+ * * DISCONNECTED: 5
  * @typedef {number} Status
  */
 exports.Status = {
@@ -150,11 +150,11 @@ exports.Status = {
 
 /**
  * The current status of a voice connection. Here are the available statuses:
- * * CONNECTED
- * * CONNECTING
- * * AUTHENTICATING
- * * RECONNECTING
- * * DISCONNECTED
+ * * CONNECTED: 0
+ * * CONNECTING: 1
+ * * AUTHENTICATING: 2
+ * * RECONNECTING: 3
+ * * DISCONNECTED: 4
  * @typedef {number} VoiceStatus
  */
 exports.VoiceStatus = {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes a small typo in the type for GuildAuditLogEntry#target and CategoryChannel#children, amongst other things

~Also, quick question: Shouldn't the `target` return a message object when the `targetType` is `MESSAGE`?~ Nevermind, it apparently returns a user ID

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
