### PR TITLE
fix(ClientManager): reject login with proper error on timeout or on connection failure

### DIFF
--- a/src/client/ClientManager.js
+++ b/src/client/ClientManager.js
@@ -37,11 +37,12 @@ class ClientManager {
   connectToWebSocket(token, resolve, reject) {
     this.client.emit(Constants.Events.DEBUG, `Authenticated using token ${token}`);
     this.client.token = token;
-    const timeout = this.client.setTimeout(() => reject(new Error('TOKEN_INVALID')), 1000 * 300);
+    const timeout = this.client.setTimeout(() => reject(new Error('WS_CONNECTION_TIMEOUT')), 1000 * 300);
     this.client.api.gateway.get().then(res => {
       const gateway = `${res.url}/`;
       this.client.emit(Constants.Events.DEBUG, `Using gateway ${gateway}`);
       this.client.ws.connect(gateway);
+      this.client.ws.connection.ws.once('error', reject);
       this.client.ws.connection.once('close', event => {
         if (event.code === 4004) reject(new Error('TOKEN_INVALID'));
         if (event.code === 4010) reject(new Error('SHARDING_INVALID'));

--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -8,6 +8,7 @@ const Messages = {
 
   FEATURE_USER_ONLY: 'Only user accounts are able to make use of this feature.',
 
+  WS_CONNECTION_TIMEOUT: 'The connection to the gateway timed out.',
   WS_CONNECTION_EXISTS: 'There is already an existing WebSocket connection.',
   WS_NOT_OPEN: (data = 'data') => `Websocket not open to send ${data}`,
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

When the client's connection to the gateway times out after 5 minutes, reject with an error stating that isntead of saying that the token was invalid.
Also reject when the WebSocket emits an error, like a connection failure.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
