### PR TITLE
Permissions improvements

### DIFF
--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -96,10 +96,10 @@ class Permissions {
   }
 
   /**
- * Gets an {@link Array} of permission names (such as `VIEW_CHANNEL`) based on the permissions available.
- * @param {boolean} [checkAdmin=true] Whether to allow the administrator permission to override
- * @returns {string[]}
- */
+   * Gets an {@link Array} of permission names (such as `VIEW_CHANNEL`) based on the permissions available.
+   * @param {boolean} [checkAdmin=true] Whether to allow the administrator permission to override
+   * @returns {string[]}
+   */
   toArray(checkAdmin = true) {
     return Object.keys(this.constructor.FLAGS).filter(perm => this.has(perm, checkAdmin));
   }

--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -38,7 +38,7 @@ class Permissions {
    */
   missing(permissions, checkAdmin = true) {
     if (permissions instanceof Array) return permissions.filter(p => !this.has(p, checkAdmin));
-    return this.missing(new Permissions(permissions).toArray());
+    return this.missing(new Permissions(permissions).toArray(checkAdmin), checkAdmin);
   }
 
   /**

--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -32,11 +32,12 @@ class Permissions {
 
   /**
    * Gets all given permissions that are missing from the bitfield.
-   * @param {PermissionResolvable[]} permissions Permissions to check for
+   * @param {PermissionResolvable[]|Permissions} permissions Permissions to check for
    * @param {boolean} [checkAdmin=true] Whether to allow the administrator permission to override
    * @returns {PermissionResolvable[]}
    */
   missing(permissions, checkAdmin = true) {
+    if (permissions instanceof Permissions) return this.missing(permissions.toArray());
     return permissions.filter(p => !this.has(p, checkAdmin));
   }
 

--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -34,11 +34,13 @@ class Permissions {
    * Gets all given permissions that are missing from the bitfield.
    * @param {PermissionResolvable|PermissionResolvable[]} permissions Permission(s) to check for
    * @param {boolean} [checkAdmin=true] Whether to allow the administrator permission to override
-   * @returns {PermissionResolvable[]}
+   * @returns {string[]}
    */
   missing(permissions, checkAdmin = true) {
-    if (permissions instanceof Array) return permissions.filter(p => !this.has(p, checkAdmin));
-    return this.missing(new this.constructor(permissions).toArray(checkAdmin), checkAdmin);
+    if (checkAdmin && this.has(this.constructor.FLAGS.ADMINISTRATOR)) return [];
+    permissions = new this.constructor(permissions);
+    const missing = new this.constructor(~this.bitfield & permissions.bitfield);
+    return missing.toArray(checkAdmin);
   }
 
   /**

--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -126,6 +126,15 @@ class Permissions {
     if (typeof permission === 'string') return this.FLAGS[permission];
     throw new RangeError('PERMISSIONS_INVALID');
   }
+
+  /**
+   * Resolves permissions to an instance of {@link Permissions}
+   * @param {PermissionResolvable|PermissionResolvable[]} permission - Permission(s) to resolve
+   * @returns {Permissions}
+   */
+  static resolveToObject(permission) {
+    return new Permissions(Permissions.resolve(permission));
+  }
 }
 
 /**

--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -38,7 +38,7 @@ class Permissions {
    */
   missing(permissions, checkAdmin = true) {
     if (permissions instanceof Array) return permissions.filter(p => !this.has(p, checkAdmin));
-    return this.missing(new Permissions(permissions).toArray(checkAdmin), checkAdmin);
+    return this.missing(new this.constructor(permissions).toArray(checkAdmin), checkAdmin);
   }
 
   /**

--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -47,11 +47,7 @@ class Permissions {
    * @returns {PermissionResolvable[]}
    */
   toArray(checkAdmin = true) {
-    const arr = [];
-    for (const perm of Object.keys(Permissions.FLAGS)) {
-      if (this.has(perm, checkAdmin)) arr.push(perm);
-    }
-    return arr;
+    return Object.keys(this.constructor.FLAGS).filter(perm => this.has(perm, checkAdmin));
   }
 
   /**

--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -7,7 +7,7 @@ const { RangeError } = require('../errors');
  */
 class Permissions {
   /**
-   * @param {PermissionResolvable|PermissionResolvable[]} permissions Permission(s) to read from
+   * @param {PermissionResolvable} permissions Permission(s) to read from
    */
   constructor(permissions) {
     /**
@@ -19,7 +19,7 @@ class Permissions {
 
   /**
    * Checks whether the bitfield has a permission, or multiple permissions.
-   * @param {PermissionResolvable|PermissionResolvable[]} permission Permission(s) to check for
+   * @param {PermissionResolvable} permission Permission(s) to check for
    * @param {boolean} [checkAdmin=true] Whether to allow the administrator permission to override
    * @returns {boolean}
    */
@@ -32,7 +32,7 @@ class Permissions {
 
   /**
    * Gets all given permissions that are missing from the bitfield.
-   * @param {PermissionResolvable|PermissionResolvable[]} permissions Permission(s) to check for
+   * @param {PermissionResolvable} permissions Permission(s) to check for
    * @param {boolean} [checkAdmin=true] Whether to allow the administrator permission to override
    * @returns {string[]}
    */
@@ -112,12 +112,13 @@ class Permissions {
    * * A string (see {@link Permissions.FLAGS})
    * * A permission number
    * * An instance of Permissions
-   * @typedef {string|number|Permissions} PermissionResolvable
+   * * An Array of PermissionResolvable
+   * @typedef {string|number|Permissions|PermissionResolvable[]} PermissionResolvable
    */
 
   /**
    * Resolves permissions to their numeric form.
-   * @param {PermissionResolvable|PermissionResolvable[]} permission - Permission(s) to resolve
+   * @param {PermissionResolvable} permission - Permission(s) to resolve
    * @returns {number}
    */
   static resolve(permission) {

--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -19,11 +19,12 @@ class Permissions {
 
   /**
    * Checks whether the bitfield has a permission, or multiple permissions.
-   * @param {PermissionResolvable|PermissionResolvable[]} permission Permission(s) to check for
+   * @param {PermissionResolvable|PermissionResolvable[]|Permissions} permission Permission(s) to check for
    * @param {boolean} [checkAdmin=true] Whether to allow the administrator permission to override
    * @returns {boolean}
    */
   has(permission, checkAdmin = true) {
+    if (permission instanceof Permissions) return this.has(permission.toArray());
     if (permission instanceof Array) return permission.every(p => this.has(p, checkAdmin));
     permission = this.constructor.resolve(permission);
     if (checkAdmin && (this.bitfield & this.constructor.FLAGS.ADMINISTRATOR) > 0) return true;

--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -42,7 +42,7 @@ class Permissions {
   }
 
   /**
-   * Gets an {@link Array} of permission names (such as VIEW_CHANNEL) based on the permissions available.
+   * Gets an {@link Array} of permission names (such as `VIEW_CHANNEL`) based on the permissions available.
    * @param {boolean} [checkAdmin=true] Whether to allow the administrator permission to override
    * @returns {PermissionResolvable[]}
    */

--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -41,6 +41,18 @@ class Permissions {
   }
 
   /**
+   * Returns this object as an {@link Array} of {@link PermissionResolvable}.
+   * @param {boolean} [checkAdmin=true] Whether to allow the administrator permission to override
+   * @returns {PermissionResolvable[]}
+   */
+  toArray(checkAdmin = true){
+    let arr = new Array();
+    for (let perm in Permissions.FLAGS)
+      if (this.has(perm, checkAdmin)) arr.push(perm);
+    return arr;
+  }
+
+  /**
    * Freezes these permissions, making them immutable.
    * @returns {Permissions} These permissions
    */

--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -104,6 +104,11 @@ class Permissions {
     return Object.keys(this.constructor.FLAGS).filter(perm => this.has(perm, checkAdmin));
   }
 
+  *[Symbol.iterator]() {
+    const keys = this.toArray();
+    while (keys.length) yield keys.shift();
+  }
+
   /**
    * Data that can be resolved to give a permission number. This can be:
    * * A string (see {@link Permissions.FLAGS})

--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -7,7 +7,7 @@ const { RangeError } = require('../errors');
  */
 class Permissions {
   /**
-   * @param {number|PermissionResolvable|PermissionResolvable[]} permissions Permission(s) or bitfield to read from
+   * @param {PermissionResolvable|PermissionResolvable[]} permissions Permission(s) or bitfield to read from
    */
   constructor(permissions) {
     /**

--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -32,13 +32,13 @@ class Permissions {
 
   /**
    * Gets all given permissions that are missing from the bitfield.
-   * @param {PermissionResolvable[]|PermissionResolvable} permissions Permission(s) to check for
+   * @param {PermissionResolvable|PermissionResolvable[]} permissions Permission(s) to check for
    * @param {boolean} [checkAdmin=true] Whether to allow the administrator permission to override
    * @returns {PermissionResolvable[]}
    */
   missing(permissions, checkAdmin = true) {
-    if (permissions instanceof PermissionResolvable) return this.missing(Permissions.resolveToObject(permissions).toArray(), checkAdmin);
-    return permissions.filter(p => !this.has(p, checkAdmin));
+    if (permissions instanceof Array) return permissions.filter(p => !this.has(p, checkAdmin));
+    return this.missing(new Permissions(permissions).toArray());
   }
 
   /**

--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -47,10 +47,11 @@ class Permissions {
    * @param {boolean} [checkAdmin=true] Whether to allow the administrator permission to override
    * @returns {PermissionResolvable[]}
    */
-  toArray(checkAdmin = true){
-    let arr = new Array();
-    for (let perm in Permissions.FLAGS)
+  toArray(checkAdmin = true) {
+    let arr = [];
+    for (let perm in Permissions.FLAGS) {
       if (this.has(perm, checkAdmin)) arr.push(perm);
+    }
     return arr;
   }
 

--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -42,7 +42,7 @@ class Permissions {
   }
 
   /**
-   * Gets an {@link Array} of permission names (such as VIEW_CHANNEL) based on the ones available.
+   * Gets an {@link Array} of permission names (such as VIEW_CHANNEL) based on the permissions available.
    * @param {boolean} [checkAdmin=true] Whether to allow the administrator permission to override
    * @returns {PermissionResolvable[]}
    */

--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -32,12 +32,12 @@ class Permissions {
 
   /**
    * Gets all given permissions that are missing from the bitfield.
-   * @param {PermissionResolvable[]|Permissions} permissions Permissions to check for
+   * @param {PermissionResolvable[]|PermissionResolvable} permissions Permission(s) to check for
    * @param {boolean} [checkAdmin=true] Whether to allow the administrator permission to override
    * @returns {PermissionResolvable[]}
    */
   missing(permissions, checkAdmin = true) {
-    if (permissions instanceof Permissions) return this.missing(permissions.toArray(checkAdmin), checkAdmin);
+    if (permissions instanceof PermissionResolvable) return this.missing(Permissions.resolveToObject(permissions).toArray(), checkAdmin);
     return permissions.filter(p => !this.has(p, checkAdmin));
   }
 

--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -44,7 +44,7 @@ class Permissions {
   /**
    * Gets an {@link Array} of permission names (such as `VIEW_CHANNEL`) based on the permissions available.
    * @param {boolean} [checkAdmin=true] Whether to allow the administrator permission to override
-   * @returns {PermissionResolvable[]}
+   * @returns {string[]}
    */
   toArray(checkAdmin = true) {
     return Object.keys(this.constructor.FLAGS).filter(perm => this.has(perm, checkAdmin));

--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -7,7 +7,7 @@ const { RangeError } = require('../errors');
  */
 class Permissions {
   /**
-   * @param {number|PermissionResolvable[]} permissions Permissions or bitfield to read from
+   * @param {number|PermissionResolvable|PermissionResolvable[]} permissions Permission(s) or bitfield to read from
    */
   constructor(permissions) {
     /**
@@ -125,15 +125,6 @@ class Permissions {
     if (permission instanceof Array) return permission.map(p => this.resolve(p)).reduce((prev, p) => prev | p, 0);
     if (typeof permission === 'string') return this.FLAGS[permission];
     throw new RangeError('PERMISSIONS_INVALID');
-  }
-
-  /**
-   * Resolves permissions to an instance of {@link Permissions}
-   * @param {PermissionResolvable|PermissionResolvable[]} permission - Permission(s) to resolve
-   * @returns {Permissions}
-   */
-  static resolveToObject(permission) {
-    return new Permissions(Permissions.resolve(permission));
   }
 }
 

--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -7,7 +7,7 @@ const { RangeError } = require('../errors');
  */
 class Permissions {
   /**
-   * @param {PermissionResolvable|PermissionResolvable[]} permissions Permission(s) or bitfield to read from
+   * @param {PermissionResolvable|PermissionResolvable[]} permissions Permission(s) to read from
    */
   constructor(permissions) {
     /**

--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -19,7 +19,7 @@ class Permissions {
 
   /**
    * Checks whether the bitfield has a permission, or multiple permissions.
-   * @param {PermissionResolvable|PermissionResolvable[]|Permissions} permission Permission(s) to check for
+   * @param {PermissionResolvable|PermissionResolvable[]} permission Permission(s) to check for
    * @param {boolean} [checkAdmin=true] Whether to allow the administrator permission to override
    * @returns {boolean}
    */
@@ -37,7 +37,7 @@ class Permissions {
    * @returns {PermissionResolvable[]}
    */
   missing(permissions, checkAdmin = true) {
-    if (permissions instanceof Permissions) return this.missing(permissions.toArray());
+    if (permissions instanceof Permissions) return this.missing(permissions.toArray(checkAdmin), checkAdmin);
     return permissions.filter(p => !this.has(p, checkAdmin));
   }
 
@@ -47,8 +47,8 @@ class Permissions {
    * @returns {PermissionResolvable[]}
    */
   toArray(checkAdmin = true) {
-    let arr = [];
-    for (let perm in Permissions.FLAGS) {
+    const arr = [];
+    for (const perm of Object.keys(Permissions.FLAGS)) {
       if (this.has(perm, checkAdmin)) arr.push(perm);
     }
     return arr;
@@ -116,7 +116,7 @@ class Permissions {
 
   /**
    * Resolves permissions to their numeric form.
-   * @param {PermissionResolvable|PermissionResolvable[]|Permissions} permission - Permission(s) to resolve
+   * @param {PermissionResolvable|PermissionResolvable[]} permission - Permission(s) to resolve
    * @returns {number}
    */
   static resolve(permission) {

--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -42,7 +42,7 @@ class Permissions {
   }
 
   /**
-   * Returns this object as an {@link Array} of {@link PermissionResolvable}.
+   * Gets an {@link Array} of permission names (such as VIEW_CHANNEL) based on the ones available.
    * @param {boolean} [checkAdmin=true] Whether to allow the administrator permission to override
    * @returns {PermissionResolvable[]}
    */

--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -24,7 +24,6 @@ class Permissions {
    * @returns {boolean}
    */
   has(permission, checkAdmin = true) {
-    if (permission instanceof Permissions) return this.has(permission.toArray());
     if (permission instanceof Array) return permission.every(p => this.has(p, checkAdmin));
     permission = this.constructor.resolve(permission);
     if (checkAdmin && (this.bitfield & this.constructor.FLAGS.ADMINISTRATOR) > 0) return true;
@@ -117,7 +116,7 @@ class Permissions {
 
   /**
    * Resolves permissions to their numeric form.
-   * @param {PermissionResolvable|PermissionResolvable[]} permission - Permission(s) to resolve
+   * @param {PermissionResolvable|PermissionResolvable[]|Permissions} permission - Permission(s) to resolve
    * @returns {number}
    */
   static resolve(permission) {

--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -42,15 +42,6 @@ class Permissions {
   }
 
   /**
-   * Gets an {@link Array} of permission names (such as `VIEW_CHANNEL`) based on the permissions available.
-   * @param {boolean} [checkAdmin=true] Whether to allow the administrator permission to override
-   * @returns {string[]}
-   */
-  toArray(checkAdmin = true) {
-    return Object.keys(this.constructor.FLAGS).filter(perm => this.has(perm, checkAdmin));
-  }
-
-  /**
    * Freezes these permissions, making them immutable.
    * @returns {Permissions} These permissions
    */
@@ -100,6 +91,15 @@ class Permissions {
     const serialized = {};
     for (const perm in this.constructor.FLAGS) serialized[perm] = this.has(perm, checkAdmin);
     return serialized;
+  }
+
+  /**
+ * Gets an {@link Array} of permission names (such as `VIEW_CHANNEL`) based on the permissions available.
+ * @param {boolean} [checkAdmin=true] Whether to allow the administrator permission to override
+ * @returns {string[]}
+ */
+  toArray(checkAdmin = true) {
+    return Object.keys(this.constructor.FLAGS).filter(perm => this.has(perm, checkAdmin));
   }
 
   /**

--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -14,7 +14,7 @@ class Permissions {
      * Bitfield of the packed permissions
      * @type {number}
      */
-    this.bitfield = typeof permissions === 'number' ? permissions : this.constructor.resolve(permissions);
+    this.bitfield = this.constructor.resolve(permissions);
   }
 
   /**

--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -37,10 +37,8 @@ class Permissions {
    * @returns {string[]}
    */
   missing(permissions, checkAdmin = true) {
-    if (checkAdmin && this.has(this.constructor.FLAGS.ADMINISTRATOR)) return [];
-    permissions = new this.constructor(permissions);
-    const missing = new this.constructor(~this.bitfield & permissions.bitfield);
-    return missing.toArray(false);
+    if (!(permissions instanceof Array)) permissions = new this.constructor(permissions).toArray(false);
+    return permissions.filter(p => !this.has(p, checkAdmin));
   }
 
   /**

--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -40,7 +40,7 @@ class Permissions {
     if (checkAdmin && this.has(this.constructor.FLAGS.ADMINISTRATOR)) return [];
     permissions = new this.constructor(permissions);
     const missing = new this.constructor(~this.bitfield & permissions.bitfield);
-    return missing.toArray(checkAdmin);
+    return missing.toArray(false);
   }
 
   /**


### PR DESCRIPTION
- Added `Permission#toArray`.
- Allow singular `PermissionResolvable`s as parameter to `Permissions#missing`.
- Fix JSDoc.
- Allow `Permissions` to be iterated over.
- Removed unnecessary (and bugged) conditional statement in constructor. (could accept negative bitfields before)
- [Updated typings](https://github.com/ZLima12/discord.js-typings/tree/permissions-improvements) will be submitted as a PR when/if this one gets merged.

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
