### PR TITLE
Add TextChannel#setNSFW method

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -290,6 +290,7 @@ class GuildChannel extends Channel {
       data: {
         name: (data.name || this.name).trim(),
         topic: data.topic,
+        nsfw: data.nsfw,
         bitrate: data.bitrate || (this.bitrate ? this.bitrate * 1000 : undefined),
         user_limit: data.userLimit != null ? data.userLimit : this.userLimit, // eslint-disable-line eqeqeq
         parent_id: data.parentID,

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -248,6 +248,7 @@ class GuildChannel extends Channel {
    * @property {string} [name] The name of the channel
    * @property {number} [position] The position of the channel
    * @property {string} [topic] The topic of the text channel
+   * @property {boolean} [nsfw] Whether the channel is NSFW
    * @property {number} [bitrate] The bitrate of the voice channel
    * @property {number} [userLimit] The user limit of the voice channel
    * @property {Snowflake} [parentID] The parent ID of the channel

--- a/src/structures/TextChannel.js
+++ b/src/structures/TextChannel.js
@@ -40,7 +40,7 @@ class TextChannel extends GuildChannel {
 
   /**
    * Sets whether this channel is flagged as NSFW.
-   * @param {string} nsfw Whether the channel should be considered NSFW
+   * @param {boolean} nsfw Whether the channel should be considered NSFW
    * @param {string} [reason] Reason for changing the channel's NSFW flag
    * @returns {Promise<TextChannel>}
    */

--- a/src/structures/TextChannel.js
+++ b/src/structures/TextChannel.js
@@ -39,6 +39,16 @@ class TextChannel extends GuildChannel {
   }
 
   /**
+   * Sets whether this channel is flagged as NSFW.
+   * @param {string} nsfw Whether the channel should be considered NSFW
+   * @param {string} [reason] Reason for changing the channel's NSFW flag
+   * @returns {Promise<TextChannel>}
+   */
+  setNSFW(nsfw, reason) {
+    return this.edit({ nsfw }, reason);
+  }
+
+  /**
    * Fetches all webhooks for the channel.
    * @returns {Promise<Collection<Snowflake, Webhook>>}
    */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Adds a method to set the NSFW flag on TextChannels. It should be merged because I want it to be.

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
