### PR TITLE
Fix for a small hasPermission error

### DIFF
--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -306,7 +306,7 @@ class GuildMember extends Base {
     if (typeof checkAdmin === 'undefined') checkAdmin = !explicit;
     if (typeof checkOwner === 'undefined') checkOwner = !explicit;
     if (checkOwner && this.user.id === this.guild.ownerID) return true;
-    return this.roles.some(r => r.hasPermission(permission, undefined, checkAdmin));
+    return this.roles.some(r => r.permissions.has(permission, undefined, checkAdmin));
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
After `role.hasPermission` died, this check here did as well. This just fixes that by changing `hasPermission` to `permissions.has`.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
