### PR TITLE
Migrate from snekfetch to phin

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
   "runkitExampleFilename": "./docs/examples/ping.js",
   "dependencies": {
     "pako": "^1.0.0",
+    "phin": "^2.7.0",
     "prism-media": "^0.0.2",
-    "snekfetch": "^3.5.0",
     "tweetnacl": "^1.0.0",
     "ws": "^3.3.1"
   },

--- a/src/rest/APIRequest.js
+++ b/src/rest/APIRequest.js
@@ -24,27 +24,27 @@ class APIRequest {
       this.path += `?${queryString}`;
     }
 
-    let requestHeaders = {}
+    let requestHeaders = {};
 
-    if (this.options.auth !== false) requestHeaders['Authorization'] = this.rest.getAuth();
+    if (this.options.auth !== false) requestHeaders.Authorization = this.rest.getAuth();
     if (this.options.reason) requestHeaders['X-Audit-Log-Reason'] = encodeURIComponent(this.options.reason);
     if (!browser) requestHeaders['User-Agent'] = UserAgent;
-    if (this.options.headers) Object.assign(requestHeaders, this.options.headers)
+    if (this.options.headers) Object.assign(requestHeaders, this.options.headers);
 
-    let formData = null
+    let formData = null;
 
     if (this.options.files) {
-      for (const file of this.options.files) formData[file.name] = file.file
+      for (const file of this.options.files) formData[file.name] = file.file;
 
-      if (this.options.data !== 'undefined') formData['payload_json'] = JSON.stringify(this.options.data)
+      if (this.options.data !== 'undefined') formData.payload_json = JSON.stringify(this.options.data);
     }
 
     const request = phin(Object.assign({
       url: `${API}${this.path}`,
       method: this.method,
       agent,
-      headers: requestHeaders
-    }, (this.options.files ? {form: formData} : (this.options.data !== 'undefined' ? {data: this.options.data} : {}))));
+      headers: requestHeaders,
+    }, this.options.files ? { form: formData } : this.options.data !== 'undefined' ? { data: this.options.data } : {}));
     return request;
   }
 }

--- a/src/rest/APIRequest.js
+++ b/src/rest/APIRequest.js
@@ -1,5 +1,5 @@
 const querystring = require('querystring');
-const snekfetch = require('snekfetch');
+const phin = require('phin').promisified;
 const https = require('https');
 const { browser, UserAgent } = require('../util/Constants');
 
@@ -24,19 +24,27 @@ class APIRequest {
       this.path += `?${queryString}`;
     }
 
-    const request = snekfetch[this.method](`${API}${this.path}`, { agent });
+    let requestHeaders = {}
 
-    if (this.options.auth !== false) request.set('Authorization', this.rest.getAuth());
-    if (this.options.reason) request.set('X-Audit-Log-Reason', encodeURIComponent(this.options.reason));
-    if (!browser) request.set('User-Agent', UserAgent);
-    if (this.options.headers) request.set(this.options.headers);
+    if (this.options.auth !== false) requestHeaders['Authorization'] = this.rest.getAuth();
+    if (this.options.reason) requestHeaders['X-Audit-Log-Reason'] = encodeURIComponent(this.options.reason);
+    if (!browser) requestHeaders['User-Agent'] = UserAgent;
+    if (this.options.headers) Object.assign(requestHeaders, this.options.headers)
+
+    let formData = null
 
     if (this.options.files) {
-      for (const file of this.options.files) if (file && file.file) request.attach(file.name, file.file, file.name);
-      if (typeof this.options.data !== 'undefined') request.attach('payload_json', JSON.stringify(this.options.data));
-    } else if (typeof this.options.data !== 'undefined') {
-      request.send(this.options.data);
+      for (const file of this.options.files) formData[file.name] = file.file
+
+      if (this.options.data !== 'undefined') formData['payload_json'] = JSON.stringify(this.options.data)
     }
+
+    const request = phin(Object.assign({
+      url: `${API}${this.path}`,
+      method: this.method,
+      agent,
+      headers: requestHeaders
+    }, (this.options.files ? {form: formData} : (this.options.data !== 'undefined' ? {data: this.options.data} : {}))));
     return request;
   }
 }

--- a/src/util/DataResolver.js
+++ b/src/util/DataResolver.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const fs = require('fs');
-const snekfetch = require('snekfetch');
+const phin = require('phin').promisified;
 const Util = require('../util/Util');
 const { Error, TypeError } = require('../errors');
 const { browser } = require('../util/Constants');
@@ -89,8 +89,8 @@ class DataResolver {
     if (typeof resource === 'string') {
       return new Promise((resolve, reject) => {
         if (/^https?:\/\//.test(resource)) {
-          snekfetch.get(resource)
-            .end((err, res) => {
+          phin(resource)
+            .then((err, res) => {
               if (err) return reject(err);
               if (!(res.body instanceof Buffer)) return reject(new TypeError('REQ_BODY_TYPE'));
               return resolve(res.body);

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -1,4 +1,4 @@
-const snekfetch = require('snekfetch');
+const phin = require('phin').promisified;
 const { Colors, DefaultOptions, Endpoints } = require('./Constants');
 const { Error: DiscordError, RangeError, TypeError } = require('../errors');
 const has = (o, k) => Object.prototype.hasOwnProperty.call(o, k);
@@ -57,9 +57,13 @@ class Util {
   static fetchRecommendedShards(token, guildsPerShard = 1000) {
     return new Promise((resolve, reject) => {
       if (!token) throw new DiscordError('TOKEN_MISSING');
-      snekfetch.get(`${DefaultOptions.http.api}/v${DefaultOptions.http.version}${Endpoints.botGateway}`)
-        .set('Authorization', `Bot ${token.replace(/^Bot\s*/i, '')}`)
-        .end((err, res) => {
+      phin({
+        url: `${DefaultOptions.http.api}/v${DefaultOptions.http.version}${Endpoints.botGateway}`,
+        headers: {
+          Authorization: `Bot ${token.replace(/^Bot\s*/i, '')}`
+        }
+      })
+        .then((err, res) => {
           if (err) reject(err);
           resolve(res.body.shards * (1000 / guildsPerShard));
         });

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -60,8 +60,8 @@ class Util {
       phin({
         url: `${DefaultOptions.http.api}/v${DefaultOptions.http.version}${Endpoints.botGateway}`,
         headers: {
-          Authorization: `Bot ${token.replace(/^Bot\s*/i, '')}`
-        }
+          Authorization: `Bot ${token.replace(/^Bot\s*/i, '')}`,
+        },
       })
         .then((err, res) => {
           if (err) reject(err);

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -62,6 +62,7 @@ class Util {
         headers: {
           Authorization: `Bot ${token.replace(/^Bot\s*/i, '')}`,
         },
+        parse: 'json',
       })
         .then((err, res) => {
           if (err) reject(err);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,7 +46,6 @@ const createConfig = options => {
             },
           },
         },
-        ...require('snekfetch/webpack.supplemental').rules,
       ],
     },
     node: {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR proposes switching from the snekfetch HTTP client library to the phin library. The purpose of this change is to reduce weight of the overall discord.js library. phin is **90% smaller** than the snekfetch library. (10KB vs 107KB)

This PR improves discord.js install time significantly by reducing dependency tree size.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
