### PR TITLE
fix websocket ratelimits

### DIFF
--- a/src/client/websocket/WebSocketConnection.js
+++ b/src/client/websocket/WebSocketConnection.js
@@ -62,8 +62,9 @@ class WebSocketConnection extends EventEmitter {
      */
     this.ratelimit = {
       queue: [],
-      remaining: 60,
-      total: 60,
+      remaining: 120,
+      total: 120,
+      time: 60e3,
       resetTimer: null,
     };
     this.connect(gateway);
@@ -152,7 +153,7 @@ class WebSocketConnection extends EventEmitter {
       this.ratelimit.resetTimer = this.client.setTimeout(() => {
         this.ratelimit.remaining = this.ratelimit.total;
         this.processQueue();
-      }, 120e3);
+      }, this.ratelimit.time);
     }
     while (this.ratelimit.remaining > 0) {
       const item = this.ratelimit.queue.shift();


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
i may have slightly misread the 120/60 ratelimit as 60/120

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
