### PR TITLE
Patch timestamp of 0 on guild join date

### DIFF
--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -64,7 +64,7 @@ class GuildMember extends Base {
      * @type {number}
      * @name GuildMember#joinedTimestamp
      */
-    if (typeof data.joined_at !== 'undefined') this.joinedTimestamp = new Date(data.joined_at).getTime();
+    if (data.joined_at) this.joinedTimestamp = new Date(data.joined_at).getTime();
 
     this.user = this.guild.client.users.create(data.user);
     if (data.roles) this._roles = data.roles;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The Discord API seems to send a timestamp of 0 for the joined_at on presence updates. This patch resolves this by ignoring timestamps of 0/null/undefined.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.