### PR TITLE
fix: GIF avatars with size loose their animated property

### DIFF
--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -104,7 +104,7 @@ const AllowedImageSizes = Array.from({ length: 8 }, (e, i) => 2 ** (i + 4));
 function makeImageUrl(root, { format = 'webp', size } = {}) {
   if (format && !AllowedImageFormats.includes(format)) throw new Error('IMAGE_FORMAT', format);
   if (size && !AllowedImageSizes.includes(size)) throw new RangeError('IMAGE_SIZE', size);
-  return `${root}.${format}${size ? `?size=${size}` : ''}`;
+  return `${root}.${format}${format === 'gif' ? '' : size ? `?size=${size}` : ''}`;
 }
 
 exports.Endpoints = {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR makes it to where the size param won't affect the avatar if it's a GIF. The size doesn't afect the image anyways, it just makes it not animate

Note: This is NOT a dupe of #2195, as this is pointed at `master`, while that is pointed at `11.3-dev`

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
