### PR TITLE
fix(guild#createChannel): new channel returning null

### DIFF
--- a/src/client/ClientDataManager.js
+++ b/src/client/ClientDataManager.js
@@ -72,6 +72,7 @@ class ClientDataManager {
     if (channel && !already) {
       if (this.pastReady) this.client.emit(Constants.Events.CHANNEL_CREATE, channel);
       this.client.channels.set(channel.id, channel);
+      return channel;
     } else if (already) {
       return channel;
     }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fix for #2122, didn't return channel, so it sometimes returned null depending on the duplicate events that we get

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
