### PR TITLE
fix(Guild#createChannel): default type to 'text'

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -910,8 +910,8 @@ class Guild extends Base {
   /**
    * Creates a new channel in the guild.
    * @param {string} name The name of the new channel
-   * @param {string} [type='text'] The type of the new channel, either `text`, `voice`, or `category`
    * @param {Object} [options] Options
+   * @param {string} [options.type='text'] The type of the new channel, either `text`, `voice`, or `category`
    * @param {boolean} [options.nsfw] Whether the new channel is nsfw
    * @param {number} [options.bitrate] Bitrate of the new channel in bits (only voice)
    * @param {number} [options.userLimit] Maximum amount of users allowed in the new channel (only voice)
@@ -925,7 +925,7 @@ class Guild extends Base {
    *   .then(channel => console.log(`Created new channel ${channel}`))
    *   .catch(console.error);
    */
-  createChannel(name, type, { nsfw, bitrate, userLimit, parent, overwrites, reason } = {}) {
+  createChannel(name, { type, nsfw, bitrate, userLimit, parent, overwrites, reason } = {}) {
     if (overwrites instanceof Collection || overwrites instanceof Array) {
       overwrites = overwrites.map(overwrite => {
         let allow = overwrite.allow || (overwrite.allowed ? overwrite.allowed.bitfield : 0);

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -910,7 +910,7 @@ class Guild extends Base {
   /**
    * Creates a new channel in the guild.
    * @param {string} name The name of the new channel
-   * @param {string} type The type of the new channel, either `text`, `voice`, or `category`
+   * @param {string} [type='text'] The type of the new channel, either `text`, `voice`, or `category`
    * @param {Object} [options] Options
    * @param {boolean} [options.nsfw] Whether the new channel is nsfw
    * @param {number} [options.bitrate] Bitrate of the new channel in bits (only voice)
@@ -955,7 +955,7 @@ class Guild extends Base {
     return this.client.api.guilds(this.id).channels.post({
       data: {
         name,
-        type: ChannelTypes[type.toUpperCase()],
+        type: type ? ChannelTypes[type.toUpperCase()] : 'text',
         nsfw,
         bitrate,
         user_limit: userLimit,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Self-explanatory title. Keeps this behavior from stable to default to type 'text'.

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
