### PR TITLE
fix(Shard): extend EventEmitter to be able to emit events

### DIFF
--- a/src/sharding/Shard.js
+++ b/src/sharding/Shard.js
@@ -1,4 +1,5 @@
 const childProcess = require('child_process');
+const EventEmitter = require('events');
 const path = require('path');
 const Util = require('../util/Util');
 const { Error } = require('../errors');
@@ -6,13 +7,14 @@ const { Error } = require('../errors');
 /**
  * Represents a Shard spawned by the ShardingManager.
  */
-class Shard {
+class Shard extends EventEmitter {
   /**
    * @param {ShardingManager} manager Manager that is spawning this shard
    * @param {number} id ID of this shard
    * @param {string[]} [args=[]] Command line arguments to pass to the script
    */
   constructor(manager, id, args = []) {
+    super();
     /**
      * Manager that created the shard
      * @type {ShardingManager}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The Shard class is intended to emit events, but doesn't extend EventEmitter,
making it not possible to use sharding.

This PR resolves that issue by extending EventEmitter.

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
