### PR TITLE
feature(ClientUser): deprecate ClientUser#setGame in favour of ClientUser#setActivity

### DIFF
--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -200,7 +200,7 @@ class ClientUser extends User {
 
       if (data.game) {
         game = data.game;
-        game.type = game.url && !game.type ? 1 : game.type || 0;
+        game.type = game.url && typeof game.type === 'undefined' ? 1 : game.type || 0;
         if (typeof game.type === 'string') {
           game.type = Constants.ActivityTypes.indexOf(game.type.toUpperCase());
         }

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -165,6 +165,7 @@ class ClientUser extends User {
    * @property {Object} [game] Game the user is playing
    * @property {string} [game.name] Name of the game
    * @property {string} [game.url] Twitch stream URL
+   * @property {?ActivityType|number} [game.type] Type of the activity
    */
 
   /**
@@ -199,7 +200,10 @@ class ClientUser extends User {
 
       if (data.game) {
         game = data.game;
-        game.type = game.url ? 1 : 0;
+        game.type = game.url && !game.type ? 1 : game.type || 0;
+        if (typeof game.type === 'string') {
+          game.type = Constants.ActivityTypes.indexOf(game.type.toUpperCase());
+        }
       } else if (typeof data.game !== 'undefined') {
         game = null;
       }
@@ -242,8 +246,8 @@ class ClientUser extends User {
 
   /**
    * Sets the game the client user is playing.
-   * @param {?string} game Game being played
-   * @param {string} [streamingURL] Twitch stream URL
+   * @param {string} game Game being played
+   * @param {?string} [streamingURL] Twitch stream URL
    * @returns {Promise<ClientUser>}
    */
   setGame(game, streamingURL) {

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -3,6 +3,7 @@ const Collection = require('../util/Collection');
 const ClientUserSettings = require('./ClientUserSettings');
 const ClientUserGuildSettings = require('./ClientUserGuildSettings');
 const Constants = require('../util/Constants');
+const util = require('util');
 
 /**
  * Represents the logged in client's Discord user.
@@ -246,9 +247,10 @@ class ClientUser extends User {
 
   /**
    * Sets the game the client user is playing.
-   * @param {string} game Game being played
+   * @param {?string} game Game being played
    * @param {?string} [streamingURL] Twitch stream URL
    * @returns {Promise<ClientUser>}
+   * @deprecated
    */
   setGame(game, streamingURL) {
     if (!game) return this.setPresence({ game: null });
@@ -257,6 +259,21 @@ class ClientUser extends User {
         name: game,
         url: streamingURL,
       },
+    });
+  }
+
+  /**
+   * Sets the activity the client user is playing.
+   * @param {?string} name Activity being played
+   * @param {Object} [options] Options for setting the activity
+   * @param {string} [options.url] Twitch stream URL
+   * @param {ActivityType|number} [options.type] Type of the activity
+   * @returns {Promise<Presence>}
+   */
+  setActivity(name, { url, type } = {}) {
+    if (!name) return this.setPresence({ activity: null });
+    return this.setPresence({
+      game: { name, type, url },
     });
   }
 
@@ -355,5 +372,8 @@ class ClientUser extends User {
     return this.client.rest.methods.acceptInvite(invite);
   }
 }
+
+ClientUser.prototype.setGame =
+  util.deprecate(ClientUser.prototype.setGame, 'ClientUser#setGame: use ClientUser#setActivity instead');
 
 module.exports = ClientUser;

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -1214,6 +1214,7 @@ class Guild {
  * @name Guild#defaultChannel
  * @type {TextChannel}
  * @readonly
+ * @deprecated
  */
 Object.defineProperty(Guild.prototype, 'defaultChannel', {
   get: util.deprecate(function defaultChannel() {

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -351,6 +351,21 @@ exports.Events = {
 };
 
 /**
+ * The type of an activity of a users presence, e.g. `PLAYING`. Here are the available types:
+ * * PLAYING
+ * * STREAMING
+ * * LISTENING
+ * * WATCHING
+ * @typedef {string} ActivityType
+ */
+exports.ActivityTypes = [
+  'PLAYING',
+  'STREAMING',
+  'LISTENING',
+  'WATCHING',
+];
+
+/**
  * The type of a websocket message event, e.g. `MESSAGE_CREATE`. Here are the available events:
  * * READY
  * * RESUMED


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Enables you to set `watching` and `listening` via either number form or via strings in `ClientUser#setPresence`. This also deprecates `ClientUser#setGame` in favour of `ClientUser#setActivity`

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
