### PR TITLE
Add more options to MessageMentions#has

### DIFF
--- a/src/structures/MessageMentions.js
+++ b/src/structures/MessageMentions.js
@@ -121,18 +121,18 @@ class MessageMentions {
    * Takes into account user mentions, role mentions, and @everyone/@here mentions.
    * @param {UserResolvable|GuildMember|Role|GuildChannel} data User/GuildMember/Role/Channel to check
    * @param {Object} [options] Options
-   * @param {boolean} [options.ignoreSelf=false] - Whether to ignore direct mentions to the item
+   * @param {boolean} [options.ignoreDirect=false] - Whether to ignore direct mentions to the item
    * @param {boolean} [options.ignoreRoles=false] - Whether to ignore role mentions to a guild member
    * @param {boolean} [options.ignoreEveryone=false] - Whether to ignore everyone/here mentions
    * @returns {boolean}
    */
-  has(data, { ignoreSelf = false, ignoreRoles = false, ignoreEveryone = false } = {}) {
+  has(data, { ignoreDirect = false, ignoreRoles = false, ignoreEveryone = false } = {}) {
     if (!ignoreEveryone && this.everyone) return true;
     if (!ignoreRoles && data instanceof GuildMember) {
       for (const role of this.roles.values()) if (data.roles.has(role.id)) return true;
     }
 
-    if (!ignoreSelf) {
+    if (!ignoreDirect) {
       const id = data.id || data;
       return this.users.has(id) || this.channels.has(id) || this.roles.has(id);
     }

--- a/src/structures/MessageMentions.js
+++ b/src/structures/MessageMentions.js
@@ -117,19 +117,27 @@ class MessageMentions {
   }
 
   /**
-   * Check if a user is mentioned.
+   * Checks if a user, guild member, role, or channel is mentioned.
    * Takes into account user mentions, role mentions, and @everyone/@here mentions.
    * @param {UserResolvable|GuildMember|Role|GuildChannel} data User/GuildMember/Role/Channel to check
-   * @param {boolean} [strict=true] If role mentions and everyone/here mentions should be included
+   * @param {Object} [options] Options
+   * @param {boolean} [options.ignoreSelf=false] - Whether to ignore direct mentions to the item
+   * @param {boolean} [options.ignoreRoles=false] - Whether to ignore role mentions to a guild member
+   * @param {boolean} [options.ignoreEveryone=false] - Whether to ignore everyone/here mentions
    * @returns {boolean}
    */
-  has(data, strict = true) {
-    if (strict && this.everyone) return true;
-    if (strict && data instanceof GuildMember) {
+  has(data, { ignoreSelf = false, ignoreRoles = false, ignoreEveryone = false } = {}) {
+    if (!ignoreEveryone && this.everyone) return true;
+    if (!ignoreRoles && data instanceof GuildMember) {
       for (const role of this.roles.values()) if (data.roles.has(role.id)) return true;
     }
-    const id = data.id || data;
-    return this.users.has(id) || this.channels.has(id) || this.roles.has(id);
+
+    if (!ignoreSelf) {
+      const id = data.id || data;
+      return this.users.has(id) || this.channels.has(id) || this.roles.has(id);
+    }
+
+    return false;
   }
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Previous `strict` option ignores both roles and everyone/here.  
New options allow ignoring individual kinds as well as direct mentions.  

**Semantic versioning classification:**  
- [X] This PR changes the library's interface (methods or parameters added)
  - [X] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
