### PR TITLE
Make all VoiceChannel bitrates in bps

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -292,7 +292,7 @@ class GuildChannel extends Channel {
         name: (data.name || this.name).trim(),
         topic: data.topic,
         nsfw: data.nsfw,
-        bitrate: data.bitrate || (this.bitrate ? this.bitrate * 1000 : undefined),
+        bitrate: data.bitrate || this.bitrate,
         user_limit: typeof data.userLimit !== 'undefined' ? data.userLimit : this.userLimit,
         parent_id: data.parentID,
         lock_permissions: data.lockPermissions,

--- a/src/structures/VoiceChannel.js
+++ b/src/structures/VoiceChannel.js
@@ -25,7 +25,7 @@ class VoiceChannel extends GuildChannel {
      * The bitrate of this voice channel
      * @type {number}
      */
-    this.bitrate = data.bitrate * 0.001;
+    this.bitrate = data.bitrate;
 
     /**
      * The maximum amount of users allowed in this channel - 0 means unlimited.
@@ -76,18 +76,17 @@ class VoiceChannel extends GuildChannel {
   }
 
   /**
-   * Sets the bitrate of the channel (in kbps).
+   * Sets the bitrate of the channel.
    * @param {number} bitrate The new bitrate
    * @param {string} [reason] Reason for changing the channel's bitrate
    * @returns {Promise<VoiceChannel>}
    * @example
    * // Set the bitrate of a voice channel
-   * voiceChannel.setBitrate(48)
-   *   .then(vc => console.log(`Set bitrate to ${vc.bitrate}kbps for ${vc.name}`))
+   * voiceChannel.setBitrate(48000)
+   *   .then(vc => console.log(`Set bitrate to ${vc.bitrate}bps for ${vc.name}`))
    *   .catch(console.error);
    */
   setBitrate(bitrate, reason) {
-    bitrate *= 1000;
     return this.edit({ bitrate }, reason);
   }
 


### PR DESCRIPTION
instead of mixed kbps/bps

**Please describe the changes this PR makes and why it should be merged:**
Makes the methods consistently use bps for bitrates.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
