### PR TITLE
Depreciate default channel on old docs

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -1214,6 +1214,7 @@ class Guild {
  * @name Guild#defaultChannel
  * @type {TextChannel}
  * @readonly
+ * @deprecated
  */
 Object.defineProperty(Guild.prototype, 'defaultChannel', {
   get: util.deprecate(function defaultChannel() {


### PR DESCRIPTION
Makes default channel as depreciated so users know to stop using it

**Semantic versioning classification:**  
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
