### PR TITLE
allow functions in shard eval yay

### DIFF
--- a/src/sharding/Shard.js
+++ b/src/sharding/Shard.js
@@ -174,8 +174,8 @@ class Shard extends EventEmitter {
   }
 
   /**
-   * Evaluates a script on the shard, in the context of the {@link Client}.
-   * @param {string} script JavaScript to run on the shard
+   * Evaluates a script or function on the shard, in the context of the {@link Client}.
+   * @param {string|Function} script JavaScript to run on the shard
    * @returns {Promise<*>} Result of the script execution
    */
   eval(script) {
@@ -190,7 +190,8 @@ class Shard extends EventEmitter {
       };
       this.process.on('message', listener);
 
-      this.send({ _eval: script }).catch(err => {
+      const _eval = typeof script === 'function' ? `(${script})(this)` : script;
+      this.send({ _eval }).catch(err => {
         this.process.removeListener('message', listener);
         this._evals.delete(script);
         reject(err);

--- a/src/sharding/ShardClientUtil.js
+++ b/src/sharding/ShardClientUtil.js
@@ -86,6 +86,7 @@ class ShardClientUtil {
    */
   broadcastEval(script) {
     return new Promise((resolve, reject) => {
+      script = typeof script !== 'function' ? `(${script})(this)` : script;
       const listener = message => {
         if (!message || message._sEval !== script) return;
         process.removeListener('message', listener);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`eval((client) => client.token)` > `eval('this.token')`

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
