### PR TITLE
 fix(Split/Webhook): readd message chunk sending and fix webhook avatar/username

### DIFF
--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -105,6 +105,19 @@ class Webhook {
 
     const { data, files } = await createMessage(this, options);
 
+    if (data.content instanceof Array) {
+      const messages = [];
+      for (let i = 0; i < data.content.length; i++) {
+        const opt = i === data.content.length - 1 ? { embeds: data.embeds, files } : {};
+        Object.assign(opt, { avatarURL: data.avatar_url, content: data.content[i], username: data.username });
+        // eslint-disable-next-line no-await-in-loop
+        const message = await this.send(data.content[i], opt);
+        messages.push(message);
+      }
+      return messages;
+    }
+
+
     return this.client.api.webhooks(this.id, this.token).post({
       data, files,
       query: { wait: true },

--- a/src/structures/shared/CreateMessage.js
+++ b/src/structures/shared/CreateMessage.js
@@ -10,8 +10,9 @@ module.exports = async function createMessage(channel, options) {
   const User = require('../User');
   const GuildMember = require('../GuildMember');
   const Webhook = require('../Webhook');
+  const WebhookClient = require('../../client/WebhookClient');
 
-  const webhook = channel instanceof Webhook;
+  const webhook = channel instanceof Webhook || channel instanceof WebhookClient;
 
   if (typeof options.nonce !== 'undefined') {
     options.nonce = parseInt(options.nonce);
@@ -88,15 +89,11 @@ module.exports = async function createMessage(channel, options) {
         return file;
       })
     ));
-    delete options.files;
   }
 
   if (webhook) {
     if (!options.username) options.username = this.name;
-    if (options.avatarURL) {
-      options.avatar_url = options.avatarURL;
-      options.avatarURL = null;
-    }
+    if (options.avatarURL) options.avatar_url = options.avatarURL;
   }
 
   return { data: {
@@ -106,6 +103,6 @@ module.exports = async function createMessage(channel, options) {
     embed: options.embed,
     embeds: options.embeds,
     username: options.username,
-    avatar_url: options.avatarURL,
+    avatar_url: options.avatar_url,
   }, files };
 };

--- a/src/structures/shared/SendMessage.js
+++ b/src/structures/shared/SendMessage.js
@@ -7,6 +7,17 @@ module.exports = async function sendMessage(channel, options) { // eslint-disabl
 
   const { data, files } = await createMessage(channel, options);
 
+  if (data.content instanceof Array) {
+    const messages = [];
+    for (let i = 0; i < data.content.length; i++) {
+      const opt = i === data.content.length - 1 ? { tts: data.tts, embed: data.embed, files } : { tts: data.tts };
+      // eslint-disable-next-line no-await-in-loop
+      const message = await channel.send(data.content[i], opt);
+      messages.push(message);
+    }
+    return messages;
+  }
+
   return channel.client.api.channels[channel.id].messages.post({ data, files })
     .then(d => channel.client.actions.MessageCreate.handle(d).message);
 };


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- `WebhookClient` is no longer instanceof `Webhook`, it's now extending `BaseClient`. 
Another instanceof is needed here.
- Read the correct property (`avatar_url`) to reflect per message avatar changes with webhooks.
- Removed deleting/setting to null of some options.
If that is in any way necessary, feel free to enlighten me.
- Readded message chunk sending (used when using SplitOptions).

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
