### PR TITLE
fix typo in ws manager

### DIFF
--- a/src/client/ClientManager.js
+++ b/src/client/ClientManager.js
@@ -42,7 +42,7 @@ class ClientManager {
       const gateway = `${res.url}/`;
       this.client.emit(Events.DEBUG, `Using gateway ${gateway}`);
       this.client.ws.connect(gateway);
-      this.client.ws.connection.ws.once('error', reject);
+      this.client.ws.connection.once('error', reject);
       this.client.ws.connection.once('close', event => {
         if (event.code === 4004) reject(new Error('TOKEN_INVALID'));
         if (event.code === 4010) reject(new Error('SHARDING_INVALID'));


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`client.ws.connection.ws.once` is bad but `this.client.ws.connection.once` is good

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
