### PR TITLE
fix(Shard): failing to respawn on exit

### DIFF
--- a/src/sharding/Shard.js
+++ b/src/sharding/Shard.js
@@ -92,7 +92,7 @@ class Shard extends EventEmitter {
 
     this.process = childProcess.fork(path.resolve(this.manager.file), this.args, { env: this.env })
       .on('message', this._handleMessage.bind(this))
-      .on('exit', this._exitListener);
+      .on('exit', () => this._exitListener(this.manager.respawn));
 
     /**
      * Emitted upon the creation of the shard's child process.


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`Shard._handleExit` was being passed `null` from the `exit` event, which would stop shards from respawning no matter what the respawn setting is set as, so this makes sure to pass the manager's option of respawn.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
