### PR TITLE
Bug fix : Allowing for undefined bitrate

### DIFF
--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -318,7 +318,7 @@ class RESTMethods {
     data.name = (_data.name || channel.name).trim();
     data.topic = _data.topic || channel.topic;
     data.position = _data.position || channel.position;
-    data.bitrate = _data.bitrate || channel.bitrate;
+    data.bitrate = _data.bitrate || (channel.bitrate ? channel.bitrate * 1000 : undefined);
     data.user_limit = _data.userLimit || channel.userLimit;
     data.parent_id = _data.parent || (channel.parent ? channel.parent.id : undefined);
     return this.rest.makeRequest('patch', Endpoints.Channel(channel), true, data, undefined, reason).then(newData =>


### PR DESCRIPTION
If you did not define a bitrate, the API would throw an error as the bitrate is too small.

This is because the bitrate number is reduced in magnitude by 3 by the VoiceChannel class. But is never increased before accessing endpoint.


**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
