### PR TITLE
user._patch shouldn't try to touch the token

### DIFF
--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -88,6 +88,8 @@ class ClientUser extends User {
         this.guildSettings.set(settings.guild_id, new ClientUserGuildSettings(this.client, settings));
       }
     }
+
+    if (data.token) this.client.token = data.token;
   }
 
   /**

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -63,8 +63,6 @@ class User extends Base {
      * @type {?Message}
      */
     this.lastMessage = null;
-
-    if (data.token) this.client.token = data.token;
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This is more organization, but the user._patch method attempts to change the client.token if there is a data.token property, which should only come on a ClientUser._patch. So the check/assign moved to the ClientUser._patch instead...

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
