### PR TITLE
fix(UserGuildSettingsUpdate): not creating settings with new guilds

### DIFF
--- a/src/client/websocket/packets/handlers/UserGuildSettingsUpdate.js
+++ b/src/client/websocket/packets/handlers/UserGuildSettingsUpdate.js
@@ -1,10 +1,13 @@
 const AbstractHandler = require('./AbstractHandler');
 const Constants = require('../../../../util/Constants');
+const ClientUserGuildSettings = require('../../../../structures/ClientUserGuildSettings');
 
 class UserGuildSettingsUpdateHandler extends AbstractHandler {
   handle(packet) {
     const client = this.packetManager.client;
-    client.user.guildSettings.get(packet.d.guild_id).patch(packet.d);
+    const settings = client.user.guildSettings.get(packet.d.guild_id);
+    if (settings) settings.patch(packet.d);
+    else client.user.guildSettings.set(packet.d.guild_id, new ClientUserGuildSettings(packet.d, client));
     client.emit(Constants.Events.USER_GUILD_SETTINGS_UPDATE, client.user.guildSettings.get(packet.d.guild_id));
   }
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixes #2139 and #2140 (same thing), where the guild settings were not being properly instantiated if you recently joined a guild after the user bot was running and then tried to do some user setting stuff.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
