### PR TITLE
Fix channels.resolve

### DIFF
--- a/src/stores/DataStore.js
+++ b/src/stores/DataStore.js
@@ -10,7 +10,7 @@ class DataStore extends Collection {
     super();
     if (!Structures) Structures = require('../util/Structures');
     Object.defineProperty(this, 'client', { value: client });
-    Object.defineProperty(this, 'holds', { value: Structures.get(holds.name) });
+    Object.defineProperty(this, 'holds', { value: Structures.get(holds.name) || holds });
     if (iterable) for (const item of iterable) this.create(item);
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
fixes #2136 as Channel is not an extendable structure, all of the child structures are. Structures.get('Channel') returns undefined.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
