### PR TITLE
Typo in Message.awaitReactions docs

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -291,7 +291,7 @@ class Message extends Base {
    */
 
   /**
-   * Similar to createMessageCollector but in promise form.
+   * Similar to createReactionCollector but in promise form.
    * Resolves with a collection of reactions that pass the specified filter.
    * @param {CollectorFilter} filter The filter function to use
    * @param {AwaitReactionsOptions} [options={}] Optional options to pass to the internal collector


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Small typo in `Message.awaitReactions()`

Changed: **"Similar to createMessageCollector but in promise form."**
To: **"Similar to createReactionCollector but in promise form."**

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
