### PR TITLE
docs: Small doc improvement for PermissionOverwrites

### DIFF
--- a/src/structures/PermissionOverwrites.js
+++ b/src/structures/PermissionOverwrites.js
@@ -24,8 +24,15 @@ class PermissionOverwrites {
     this.id = data.id;
 
     /**
+     * The type of a permission overwrite. It can be one of:
+     * * member
+     * * role
+     * @typedef {string} OverwriteType
+     */
+
+    /**
      * The type of this overwrite
-     * @type {string}
+     * @type {OverwriteType}
      */
     this.type = data.type;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR just adds `OverwriteType`, a small typedef that shows all the possible returns of PermissionOverwrite.type

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
