### PR TITLE
Make datastore holds property writeable

### DIFF
--- a/src/stores/DataStore.js
+++ b/src/stores/DataStore.js
@@ -8,7 +8,7 @@ class DataStore extends Collection {
   constructor(client, iterable, holds) {
     super();
     Object.defineProperty(this, 'client', { value: client });
-    Object.defineProperty(this, 'holds', { value: holds });
+    Object.defineProperty(this, 'holds', { value: holds, writable: true });
     if (iterable) for (const item of iterable) this.create(item);
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Sets writable property of the property descriptor for DataStore#holds to true, this leaves a lot of the structures open for extension hence it allows users to not edit prototypes/use container classes and instead inject the extension in.

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
