### PR TITLE
Export DataStore from the Discord.js module

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ module.exports = {
   Collection: require('./util/Collection'),
   Constants: require('./util/Constants'),
   DataResolver: require('./util/DataResolver'),
+  DataStore: require('./stores/DataStore'),
   DiscordAPIError: require('./rest/DiscordAPIError'),
   EvaluatedPermissions: require('./util/Permissions'),
   Permissions: require('./util/Permissions'),


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Since Discord.js is exporting Collections and DataStore's are a pretty easy to use & extend DataStore Model, would i like to add it to the discord.js exports so users can use it in code as an Storage if they want (like Collections).

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
