### PR TITLE
fix(CreateMessage): reassigning wrong content

### DIFF
--- a/src/structures/shared/CreateMessage.js
+++ b/src/structures/shared/CreateMessage.js
@@ -39,7 +39,7 @@ module.exports = async function createMessage(channel, options) {
     const id = channel.client.users.resolveID(options.reply);
     const mention = `<@${options.reply instanceof GuildMember && options.reply.nickname ? '!' : ''}${id}>`;
     if (options.split) options.split.prepend = `${mention}, ${options.split.prepend || ''}`;
-    options.content = `${mention}${typeof options.content !== 'undefined' ? `, ${options.content}` : ''}`;
+    content = `${mention}${typeof options.content !== 'undefined' ? `, ${options.content}` : ''}`;
   }
 
   if (content) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fix for #2158, which broke `message.reply()` (it didn't mention anymore), so now it does again. Hurrah.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
