### PR TITLE
fix(bulkDelete): stop rejections when filterOld=true

### DIFF
--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -398,17 +398,7 @@ class TextBasedChannel {
       }
       if (messageIDs.length === 0) return new Collection();
       if (messageIDs.length === 1) {
-        return this.fetchMessage(messageIDs[0]).then(m => {
-          this.client.rest.methods.deleteMessage(m)
-            .then(() => {
-              const { message } = this.client.actions.MessageDelete.handle({
-                channel_id: this.id,
-                id: m.id,
-              });
-              if (message) return new Collection([[message.id, message]]);
-              return new Collection();
-            });
-        });
+        return this.fetchMessage(messageIDs[0]).then(msg => msg.delete().then(() => new Collection([[msg.id, msg]])));
       }
       return this.client.rest.methods.bulkDeleteMessages(this, messageIDs, filterOld);
     }

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -4,6 +4,7 @@ const MessageCollector = require('../MessageCollector');
 const Collection = require('../../util/Collection');
 const Attachment = require('../../structures/Attachment');
 const RichEmbed = require('../../structures/RichEmbed');
+const Snowflake = require('../../util/Snowflake');
 const util = require('util');
 
 /**
@@ -390,11 +391,28 @@ class TextBasedChannel {
    * @returns {Promise<Collection<Snowflake, Message>>} Deleted messages
    */
   bulkDelete(messages, filterOld = false) {
-    if (!isNaN(messages)) return this.fetchMessages({ limit: messages }).then(msgs => this.bulkDelete(msgs, filterOld));
     if (messages instanceof Array || messages instanceof Collection) {
-      const messageIDs = messages instanceof Collection ? messages.keyArray() : messages.map(m => m.id);
+      let messageIDs = messages instanceof Collection ? messages.keyArray() : messages.map(m => m.id);
+      if (filterOld) {
+        messageIDs = messageIDs.filter(id => Date.now() - Snowflake.deconstruct(id).date.getTime() < 1209600000);
+      }
+      if (messageIDs.length === 0) return new Collection();
+      if (messageIDs.length === 1) {
+        return this.fetchMessage(messageIDs[0]).then(m => {
+          this.client.rest.methods.deleteMessage(m)
+            .then(() => {
+              const { message } = this.client.actions.MessageDelete.handle({
+                channel_id: this.id,
+                id: m.id,
+              });
+              if (message) return new Collection([[message.id, message]]);
+              return new Collection();
+            });
+        });
+      }
       return this.client.rest.methods.bulkDeleteMessages(this, messageIDs, filterOld);
     }
+    if (!isNaN(messages)) return this.fetchMessages({ limit: messages }).then(msgs => this.bulkDelete(msgs, filterOld));
     throw new TypeError('The messages must be an Array, Collection, or number.');
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Self-explanatory title. `BulkDelete` would attempt to mass delete 1 or 0 messages and reject regardless of ignoring old, so now it does (not reject).

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
