### PR TITLE
emit ReactionCollector#remove on all unreactions

### DIFF
--- a/src/structures/ReactionCollector.js
+++ b/src/structures/ReactionCollector.js
@@ -92,7 +92,7 @@ class ReactionCollector extends Collector {
      * @event ReactionCollector#remove
      * @param {MessageReaction} reaction The reaction that was removed
      */
-    this.emit('remove', reaction);
+    if (this.collected.has(reaction)) this.emit('remove', reaction);
     return reaction.count ? null : ReactionCollector.key(reaction);
   }
 

--- a/src/structures/ReactionCollector.js
+++ b/src/structures/ReactionCollector.js
@@ -83,7 +83,17 @@ class ReactionCollector extends Collector {
    * @returns {?Snowflake|string}
    */
   dispose(reaction) {
-    return reaction.message.id === this.message.id && !reaction.count ? ReactionCollector.key(reaction) : null;
+    if (reaction.message.id !== this.message.id) return null;
+
+    /**
+     * Emitted whenever a reaction is removed from a message. Will emit on all reaction removals,
+     * as opposed to {@link Collector#dispose} which will only be emitted when the entire reaction
+     * is removed.
+     * @event ReactionCollector#remove
+     * @param {MessageReaction} reaction The reaction that was removed
+     */
+    this.emit('remove', reaction);
+    return reaction.count ? null : ReactionCollector.key(reaction);
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This will emit an event when a user removes a collected reaction. This is in addition to Collector#dispose, which will only fire when all users have unreacted to the same emoji.

Closes #2056 

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
