### PR TITLE
docs: Add/normalize .toString() docs on all classes

### DIFF
--- a/src/structures/ClientApplication.js
+++ b/src/structures/ClientApplication.js
@@ -199,7 +199,7 @@ class ClientApplication extends Base {
    * @returns {string}
    * @example
    * // Logs: Application name: My App
-   * console.log(`Application name: ${application}!`);
+   * console.log(`Application name: ${application}`);
    */
   toString() {
     return this.name;

--- a/src/structures/ClientApplication.js
+++ b/src/structures/ClientApplication.js
@@ -195,7 +195,7 @@ class ClientApplication extends Base {
   }
 
   /**
-   * When concatenated with a string, this automatically concatenates the application's name instead of the
+   * When concatenated with a string, this automatically returns the application's name instead of the
    * ClientApplication object.
    * @returns {string}
    * @example

--- a/src/structures/ClientApplication.js
+++ b/src/structures/ClientApplication.js
@@ -195,7 +195,8 @@ class ClientApplication extends Base {
   }
 
   /**
-   * When concatenated with a string, this automatically concatenates the app name rather than the app object.
+   * When concatenated with a string, this automatically concatenates the application's name instead of the
+   * ClientApplication object.
    * @returns {string}
    * @example
    * // Logs: Application name: My App

--- a/src/structures/ClientApplication.js
+++ b/src/structures/ClientApplication.js
@@ -197,6 +197,9 @@ class ClientApplication extends Base {
   /**
    * When concatenated with a string, this automatically concatenates the app name rather than the app object.
    * @returns {string}
+   * @example
+   * // Logs: Application name: My App
+   * console.log(`Application name: ${application}!`);
    */
   toString() {
     return this.name;

--- a/src/structures/DMChannel.js
+++ b/src/structures/DMChannel.js
@@ -27,7 +27,7 @@ class DMChannel extends Channel {
   }
 
   /**
-   * When concatenated with a string, this automatically concatenates the recipient's mention instead of the
+   * When concatenated with a string, this automatically returns the recipient's mention instead of the
    * DMChannel object.
    * @returns {string}
    * @example

--- a/src/structures/DMChannel.js
+++ b/src/structures/DMChannel.js
@@ -28,7 +28,7 @@ class DMChannel extends Channel {
 
   /**
    * When concatenated with a string, this automatically concatenates the recipient's mention instead of the
-   * DM channel object.
+   * DMChannel object.
    * @returns {string}
    * @example
    * // Logs: Hello from <@123456789012345678>!

--- a/src/structures/DMChannel.js
+++ b/src/structures/DMChannel.js
@@ -30,6 +30,9 @@ class DMChannel extends Channel {
    * When concatenated with a string, this automatically concatenates the recipient's mention instead of the
    * DM channel object.
    * @returns {string}
+   * @example
+   * // Logs: Hello from <@123456789012345678>!
+   * console.log(`Hello from ${channel}!`);
    */
   toString() {
     return this.recipient.toString();

--- a/src/structures/Emoji.js
+++ b/src/structures/Emoji.js
@@ -190,7 +190,7 @@ class Emoji extends Base {
   }
 
   /**
-   * When concatenated with a string, this automatically returns the emoji mention rather than the object.
+   * When concatenated with a string, this automatically concatenates the emoji's mention instead of the Emoji object.
    * @returns {string}
    * @example
    * // Send an emoji:

--- a/src/structures/GroupDMChannel.js
+++ b/src/structures/GroupDMChannel.js
@@ -208,9 +208,6 @@ class GroupDMChannel extends Channel {
    * @example
    * // Logs: Hello from My Group DM!
    * console.log(`Hello from ${channel}!`);
-   * @example
-   * // Logs: Hello from My Group DM!
-   * console.log(`Hello from ' + channel + '!');
    */
   toString() {
     return this.name;

--- a/src/structures/GroupDMChannel.js
+++ b/src/structures/GroupDMChannel.js
@@ -203,7 +203,8 @@ class GroupDMChannel extends Channel {
   }
 
   /**
-   * When concatenated with a string, this automatically concatenates the channel's name instead of the Channel object.
+   * When concatenated with a string, this automatically concatenates the channel's name instead of the
+   * GroupDMChannel object.
    * @returns {string}
    * @example
    * // Logs: Hello from My Group DM!

--- a/src/structures/GroupDMChannel.js
+++ b/src/structures/GroupDMChannel.js
@@ -203,7 +203,7 @@ class GroupDMChannel extends Channel {
   }
 
   /**
-   * When concatenated with a string, this automatically concatenates the channel's name instead of the
+   * When concatenated with a string, this automatically returns the channel's name instead of the
    * GroupDMChannel object.
    * @returns {string}
    * @example

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -1123,7 +1123,7 @@ class Guild extends Base {
   }
 
   /**
-   * When concatenated with a string, this automatically concatenates the guild's name instead of the Guild object.
+   * When concatenated with a string, this automatically returns the guild's name instead of the Guild object.
    * @returns {string}
    * @example
    * // Logs: Hello from My Guild!

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -1128,9 +1128,6 @@ class Guild extends Base {
    * @example
    * // Logs: Hello from My Guild!
    * console.log(`Hello from ${guild}!`);
-   * @example
-   * // Logs: Hello from My Guild!
-   * console.log('Hello from ' + guild + '!');
    */
   toString() {
     return this.name;

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -1123,7 +1123,7 @@ class Guild extends Base {
   }
 
   /**
-   * When concatenated with a string, this automatically concatenates the guild's name instead of the guild object.
+   * When concatenated with a string, this automatically concatenates the guild's name instead of the Guild object.
    * @returns {string}
    * @example
    * // Logs: Hello from My Guild!

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -488,7 +488,7 @@ class GuildChannel extends Channel {
   }
 
   /**
-   * When concatenated with a string, this automatically returns the channel's mention instead of the Channel object.
+   * When concatenated with a string, this automatically concatenates the channel's mention instead of the Channel object.
    * @returns {string}
    * @example
    * // Logs: Hello from <#123456789012345678>!

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -491,11 +491,8 @@ class GuildChannel extends Channel {
    * When concatenated with a string, this automatically returns the channel's mention instead of the Channel object.
    * @returns {string}
    * @example
-   * // Outputs: Hello from #general
-   * console.log(`Hello from ${channel}`);
-   * @example
-   * // Outputs: Hello from #general
-   * console.log('Hello from ' + channel);
+   * // Logs: Hello from <#123456789012345678>!
+   * console.log(`Hello from ${channel}!`);
    */
   toString() {
     return `<#${this.id}>`;

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -488,7 +488,7 @@ class GuildChannel extends Channel {
   }
 
   /**
-   * When concatenated with a string, this automatically concatenates the channel's mention instead of the Channel object.
+   * When concatenated with a string, this automatically returns the channel's mention instead of the Channel object.
    * @returns {string}
    * @example
    * // Logs: Hello from <#123456789012345678>!

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -535,8 +535,7 @@ class GuildMember extends Base {
   }
 
   /**
-   * When concatenated with a string, this automatically concatenates the user's mention instead of the
-   * GuildMember object.
+   * When concatenated with a string, this automatically returns the user's mention instead of the GuildMember object.
    * @returns {string}
    * @example
    * // Logs: Hello from <@123456789012345678>!

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -535,7 +535,8 @@ class GuildMember extends Base {
   }
 
   /**
-   * When concatenated with a string, this automatically concatenates the user's mention instead of the Member object.
+   * When concatenated with a string, this automatically concatenates the user's mention instead of the
+   * GuildMember object.
    * @returns {string}
    * @example
    * // Logs: Hello from <@123456789012345678>!

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -538,7 +538,7 @@ class GuildMember extends Base {
    * When concatenated with a string, this automatically concatenates the user's mention instead of the Member object.
    * @returns {string}
    * @example
-   * // Logs: Hello from <@123456789>!
+   * // Logs: Hello from <@123456789012345678>!
    * console.log(`Hello from ${member}!`);
    */
   toString() {

--- a/src/structures/ReactionEmoji.js
+++ b/src/structures/ReactionEmoji.js
@@ -38,7 +38,7 @@ class ReactionEmoji {
    * Creates the text required to form a graphical emoji on Discord.
    * @example
    * // Send the emoji used in a reaction to the channel the reaction is part of
-   * reaction.message.channel.send(`The emoji used is ${reaction.emoji}`);
+   * reaction.message.channel.send(`The emoji used was: ${reaction.emoji}`);
    * @returns {string}
    */
   toString() {

--- a/src/structures/ReactionEmoji.js
+++ b/src/structures/ReactionEmoji.js
@@ -35,8 +35,8 @@ class ReactionEmoji {
   }
 
   /**
-   * When concatenated with a string, this automatically concatenates the text required to form a graphical emoji
-   * on Discord instead of the ReactionEmoji object.
+   * When concatenated with a string, this automatically returns the text required to form a graphical emoji on Discord
+   * instead of the ReactionEmoji object.
    * @returns {string}
    * @example
    * // Send the emoji used in a reaction to the channel the reaction is part of

--- a/src/structures/ReactionEmoji.js
+++ b/src/structures/ReactionEmoji.js
@@ -35,11 +35,12 @@ class ReactionEmoji {
   }
 
   /**
-   * Creates the text required to form a graphical emoji on Discord.
+   * When concatenated with a string, this automatically concatenates the text required to form a graphical emoji
+   * on Discord instead of the ReactionEmoji object.
+   * @returns {string}
    * @example
    * // Send the emoji used in a reaction to the channel the reaction is part of
    * reaction.message.channel.send(`The emoji used was: ${reaction.emoji}`);
-   * @returns {string}
    */
   toString() {
     return this.id ? `<:${this.name}:${this.id}>` : this.name;

--- a/src/structures/Role.js
+++ b/src/structures/Role.js
@@ -334,6 +334,9 @@ class Role extends Base {
   /**
    * When concatenated with a string, this automatically concatenates the role mention rather than the Role object.
    * @returns {string}
+   * @example
+   * // Logs: Role: <@&123456789012345678>
+   * console.log(`Role: ${role}`);
    */
   toString() {
     if (this.id === this.guild.id) return '@everyone';

--- a/src/structures/Role.js
+++ b/src/structures/Role.js
@@ -332,7 +332,7 @@ class Role extends Base {
   }
 
   /**
-   * When concatenated with a string, this automatically concatenates the role mention rather than the Role object.
+   * When concatenated with a string, this automatically concatenates the role's mention instead of the Role object.
    * @returns {string}
    * @example
    * // Logs: Role: <@&123456789012345678>

--- a/src/structures/Role.js
+++ b/src/structures/Role.js
@@ -332,7 +332,7 @@ class Role extends Base {
   }
 
   /**
-   * When concatenated with a string, this automatically concatenates the role's mention instead of the Role object.
+   * When concatenated with a string, this automatically returns the role's mention instead of the Role object.
    * @returns {string}
    * @example
    * // Logs: Role: <@&123456789012345678>

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -250,7 +250,7 @@ class User extends Base {
   }
 
   /**
-   * When concatenated with a string, this automatically concatenates the user's mention instead of the User object.
+   * When concatenated with a string, this automatically returns the user's mention instead of the User object.
    * @returns {string}
    * @example
    * // Logs: Hello from <@123456789012345678>!

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -253,7 +253,7 @@ class User extends Base {
    * When concatenated with a string, this automatically concatenates the user's mention instead of the User object.
    * @returns {string}
    * @example
-   * // logs: Hello from <@123456789>!
+   * // Logs: Hello from <@123456789012345678>!
    * console.log(`Hello from ${user}!`);
    */
   toString() {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR normalizes the docs examples for the `.toString()` method on all classes. Additionally, the ES5 examples were removed, and classes that were missing an example before now have one.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
