### PR TITLE
handle string ffmpeg input

### DIFF
--- a/src/client/voice/VoiceBroadcast.js
+++ b/src/client/voice/VoiceBroadcast.js
@@ -41,7 +41,7 @@ class VoiceBroadcast extends EventEmitter {
    *   .catch(console.error);
    */
   playFile(file, options) {
-    return this.player.playUnknownStream(`file:${file}`, options);
+    return this.player.playUnknown(`file:${file}`, options);
   }
 
   /**
@@ -51,7 +51,7 @@ class VoiceBroadcast extends EventEmitter {
    * @returns {StreamDispatcher}
    */
   playArbitraryInput(input, options) {
-    return this.player.playUnknownStream(input, options);
+    return this.player.playUnknown(input, options);
   }
 
   /**
@@ -71,7 +71,7 @@ class VoiceBroadcast extends EventEmitter {
    *   .catch(console.error);
    */
   playStream(stream, options) {
-    return this.player.playUnknownStream(stream, options);
+    return this.player.playUnknown(stream, options);
   }
 
   /**

--- a/src/client/voice/VoiceBroadcast.js
+++ b/src/client/voice/VoiceBroadcast.js
@@ -41,7 +41,7 @@ class VoiceBroadcast extends EventEmitter {
    *   .catch(console.error);
    */
   playFile(file, options) {
-    return this.player.playUnknown(`file:${file}`, options);
+    return this.player.playUnknown(file, options);
   }
 
   /**

--- a/src/client/voice/VoiceConnection.js
+++ b/src/client/voice/VoiceConnection.js
@@ -457,7 +457,7 @@ class VoiceConnection extends EventEmitter {
    *   .catch(console.error);
    */
   playFile(file, options) {
-    return this.player.playUnknown(`file:${file}`, options);
+    return this.player.playUnknown(file, options);
   }
 
   /**

--- a/src/client/voice/VoiceConnection.js
+++ b/src/client/voice/VoiceConnection.js
@@ -457,7 +457,7 @@ class VoiceConnection extends EventEmitter {
    *   .catch(console.error);
    */
   playFile(file, options) {
-    return this.player.playUnknownStream(`file:${file}`, options);
+    return this.player.playUnknown(`file:${file}`, options);
   }
 
   /**
@@ -467,7 +467,7 @@ class VoiceConnection extends EventEmitter {
    * @returns {StreamDispatcher}
    */
   playArbitraryInput(input, options) {
-    return this.player.playUnknownStream(input, options);
+    return this.player.playUnknown(input, options);
   }
 
   /**
@@ -487,7 +487,7 @@ class VoiceConnection extends EventEmitter {
    *   .catch(console.error);
    */
   playStream(stream, options) {
-    return this.player.playUnknownStream(stream, options);
+    return this.player.playUnknown(stream, options);
   }
 
   /**

--- a/src/client/voice/dispatcher/BroadcastDispatcher.js
+++ b/src/client/voice/dispatcher/BroadcastDispatcher.js
@@ -1,4 +1,3 @@
-const Collection = require('../../../util/Collection');
 const StreamDispatcher = require('./StreamDispatcher');
 
 /**

--- a/src/client/voice/dispatcher/StreamDispatcher.js
+++ b/src/client/voice/dispatcher/StreamDispatcher.js
@@ -146,7 +146,7 @@ class StreamDispatcher extends Writable {
 
   /**
    * Sets the expected packet loss percentage if using a compatible Opus stream.
-   * @param {number} value between 0 and 1 
+   * @param {number} value between 0 and 1
    * @returns {boolean} Returns true if it was successfully set.
    */
   setPLP(value) {
@@ -157,7 +157,7 @@ class StreamDispatcher extends Writable {
 
   /**
    * Enables or disables forward error correction if using a compatible Opus stream.
-   * @param {boolean} enabled true to enable 
+   * @param {boolean} enabled true to enable
    * @returns {boolean} Returns true if it was successfully set.
    */
   setFEC(enabled) {

--- a/src/client/voice/player/AudioPlayer.js
+++ b/src/client/voice/player/AudioPlayer.js
@@ -1,5 +1,3 @@
-const prism = require('prism-media');
-const StreamDispatcher = require('../dispatcher/StreamDispatcher');
 const BasePlayer = require('./BasePlayer');
 
 /**

--- a/src/client/voice/player/BasePlayer.js
+++ b/src/client/voice/player/BasePlayer.js
@@ -1,4 +1,5 @@
 const EventEmitter = require('events').EventEmitter;
+const { Readable: ReadableStream } = require('stream');
 const prism = require('prism-media');
 const StreamDispatcher = require('../dispatcher/StreamDispatcher');
 
@@ -16,7 +17,7 @@ const FFMPEG_ARGUMENTS = [
  * @extends {EventEmitter}
  */
 class BasePlayer extends EventEmitter {
-  constructor(voiceConnection) {
+  constructor() {
     super();
 
     this.dispatcher = null;
@@ -41,8 +42,12 @@ class BasePlayer extends EventEmitter {
 
   playUnknownStream(stream, options) {
     this.destroyDispatcher();
-    const ffmpeg = new prism.FFmpeg({ args: FFMPEG_ARGUMENTS });
-    stream.pipe(ffmpeg);
+
+    const isStream = stream instanceof ReadableStream;
+    const args = isStream ? FFMPEG_ARGUMENTS : ['-i', stream, ...FFMPEG_ARGUMENTS];
+    const ffmpeg = new prism.FFmpeg({ args });
+    if (isStream) stream.pipe(ffmpeg);
+
     return this.playPCMStream(ffmpeg, options, { ffmpeg });
   }
 

--- a/src/client/voice/player/BasePlayer.js
+++ b/src/client/voice/player/BasePlayer.js
@@ -40,13 +40,13 @@ class BasePlayer extends EventEmitter {
     }
   }
 
-  playUnknownStream(stream, options) {
+  playUnknown(input, options) {
     this.destroyDispatcher();
 
-    const isStream = stream instanceof ReadableStream;
-    const args = isStream ? FFMPEG_ARGUMENTS : ['-i', stream, ...FFMPEG_ARGUMENTS];
+    const isStream = input instanceof ReadableStream;
+    const args = isStream ? FFMPEG_ARGUMENTS : ['-i', input, ...FFMPEG_ARGUMENTS];
     const ffmpeg = new prism.FFmpeg({ args });
-    if (isStream) stream.pipe(ffmpeg);
+    if (isStream) input.pipe(ffmpeg);
 
     return this.playPCMStream(ffmpeg, options, { ffmpeg });
   }

--- a/src/client/voice/player/BroadcastAudioPlayer.js
+++ b/src/client/voice/player/BroadcastAudioPlayer.js
@@ -1,4 +1,3 @@
-const prism = require('prism-media');
 const BroadcastDispatcher = require('../dispatcher/BroadcastDispatcher');
 const BasePlayer = require('./BasePlayer');
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Patches `BasePlayer#playUnknownStream` to handle streams of type string as arbitrary FFmpeg input. (also removes useless constructor param)

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
