### PR TITLE
fix(Presence): pass client and default to offline

### DIFF
--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -125,7 +125,7 @@ class GuildMember extends Base {
    * @readonly
    */
   get presence() {
-    return this.frozenPresence || this.guild.presences.get(this.id) || new Presence();
+    return this.frozenPresence || this.guild.presences.get(this.id) || new Presence(this.client);
   }
 
   /**

--- a/src/structures/Presence.js
+++ b/src/structures/Presence.js
@@ -19,7 +19,7 @@ class Presence {
      * * **`dnd`** - user is in Do Not Disturb
      * @type {string}
      */
-    this.status = data.status || this.status;
+    this.status = data.status || this.status || 'offline';
 
     const activity = data.game || data.activity;
     /**

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -95,7 +95,7 @@ class User extends Base {
     for (const guild of this.client.guilds.values()) {
       if (guild.presences.has(this.id)) return guild.presences.get(this.id);
     }
-    return new Presence();
+    return new Presence(this.client);
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This (hopefully) fixes #2058 

https://github.com/hydrabolt/discord.js/blob/ee1d4c53f2770b5e4748d0d7402dc0291f9f869e/src/structures/Presence.js#L22
https://github.com/hydrabolt/discord.js/blob/243ff48a67446fba96da91503670cea0aba3a968/src/structures/Presence.js#L17
These two would explain why presences can have an `undefined` status:
- Solved by defaulting to `offline` again.

The `client` property can be undefined beacuse `GuildMember#presence` and `User#presence` default to `new Presence()` when no other presence was found and didn't pass the client to the constructor.
- Solved by passing the client to the constructor.


**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
