### PR TITLE
voice: Add VoiceChannel#rawBitrate 

### DIFF
--- a/src/structures/VoiceChannel.js
+++ b/src/structures/VoiceChannel.js
@@ -22,16 +22,24 @@ class VoiceChannel extends GuildChannel {
   _patch(data) {
     super._patch(data);
     /**
-     * The bitrate of this voice channel
+     * The raw bitrate of this voice channel (in bps)
      * @type {number}
      */
-    this.bitrate = data.bitrate * 0.001;
+    this.rawBitrate = data.bitrate;
 
     /**
      * The maximum amount of users allowed in this channel - 0 means unlimited.
      * @type {number}
      */
     this.userLimit = data.user_limit;
+  }
+
+  /**
+   * The bitrate of this voice channel (in kbps)
+   * @type {number}
+   */
+  get bitrate() {
+    return this.rawBitrate * 0.001;
   }
 
   /**

--- a/src/structures/VoiceChannel.js
+++ b/src/structures/VoiceChannel.js
@@ -37,6 +37,7 @@ class VoiceChannel extends GuildChannel {
   /**
    * The bitrate of this voice channel (in kbps)
    * @type {number}
+   * @readonly
    */
   get bitrate() {
     return this.rawBitrate * 0.001;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
For those people who wants the raw bitrate (in bps). This PR is probably *not* needed, cause you can easily do `channel.bitrate * 1000`, but since we have position and rawPosition, I thought this might also be useful.
This also makes VoiceChannel#bitrate a getter

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
