### PR TITLE
Fixing Cannot send an empty message error for WebhookClient.

### DIFF
--- a/src/structures/shared/CreateMessage.js
+++ b/src/structures/shared/CreateMessage.js
@@ -10,8 +10,9 @@ module.exports = async function createMessage(channel, options) {
   const User = require('../User');
   const GuildMember = require('../GuildMember');
   const Webhook = require('../Webhook');
+  const WebhookClient = require('../../client/WebhookClient');
 
-  const webhook = channel instanceof Webhook;
+  const webhook = channel instanceof Webhook || channel instanceof WebhookClient;
 
   if (typeof options.nonce !== 'undefined') {
     options.nonce = parseInt(options.nonce);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

When trying to send an embed with

    const client = new WebhookClient('id', 'token');
    client.send({embed});

It gives me a `Cannot send an empty message` error.

This will make it work.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
