### PR TITLE
deprecated or remove hasPermission

### DIFF
--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -296,6 +296,7 @@ class GuildMember extends Base {
    * @param {PermissionResolvable|PermissionResolvable[]} permission Permission(s) to check for
    * @param {boolean} [checkAdmin=true] Whether to allow the administrator permission to override
    * @param {boolean} [checkOwner=true] Whether to allow being the guild's owner to override
+   * @deprecated
    * @returns {boolean}
    */
   hasPermission(permission, checkAdmin = true, checkOwner = true) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Since hasPermissions was deprecated a while ago and all Permission related stuff was moved to the Permission Class but hasPermission wasn't, even when mostly everything you do with hasPermission is possible with 2 lines of code and the has method, would i recommend deprecating it aswell or even remove it completly since V12 isn't released yet.

because i just dont see why hasPermissions should be deprecated/removed and hasPermission not when the Permission Class offers everything you need

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
