### PR TITLE
fix(ShardingManager): not a callback error

### DIFF
--- a/src/sharding/ShardingManager.js
+++ b/src/sharding/ShardingManager.js
@@ -132,7 +132,7 @@ class ShardingManager extends EventEmitter {
       const promises = [];
       const shard = this.createShard();
       promises.push(shard.spawn(waitForReady));
-      if (delay > 0 && s !== amount) promises.push(delayFor(delay));
+      if (delay > 0 && s !== amount) promises.push(() => delayFor(delay));
       await Promise.all(promises); // eslint-disable-line no-await-in-loop
     }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Not passing a callback in the promisified setTimeout threw errors and as a result didn't spawn any shards other than the first one, this should fix that.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
