### PR TITLE
fix(Role): setPosition typo

### DIFF
--- a/src/structures/Role.js
+++ b/src/structures/Role.js
@@ -280,7 +280,7 @@ class Role extends Base {
       .then(updatedRoles => {
         this.client.actions.GuildRolesPositionUpdate.handle({
           guild_id: this.guild.id,
-          channels: updatedRoles,
+          roles: updatedRoles,
         });
         return this;
       });


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixed a simple typo where in the actions handler, it was expecting roles instead of the given channels from Role#setPosition.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
