### PR TITLE
Don't send files in edit request

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -377,10 +377,10 @@ class Message extends Base {
     }
     if (!options.content) options.content = content;
 
-    const { data, files } = await createMessage(this, options);
+    const { data } = await createMessage(this, options);
 
     return this.client.api.channels[this.channel.id].messages[this.id]
-      .patch({ data, files })
+      .patch({ data })
       .then(d => {
         const clone = this._clone();
         clone._patch(d);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
It is not possible to edit a messages attachments in Discord after a message has been sent, discord.js however, does provide such functionality! (or at least tries to)

The docs for Message#edit say you can pass it a MessageEmbed, however if that embed contains attachments it breaks. Files should not be sent along with the `edit` request.

**Steps to reproduce:**
```js
    const embed = new MessageEmbed()
      .setTitle('foo')
      .setDescription('bar')
      .attachFiles(['src/assets/icons/play.png'])
      .setThumbnail('attachment://play.png')

    const m = await msg.channel.send(embed)

    embed.setDescription('baz')
    setTimeout(() => m.edit(embed), 1e3)
```
**Result:**
```
[00:31:37 DiscordAPIError] Invalid Form Body; CONTENT_TYPE_INVALID: Expected "Content-Type" header to be one of set(['application/json']).
    at item.request.gen.end (/Users/TeeSeal/Code/Discord/Haku/node_modules/discord.js/src/rest/handlers/RequestHandler.js:79:65)
    at then (/Users/TeeSeal/Code/Discord/Haku/node_modules/snekfetch/src/index.js:218:21)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:160:7)
```
And no edit.

I didn't bother to dig deeper into the implementation to figure out why that header wasn't being set since removing the files seems to have fixed the issue.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
- [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed) (I guess?)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
