### PR TITLE
Mark defaultChannel as deprecated

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -1214,6 +1214,7 @@ class Guild {
  * @name Guild#defaultChannel
  * @type {TextChannel}
  * @readonly
+ * @deprecated
  */
 Object.defineProperty(Guild.prototype, 'defaultChannel', {
   get: util.deprecate(function defaultChannel() {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The documentation indicates this property is safe to use, but it throws a runtime warning saying it's deprecated and unreliable. This should be clearly noted in the documentation.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
