### PR TITLE
fix(Guild#createChannel): default to text

### DIFF
--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -279,7 +279,7 @@ class RESTMethods {
     }
     return this.rest.makeRequest('post', Endpoints.Guild(guild).channels, true, {
       name: channelName,
-      type: Constants.ChannelTypes[channelType.toUpperCase()],
+      type: channelType ? Constants.ChannelTypes[channelType.toUpperCase()] : 'text',
       permission_overwrites: overwrites,
     }, undefined, reason).then(data => this.client.actions.ChannelCreate.handle(data).channel);
   }

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -884,10 +884,10 @@ class Guild {
   /**
    * Creates a new channel in the guild.
    * @param {string} name The name of the new channel
-   * @param {string} type The type of the new channel, either `text` or `voice` or `category`
+   * @param {string} [type='text'] The type of the new channel, either `text` or `voice` or `category`
    * @param {Array<PermissionOverwrites|ChannelCreationOverwrites>} [overwrites] Permission overwrites
    * @param {string} [reason] Reason for creating this channel
-   * @returns {Promise<TextChannel|VoiceChannel>}
+   * @returns {Promise<CategoryChannel|TextChannel|VoiceChannel>}
    * @example
    * // Create a new text channel
    * guild.createChannel('new-general', 'text')


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Re-adds the functionality from stable where not providing a channel type would default to `text`. Ironically, this is also incorrectly documented in stable. Also updated return type since we can also make categories with this method.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
