### PR TITLE
added a new Typedef for Bans you can get from <Guild>.fetchBans() and fixed a little typo in the fetchAuditLogs() method

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -432,15 +432,15 @@ class Guild extends Base {
   }
 
   /**
-   * A Discord Ban Object.
-   * @typedef {Object} Ban
-   * @property {User} user The banned user
-   * @property {?string} reason The reason
+   * An object containing information about a guild member's ban.
+   * @typedef {Object} BanInfo
+   * @property {User} user User that was banned
+   * @property {?string} reason Reason the user was banned
    */
 
   /**
    * Fetches a collection of banned users in this guild.
-   * @returns {Promise<Collection<Snowflake, Ban>>}
+   * @returns {Promise<Collection<Snowflake, BanInfo>>}
    */
   fetchBans() {
     return this.client.api.guilds(this.id).bans.get().then(bans =>

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -434,8 +434,8 @@ class Guild extends Base {
   /**
    * A Discord Ban Object.
    * @typedef {Object} Ban
-   * @property {User} user the banned user.
-   * @property {?string} reason the reason of the ban.
+   * @property {User} user The banned user
+   * @property {?string} reason The reason
    */
 
   /**

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -432,11 +432,11 @@ class Guild extends Base {
   }
 
   /**
- * A Discord Ban Object.
- * @typedef {Object} Ban
- * @property {User} user the banned user.
- * @property {?string} reason the reason of the ban.
- */
+   * A Discord Ban Object.
+   * @typedef {Object} Ban
+   * @property {User} user the banned user.
+   * @property {?string} reason the reason of the ban.
+   */
 
   /**
    * Fetches a collection of banned users in this guild.

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -432,9 +432,15 @@ class Guild extends Base {
   }
 
   /**
+ * A Discord Guild Ban.
+ * @typedef {Object} Ban
+ * @property {User} user the banned user.
+ * @property {?string} reason the reason of the ban.
+ */
+
+  /**
    * Fetches a collection of banned users in this guild.
-   * The returned collection contains user objects keyed under `user` and reasons keyed under `reason`.
-   * @returns {Promise<Collection<Snowflake, Object>>}
+   * @returns {Promise<Collection<Snowflake, Ban>>}
    */
   fetchBans() {
     return this.client.api.guilds(this.id).bans.get().then(bans =>
@@ -496,7 +502,7 @@ class Guild extends Base {
    * @param {Snowflake|GuildAuditLogsEntry} [options.after] Limit to entries from after specified entry
    * @param {number} [options.limit] Limit number of entries
    * @param {UserResolvable} [options.user] Only show entries involving this user
-   * @param {ActionType|number} [options.type] Only show entries involving this action type
+   * @param {AuditLogAction|number} [options.type] Only show entries involving this action type
    * @returns {Promise<GuildAuditLogs>}
    */
   fetchAuditLogs(options = {}) {

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -432,7 +432,7 @@ class Guild extends Base {
   }
 
   /**
- * A Discord Guild Ban.
+ * A Discord Ban Object.
  * @typedef {Object} Ban
  * @property {User} user the banned user.
  * @property {?string} reason the reason of the ban.


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
added a new typedef for Discord Bans because it looks cleaner than write it in the description and fixed a little typo in fetchAuditLogs.type type so its now correct and clickable

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
