### PR TITLE
fix(GuildAuditLogs): incorrect webhook reference

### DIFF
--- a/src/structures/GuildAuditLogs.js
+++ b/src/structures/GuildAuditLogs.js
@@ -282,7 +282,14 @@ class GuildAuditLogsEntry {
       this.target = guild.client[`${targetType.toLowerCase()}s`].get(data.target_id);
     } else if (targetType === Targets.WEBHOOK) {
       this.target = logs.webhooks.get(data.target_id) ||
-        new Webhook(guild.client, { id: data.target_id, guild_id: guild.id });
+        new Webhook(guild.client,
+          this.changes.reduce((o, c) => {
+            o[c.key] = c.new || c.old;
+            return o;
+          }, {
+            id: data.target_id,
+            guild_id: guild.id,
+          }));
     } else if (targetType === Targets.INVITE) {
       if (guild.me.permissions.has('MANAGE_GUILD')) {
         const change = this.changes.find(c => c.key === 'code');

--- a/src/structures/GuildAuditLogs.js
+++ b/src/structures/GuildAuditLogs.js
@@ -70,7 +70,7 @@ class GuildAuditLogs {
      */
     this.entries = new Collection();
     for (const item of data.audit_log_entries) {
-      const entry = new GuildAuditLogsEntry(guild, item);
+      const entry = new GuildAuditLogsEntry(this, guild, item);
       this.entries.set(entry.id, entry);
     }
   }
@@ -183,7 +183,7 @@ class GuildAuditLogs {
  * Audit logs entry.
  */
 class GuildAuditLogsEntry {
-  constructor(guild, data) {
+  constructor(logs, guild, data) {
     const targetType = GuildAuditLogs.targetType(data.action_type);
     /**
      * The target type of this entry
@@ -281,7 +281,7 @@ class GuildAuditLogsEntry {
     } else if ([Targets.USER, Targets.GUILD].includes(targetType)) {
       this.target = guild.client[`${targetType.toLowerCase()}s`].get(data.target_id);
     } else if (targetType === Targets.WEBHOOK) {
-      this.target = this.webhooks.get(data.target_id);
+      this.target = logs.webhooks.get(data.target_id) || new Webhook(guild.client, { id: data.target_id, guild_id: guild.id });
     } else if (targetType === Targets.INVITE) {
       if (guild.me.permissions.has('MANAGE_GUILD')) {
         const change = this.changes.find(c => c.key === 'code');

--- a/src/structures/GuildAuditLogs.js
+++ b/src/structures/GuildAuditLogs.js
@@ -281,7 +281,8 @@ class GuildAuditLogsEntry {
     } else if ([Targets.USER, Targets.GUILD].includes(targetType)) {
       this.target = guild.client[`${targetType.toLowerCase()}s`].get(data.target_id);
     } else if (targetType === Targets.WEBHOOK) {
-      this.target = logs.webhooks.get(data.target_id) || new Webhook(guild.client, { id: data.target_id, guild_id: guild.id });
+      this.target = logs.webhooks.get(data.target_id) ||
+        new Webhook(guild.client, { id: data.target_id, guild_id: guild.id });
     } else if (targetType === Targets.INVITE) {
       if (guild.me.permissions.has('MANAGE_GUILD')) {
         const change = this.changes.find(c => c.key === 'code');


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Aimed to fix one thing, which was an undefined `this` reference within a `GuildAuditLogsEntry` structure. This passes a reference to it correctly to obtain the `webhooks` property from `GuildAuditLogs`.
Additionally ended updating Audit Logs for deleted webhook events, which provide nothing, so now there is a basic Webhook object returned at the end, if none is available.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
