### PR TITLE
Fix inconsistency with Channel Creation: CustomStructures

### DIFF
--- a/src/structures/Channel.js
+++ b/src/structures/Channel.js
@@ -66,32 +66,27 @@ class Channel extends Base {
   }
 
   static create(client, data, guild) {
-    const DMChannel = require('./DMChannel');
-    const GroupDMChannel = require('./GroupDMChannel');
-    const TextChannel = require('./TextChannel');
-    const VoiceChannel = require('./VoiceChannel');
-    const CategoryChannel = require('./CategoryChannel');
-    const GuildChannel = require('./GuildChannel');
+    const Structures = require('../util/Structures');
     let channel;
     if (data.type === ChannelTypes.DM) {
-      channel = new DMChannel(client, data);
+      channel = new Structures.get('DMChannel')(client, data);
     } else if (data.type === ChannelTypes.GROUP) {
-      channel = new GroupDMChannel(client, data);
+      channel = new Structures.get('GroupDMChannel')(client, data);
     } else {
       guild = guild || client.guilds.get(data.guild_id);
       if (guild) {
         switch (data.type) {
           case ChannelTypes.TEXT:
-            channel = new TextChannel(guild, data);
+            channel = new Structures.get('TextChannel')(guild, data);
             break;
           case ChannelTypes.VOICE:
-            channel = new VoiceChannel(guild, data);
+            channel = new Structures.get('VoiceChannel')(guild, data);
             break;
           case ChannelTypes.CATEGORY:
-            channel = new CategoryChannel(guild, data);
+            channel = new Structures.get('CategoryChannel')(guild, data);
             break;
           default:
-            channel = new GuildChannel(guild, data);
+            channel = new Structures.get('GuildChannel')(guild, data);
         }
         guild.channels.set(channel.id, channel);
       }

--- a/src/structures/Channel.js
+++ b/src/structures/Channel.js
@@ -69,24 +69,34 @@ class Channel extends Base {
     const Structures = require('../util/Structures');
     let channel;
     if (data.type === ChannelTypes.DM) {
-      channel = new Structures.get('DMChannel')(client, data);
+      const DMChannel = Structures.get('DMChannel');
+      channel = new DMChannel(client, data);
     } else if (data.type === ChannelTypes.GROUP) {
-      channel = new Structures.get('GroupDMChannel')(client, data);
+      const GroupDMChannel = Structures.get('GroupDMChannel');
+      channel = new GroupDMChannel(client, data);
     } else {
       guild = guild || client.guilds.get(data.guild_id);
       if (guild) {
         switch (data.type) {
-          case ChannelTypes.TEXT:
-            channel = new Structures.get('TextChannel')(guild, data);
+          case ChannelTypes.TEXT: {
+            const TextChannel = Structures.get('TextChannel');
+            channel = new TextChannel(guild, data);
             break;
-          case ChannelTypes.VOICE:
-            channel = new Structures.get('VoiceChannel')(guild, data);
+          }
+          case ChannelTypes.VOICE: {
+            const VoiceChannel = Structures.get('VoiceChannel');
+            channel = new VoiceChannel(guild, data);
             break;
-          case ChannelTypes.CATEGORY:
-            channel = new Structures.get('CategoryChannel')(guild, data);
+          }
+          case ChannelTypes.CATEGORY: {
+            const CategoryChannel = Structures.get('CategoryChannel');
+            channel = new CategoryChannel(guild, data);
             break;
-          default:
-            channel = new Structures.get('GuildChannel')(guild, data);
+          }
+          default: {
+            const GuildChannel = Structures.get('GuildChannel');
+            channel = new GuildChannel(guild, data);
+          }
         }
         guild.channels.set(channel.id, channel);
       }

--- a/src/util/Structures.js
+++ b/src/util/Structures.js
@@ -61,8 +61,12 @@ class Structures {
 }
 
 const structures = {
-  Channel: require('../structures/Channel'),
   Emoji: require('../structures/Emoji'),
+  DMChannel: require('../structures/DMChannel'),
+  GroupDMChannel: require('../structures/GroupDMChannel'),
+  TextChannel: require('../structures/TextChannel'),
+  VoiceChannel: require('../structures/VoiceChannel'),
+  CategoryChannel: require('../structures/CategoryChannel'),
   GuildChannel: require('../structures/GuildChannel'),
   GuildMember: require('../structures/GuildMember'),
   Guild: require('../structures/Guild'),


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Individual channel types would extend a vanilla Channel, rather than an ExtendedChannel. This change gives more flexibility, and fixes the inconsistency by allowing each individual channel type to be extended, rather than the base Channel class (and then the types incorrectly extending the vanilla Channel).

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
