### PR TITLE
voice: Add guild to VoiceConnection

### DIFF
--- a/src/client/voice/VoiceConnection.js
+++ b/src/client/voice/VoiceConnection.js
@@ -39,7 +39,7 @@ class VoiceConnection extends EventEmitter {
      * @type {VoiceChannel}
      */
     this.channel = channel;
-    
+
     /**
      * The guild this connection is present in
      * @type {Guild}

--- a/src/client/voice/VoiceConnection.js
+++ b/src/client/voice/VoiceConnection.js
@@ -39,6 +39,12 @@ class VoiceConnection extends EventEmitter {
      * @type {VoiceChannel}
      */
     this.channel = channel;
+    
+    /**
+     * The guild this connection is present in
+     * @type {Guild}
+     */
+    this.guild = channel.guild;
 
     /**
      * The current status of the voice connection


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`dispatcher.player.voiceConnection.channel.guild`

Need I say more?

I know you can easily do `voiceConnection.channel.guild`, but if the guild has `guild.voiceConnection`, why shouldn't the voice connection have it as well?

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
