### PR TITLE
fix(Client): login not using env.token

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -249,7 +249,7 @@ class Client extends BaseClient {
    * @example
    * client.login('my token');
    */
-  login(token) {
+  login(token = this.token) {
     return new Promise((resolve, reject) => {
       if (!token || typeof token !== 'string') throw new Error('TOKEN_INVALID');
       token = token.replace(/^Bot\s*/i, '');


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Was changed from stable for some reason, didn't allow the passing of the token through environment variables (something useful in sharding) and just threw an error when trying to login without providing a token there.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
