### PR TITLE
Update Shard.js

### DIFF
--- a/src/sharding/Shard.js
+++ b/src/sharding/Shard.js
@@ -160,7 +160,7 @@ class Shard {
          * Emitted upon the shard's {@link Client#ready} event.
          * @event Shard#ready
          */
-        this.emit('ready');
+        this.manager.emit('ready');
         return;
       }
 
@@ -171,7 +171,7 @@ class Shard {
          * Emitted upon the shard's {@link Client#disconnect} event.
          * @event Shard#disconnect
          */
-        this.emit('disconnect');
+        this.manager.emit('disconnect');
         return;
       }
 
@@ -182,7 +182,7 @@ class Shard {
          * Emitted upon the shard's {@link Client#reconnecting} event.
          * @event Shard#reconnecting
          */
-        this.emit('reconnecting');
+        this.manager.emit('reconnecting');
         return;
       }
 


### PR DESCRIPTION
Updating `this.emit` to `this.manager.emit` fixing the sharding manager

```
/root/donut/node_modules/discord.js/src/sharding/Shard.js:163
        this.emit('ready');
             ^

TypeError: this.emit is not a function
    at Shard._handleMessage (/root/donut/node_modules/discord.js/src/sharding/Shard.js:163:14)
    at emitTwo (events.js:125:13)
    at ChildProcess.emit (events.js:213:7)
    at emit (internal/child_process.js:774:12)
    at _combinedTickCallback (internal/process/next_tick.js:141:11)
    at process._tickCallback (internal/process/next_tick.js:180:9)
```

**Please describe the changes this PR makes and why it should be merged:**


**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
