### PR TITLE
fix(GuildChannel|Role.edit) Editing with a position not being right

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -275,10 +275,16 @@ class GuildChannel extends Channel {
    *   .then(c => console.log(`Edited channel ${c}`))
    *   .catch(console.error);
    */
-  edit(data, reason) {
+  async edit(data, reason) {
     if (typeof data.position !== 'undefined') {
-      Util.editPosition(this, data.position, this.guild._sortedChannels(this),
-        this.client.api.guilds(this.guild.id).channels, 'channel', reason).catch(err => Promise.reject(err));
+      await Util.setPosition(this, data.position, false,
+        this.guild._sortedChannels(this), this.client.api.guilds(this.guild.id).channels, reason)
+        .then(updatedChannels => {
+          this.client.actions.GuildChannelsPositionUpdate.handle({
+            guild_id: this.guild.id,
+            channels: updatedChannels,
+          });
+        });
     }
     return this.client.api.channels(this.id).patch({
       data: {

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -276,11 +276,14 @@ class GuildChannel extends Channel {
    *   .catch(console.error);
    */
   edit(data, reason) {
+    if (typeof data.position !== 'undefined') {
+      Util.editPosition(this, data.position, this.guild._sortedChannels(this),
+        this.client.api.guilds(this.guild.id).channels, 'channel', reason).catch(err => Promise.reject(err));
+    }
     return this.client.api.channels(this.id).patch({
       data: {
         name: (data.name || this.name).trim(),
         topic: data.topic,
-        position: typeof data.position === 'number' ? data.position : this.rawPosition,
         bitrate: data.bitrate || (this.bitrate ? this.bitrate * 1000 : undefined),
         user_limit: data.userLimit != null ? data.userLimit : this.userLimit, // eslint-disable-line eqeqeq
         parent_id: data.parentID,

--- a/src/structures/Role.js
+++ b/src/structures/Role.js
@@ -168,12 +168,15 @@ class Role extends Base {
   edit(data, reason) {
     if (data.permissions) data.permissions = Permissions.resolve(data.permissions);
     else data.permissions = this.permissions.bitfield;
+    if (typeof data.position !== 'undefined') {
+      Util.editPosition(this, data.position, this.guild._sortedRoles(),
+        this.client.api.guilds(this.guild.id).roles, 'role', reason).catch(err => Promise.reject(err));
+    }
     return this.client.api.guilds[this.guild.id].roles[this.id].patch({
       data: {
         name: data.name || this.name,
         color: Util.resolveColor(data.color || this.color),
         hoist: typeof data.hoist !== 'undefined' ? data.hoist : this.hoist,
-        position: typeof data.position !== 'undefined' ? data.position : this.position,
         permissions: data.permissions,
         mentionable: typeof data.mentionable !== 'undefined' ? data.mentionable : this.mentionable,
       },

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -316,30 +316,6 @@ class Util {
     }
     return f;
   }
-
-  static editPosition(item, position, sorted, route, type, reason) {
-    let updatedItems = sorted.array();
-    Util.moveElementInArray(updatedItems, item, position, false);
-    updatedItems = updatedItems.map((r, i) => ({ id: r.id, position: i }));
-    return route.patch({ data: updatedItems, reason }).then(() => {
-      switch (type.toLowerCase()) {
-        case 'channel': {
-          item.client.actions.GuildChannelsPositionUpdate.handle({
-            guild_id: item.guild.id,
-            channels: updatedItems,
-          });
-          break;
-        }
-        case 'role': {
-          item.client.actions.GuildRolesPositionUpdate.handle({
-            guild_id: item.guild.id,
-            roles: updatedItems,
-          });
-          break;
-        }
-      }
-    });
-  }
 }
 
 module.exports = Util;

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -316,6 +316,30 @@ class Util {
     }
     return f;
   }
+
+  static editPosition(item, position, sorted, route, type, reason) {
+    let updatedItems = sorted.array();
+    Util.moveElementInArray(updatedItems, item, position, false);
+    updatedItems = updatedItems.map((r, i) => ({ id: r.id, position: i }));
+    return route.patch({ data: updatedItems, reason }).then(() => {
+      switch (type.toLowerCase()) {
+        case 'channel': {
+          item.client.actions.GuildChannelsPositionUpdate.handle({
+            guild_id: item.guild.id,
+            channels: updatedItems,
+          });
+          break;
+        }
+        case 'role': {
+          item.client.actions.GuildRolesPositionUpdate.handle({
+            guild_id: item.guild.id,
+            roles: updatedItems,
+          });
+          break;
+        }
+      }
+    });
+  }
 }
 
 module.exports = Util;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes the `edit({ position: 1 })` issues, where editing a position would do nothing.
Now, if position wants to be changed, it'll attempt to change it, and if it was able to move the channel, it'll continue with the rest of the edit.

Tested and it works as expected. Works with other options as well.
This is probably janky, but it works as intended now. ~I might have to change some docs for the meaning of the position param~

This should also fix #1974 

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
