### PR TITLE
Fix user.bot

### DIFF
--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -20,6 +20,13 @@ class User extends Base {
      */
     this.id = data.id;
 
+    /**
+     * Whether or not the user is a bot
+     * @type {boolean}
+     * @name User#bot
+     */
+    this.bot = Boolean(data.bot);
+
     this._patch(data);
   }
 
@@ -44,13 +51,6 @@ class User extends Base {
      * @name User#avatar
      */
     if (typeof data.avatar !== 'undefined') this.avatar = data.avatar;
-
-    /**
-     * Whether or not the user is a bot
-     * @type {boolean}
-     * @name User#bot
-     */
-    if (typeof this.bot === 'undefined' && typeof data.bot !== 'undefined') this.bot = Boolean(data.bot);
 
     /**
      * The ID of the last message sent by the user, if one was sent

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -47,7 +47,7 @@ class User extends Base {
 
     /**
      * The ID of the user's avatar
-     * @type {string}
+     * @type {?string}
      * @name User#avatar
      */
     if (typeof data.avatar !== 'undefined') this.avatar = data.avatar;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
user.bot was either undefined or true, never false for user users. Also, double checked user.avatar for a similar bug, but discord sends null if someone unsets an avatar. So the code works, but the docs now reflect that the property is nullable.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
