### PR TITLE
fix(MessageEmbed): don't send 'files' as part of the embed

### DIFF
--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -319,7 +319,6 @@ class MessageEmbed {
       timestamp: this.timestamp ? new Date(this.timestamp) : null,
       color: this.color,
       fields: this.fields,
-      files: this.files,
       thumbnail: this.thumbnail,
       image: this.image,
       author: this.author ? {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Sending one or multiple large buffers will reject with `413: Request Entity Too Large` because the `files` property of the embed will be sent as part of `payload_json`.

That embed itself should not contain any attached files, simply removing them resolves that issue.
The file(s) will still be attached to the message like usually: [here](https://github.com/hydrabolt/discord.js/blob/master/src/rest/APIRequest.js#L35)


**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
