### PR TITLE
rewrite erlpack detection to avoid using var

### DIFF
--- a/src/WebSocket.js
+++ b/src/WebSocket.js
@@ -1,7 +1,8 @@
 const { browser } = require('./util/Constants');
 const querystring = require('querystring');
+let erlpack;
 try {
-  var erlpack = require('erlpack');
+  erlpack = require('erlpack');
   if (!erlpack.pack) erlpack = null;
 } catch (err) {} // eslint-disable-line no-empty
 


### PR DESCRIPTION
This PR rewrites the erlpack detection part of WebSocket.js to avoid using the deprecated `var` keyword in favour of `let`


**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
