### PR TITLE
[Documentation] Added a warn in fetchMentions

### DIFF
--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -245,6 +245,7 @@ class ClientUser extends User {
 
   /**
    * Fetches messages that mentioned the client's user.
+   * <warn>This is only available when using a user account.</warn>
    * @param {Object} [options] Options for the fetch
    * @param {number} [options.limit=25] Maximum number of mentions to retrieve
    * @param {boolean} [options.roles=true] Whether to include role mentions


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The `ClientUser#fetchMentions` calls and endpoint that is reserved to user accounts. However, the documentation does not mention it. This PR adds the warn message to said method.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
