### PR TITLE
fix: setPosition taking wrong IDs and edit with position 0 breaking

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -275,18 +275,23 @@ class GuildChannel extends Channel {
    *   .then(c => console.log(`Edited channel ${c}`))
    *   .catch(console.error);
    */
-  edit(data, reason) {
+  edit(editData, reason) {
+    let data = {
+      name: (editData.name || this.name).trim(),
+      topic: editData.topic,
+      position: this.rawPosition,
+      bitrate: editData.bitrate || (this.bitrate ? this.bitrate * 1000 : undefined),
+      user_limit: editData.userLimit != null ? editData.userLimit : this.userLimit, // eslint-disable-line eqeqeq
+      parent_id: editData.parentID,
+      lock_permissions: editData.lockPermissions,
+      permission_overwrites: editData.permissionOverwrites,
+    };
+
+    if (typeof editData.position !== "undefined" && editData.position === 0) data.position = 0;
+    else data.position = editData.position || this.rawPosition;
+
     return this.client.api.channels(this.id).patch({
-      data: {
-        name: (data.name || this.name).trim(),
-        topic: data.topic,
-        position: data.position || this.rawPosition,
-        bitrate: data.bitrate || (this.bitrate ? this.bitrate * 1000 : undefined),
-        user_limit: data.userLimit != null ? data.userLimit : this.userLimit, // eslint-disable-line eqeqeq
-        parent_id: data.parentID,
-        lock_permissions: data.lockPermissions,
-        permission_overwrites: data.permissionOverwrites,
-      },
+      data,
       reason,
     }).then(newData => {
       const clone = this._clone();

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -266,7 +266,7 @@ class GuildChannel extends Channel {
 
   /**
    * Edits the channel.
-   * @param {ChannelData} data The new data for the channel
+   * @param {ChannelData} editData The new data for the channel
    * @param {string} [reason] Reason for editing this channel
    * @returns {Promise<GuildChannel>}
    * @example
@@ -287,7 +287,7 @@ class GuildChannel extends Channel {
       permission_overwrites: editData.permissionOverwrites,
     };
 
-    if (typeof editData.position !== "undefined" && editData.position === 0) data.position = 0;
+    if (typeof editData.position !== 'undefined' && editData.position === 0) data.position = 0;
     else data.position = editData.position || this.rawPosition;
 
     return this.client.api.channels(this.id).patch({

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -357,7 +357,7 @@ class GuildChannel extends Channel {
       this.guild._sortedChannels(this), this.client.api.guilds(this.guild.id).channels, reason)
       .then(updatedChannels => {
         this.client.actions.GuildChannelsPositionUpdate.handle({
-          guild_id: this.id,
+          guild_id: this.guild.id,
           channels: updatedChannels,
         });
         return this;

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -266,7 +266,7 @@ class GuildChannel extends Channel {
 
   /**
    * Edits the channel.
-   * @param {ChannelData} editData The new data for the channel
+   * @param {ChannelData} data The new data for the channel
    * @param {string} [reason] Reason for editing this channel
    * @returns {Promise<GuildChannel>}
    * @example
@@ -275,23 +275,18 @@ class GuildChannel extends Channel {
    *   .then(c => console.log(`Edited channel ${c}`))
    *   .catch(console.error);
    */
-  edit(editData, reason) {
-    let data = {
-      name: (editData.name || this.name).trim(),
-      topic: editData.topic,
-      position: this.rawPosition,
-      bitrate: editData.bitrate || (this.bitrate ? this.bitrate * 1000 : undefined),
-      user_limit: editData.userLimit != null ? editData.userLimit : this.userLimit, // eslint-disable-line eqeqeq
-      parent_id: editData.parentID,
-      lock_permissions: editData.lockPermissions,
-      permission_overwrites: editData.permissionOverwrites,
-    };
-
-    if (typeof editData.position !== 'undefined' && editData.position === 0) data.position = 0;
-    else data.position = editData.position || this.rawPosition;
-
+  edit(data, reason) {
     return this.client.api.channels(this.id).patch({
-      data,
+      data: {
+        name: (data.name || this.name).trim(),
+        topic: data.topic,
+        position: typeof data.position === 'number' ? data.position : this.rawPosition,
+        bitrate: data.bitrate || (this.bitrate ? this.bitrate * 1000 : undefined),
+        user_limit: data.userLimit != null ? data.userLimit : this.userLimit, // eslint-disable-line eqeqeq
+        parent_id: data.parentID,
+        lock_permissions: data.lockPermissions,
+        permission_overwrites: data.permissionOverwrites,
+      },
       reason,
     }).then(newData => {
       const clone = this._clone();

--- a/src/structures/Role.js
+++ b/src/structures/Role.js
@@ -279,7 +279,7 @@ class Role extends Base {
       this.guild._sortedRoles(), this.client.api.guilds(this.guild.id).roles, reason)
       .then(updatedRoles => {
         this.client.actions.GuildRolesPositionUpdate.handle({
-          guild_id: this.id,
+          guild_id: this.guild.id,
           channels: updatedRoles,
         });
         return this;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixes a major? typo in GuildChannel#setPosition and in Role#setPosition

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
