### PR TITLE
fix(GuildDelete): disconnect voice and cleanup GuildChannels

### DIFF
--- a/src/client/actions/GuildDelete.js
+++ b/src/client/actions/GuildDelete.js
@@ -28,6 +28,9 @@ class GuildDeleteAction extends Action {
         };
       }
 
+      for (const channel of guild.channels.values()) this.client.channels.remove(channel.id);
+      if (guild.voiceConnection) guild.voiceConnection.disconnect();
+
       // Delete guild
       client.guilds.remove(guild.id);
       client.emit(Events.GUILD_DELETE, guild);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This seems to fix #1939
Maybe this also fixes #1870 (If those guilds are guilds that the bot left and joined)

Changes:
- Remove all channels of the left guild from `Client#channels`.
- Disconnect the voice connection if there is one.

Explanation:

Kicking a bot and readding it resulted in all guild channels being still in `Client#channels` with their old `GuildChannel#guild` reference.
Rejoining would not update those old channels because `ChannelStore#create` would just patch them.
Keeping channels after the bot left a guild seems unintended anyway.

A still active voice connection would not be disconnected by kicking the bot, the voice WebSocket on discord's seems not to care about it.
Joining to a different voice channel after rejoining seems to work though.
However it's not intended to maintain a connection to the voice WebSocket of a guild that the bot is not part of.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
