### PR TITLE
Fix Collector bug where checkEnd is only called on a valid message

### DIFF
--- a/src/structures/interfaces/Collector.js
+++ b/src/structures/interfaces/Collector.js
@@ -76,17 +76,18 @@ class Collector extends EventEmitter {
    */
   handleCollect(...args) {
     const collect = this.collect(...args);
-    if (!collect || !this.filter(...args, this.collected)) return;
 
-    this.collected.set(collect.key, collect.value);
+    if (collect && this.filter(...args, this.collected)) {
+      this.collected.set(collect.key, collect.value);
 
-    /**
-     * Emitted whenever an element is collected.
-     * @event Collector#collect
-     * @param {*} element The element that got collected
-     * @param {...*} args The arguments emitted by the listener
-     */
-    this.emit('collect', collect.value, ...args);
+      /**
+       * Emitted whenever an element is collected.
+       * @event Collector#collect
+       * @param {*} element The element that got collected
+       * @param {...*} args The arguments emitted by the listener
+       */
+      this.emit('collect', collect.value, ...args);
+    }
     this.checkEnd();
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

checkEnd should be called whether or not a message passes the filter because the number of message processed is also updated by collect.  For instance, currently messageCollector keeps running even if it has reached the limit of processed messages if none of them passes the filter.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
