### PR TITLE
Missed a deprecated method removal

### DIFF
--- a/src/structures/Role.js
+++ b/src/structures/Role.js
@@ -132,39 +132,6 @@ class Role extends Base {
   }
 
   /**
-   * Get an object mapping permission names to whether or not the role enables that permission.
-   * @returns {Object<string, boolean>}
-   * @example
-   * // Print the serialized role permissions
-   * console.log(role.serialize());
-   */
-  serialize() {
-    return this.permissions.serialize();
-  }
-
-  /**
-   * Checks if the role has a permission.
-   * @param {PermissionResolvable|PermissionResolvable[]} permission Permission(s) to check for
-   * @param {boolean} [explicit=false] Whether to require the role to explicitly have the exact permission
-   * **(deprecated)**
-   * @param {boolean} [checkAdmin] Whether to allow the administrator permission to override
-   * (takes priority over `explicit`)
-   * @returns {boolean}
-   * @example
-   * // See if a role can ban a member
-   * if (role.hasPermission('BAN_MEMBERS')) {
-   *   console.log('This role can ban members');
-   * } else {
-   *   console.log('This role can\'t ban members');
-   * }
-   */
-  hasPermission(permission, explicit = false, checkAdmin) {
-    return this.permissions.has(
-      permission, typeof checkAdmin !== 'undefined' ? checkAdmin : !explicit
-    );
-  }
-
-  /**
    * Compares this role's position to another role's.
    * @param {RoleResolvable} role Role to compare to this one
    * @returns {number} Negative number if the this role's position is lower (other role's is higher),


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Missed a deprecated method removal, and another that should be removed too.

~~\<role\>.hasPermission was marked as deprecated (incorrectly? it didn't show up in docs as deprecated).~~ and \<role\>.serialize() doesn't even make sense (OOP context). Especially when it's just an alias for \<role\>.permissions.serialize(), and all of the other permission based methods were deprecated and meant to be removed in favor of the permissions instance/methods.

**edit:** mis-read line 149 as meaning the whole method was deprecated, instead of that one argument. However, the method as a whole still doesn't really belong/should use \<role\>.permissions.has()...

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
