### PR TITLE
fix(MessageBulkDeleteAction): remove deleted messages from cache

### DIFF
--- a/src/client/actions/MessageDeleteBulk.js
+++ b/src/client/actions/MessageDeleteBulk.js
@@ -12,7 +12,10 @@ class MessageDeleteBulkAction extends Action {
       const messages = new Collection();
       for (const id of ids) {
         const message = channel.messages.get(id);
-        if (message) messages.set(message.id, message);
+        if (message) {
+          messages.set(message.id, message);
+          channel.messages.delete(id);
+        }
       }
 
       if (messages.size > 0) client.emit(Events.MESSAGE_BULK_DELETE, messages);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This fixes #2036

The bulk delete action doesn't remove the deleted messages from the cache.

This causes the call to the bulk delete action from `TextBasedChannel#bulkDelete` to fire the event the first time and the gateway event to fire it the second time.

Removing the deleted messages from the cache resolves the issue. 
_Not like they were supposed to stay there in the first place._

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
