### PR TITLE
refactor: remove redundant Client#rest and obsolete RESTManager#destroy

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -1,6 +1,5 @@
 const BaseClient = require('./BaseClient');
 const Permissions = require('../util/Permissions');
-const RESTManager = require('../rest/RESTManager');
 const ClientManager = require('./ClientManager');
 const ClientVoiceManager = require('./voice/ClientVoiceManager');
 const WebSocketManager = require('./websocket/WebSocketManager');
@@ -41,13 +40,6 @@ class Client extends BaseClient {
     }
 
     this._validateOptions();
-
-    /**
-     * The REST manager of the client
-     * @type {RESTManager}
-     * @private
-     */
-    this.rest = new RESTManager(this);
 
     /**
      * The manager of the client

--- a/src/client/ClientManager.js
+++ b/src/client/ClientManager.js
@@ -57,7 +57,6 @@ class ClientManager {
 
   destroy() {
     this.client.ws.destroy();
-    this.client.rest.destroy();
     if (!this.client.user) return Promise.resolve();
     if (this.client.user.bot) {
       this.client.token = null;

--- a/src/rest/RESTManager.js
+++ b/src/rest/RESTManager.js
@@ -32,12 +32,6 @@ class RESTManager {
     return Endpoints.CDN(this.client.options.http.cdn);
   }
 
-  destroy() {
-    for (const handler of Object.values(this.handlers)) {
-      if (handler.destroy) handler.destroy();
-    }
-  }
-
   push(handler, apiRequest) {
     return new Promise((resolve, reject) => {
       handler.push({


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

`BaseClient` already defines the `rest` property, doing it again in `Client` is redundant.
See [source](https://github.com/hydrabolt/discord.js/blob/master/src/client/BaseClient.js#L25).

Also noticed that [`RequestHandler`](https://github.com/hydrabolt/discord.js/blob/master/src/rest/handlers/RequestHandler.js) no longer has a destroy method, thus removing a pointless method call including a loop.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
