### PR TITLE
Fix query string on requests after ratelimited

### DIFF
--- a/src/rest/APIRequest.js
+++ b/src/rest/APIRequest.js
@@ -10,9 +10,11 @@ class APIRequest {
     this.rest = rest;
     this.client = rest.client;
     this.method = method;
-    this.path = `${path}${querystring.stringify(this.options.query)}`;
     this.route = options.route;
     this.options = options;
+
+    const queryString = querystring.stringify(options.query);
+    this.path = `${path}${queryString ? `?${queryString}` : ''}`;
   }
 
   gen() {

--- a/src/rest/APIRequest.js
+++ b/src/rest/APIRequest.js
@@ -13,7 +13,7 @@ class APIRequest {
     this.route = options.route;
     this.options = options;
 
-    const queryString = querystring.stringify(options.query);
+    const queryString = (querystring.stringify(options.query).match(/[^=&?]+=[^=&?]+/g) || []).join('&');
     this.path = `${path}${queryString ? `?${queryString}` : ''}`;
   }
 

--- a/src/rest/APIRequest.js
+++ b/src/rest/APIRequest.js
@@ -13,15 +13,17 @@ class APIRequest {
     this.path = path.toString();
     this.route = options.route;
     this.options = options;
+    this.builtQueryString = false;
   }
 
   gen() {
     const API = this.options.versioned === false ? this.client.options.http.api :
       `${this.client.options.http.api}/v${this.client.options.http.version}`;
 
-    if (this.options.query) {
-      const queryString = (querystring.stringify(this.options.query).match(/[^=&?]+=[^=&?]+/g) || []).join('&');
+    if (this.options.query && !this.builtQueryString) {
+      const queryString = querystring.stringify(this.options.query);
       this.path += `?${queryString}`;
+      this.builtQueryString = true;
     }
 
     const request = snekfetch[this.method](`${API}${this.path}`, { agent });

--- a/src/rest/APIRequest.js
+++ b/src/rest/APIRequest.js
@@ -10,21 +10,14 @@ class APIRequest {
     this.rest = rest;
     this.client = rest.client;
     this.method = method;
-    this.path = path.toString();
+    this.path = `${path}${querystring.stringify(this.options.query)}`;
     this.route = options.route;
     this.options = options;
-    this.builtQueryString = false;
   }
 
   gen() {
     const API = this.options.versioned === false ? this.client.options.http.api :
       `${this.client.options.http.api}/v${this.client.options.http.version}`;
-
-    if (this.options.query && !this.builtQueryString) {
-      const queryString = querystring.stringify(this.options.query);
-      this.path += `?${queryString}`;
-      this.builtQueryString = true;
-    }
 
     const request = snekfetch[this.method](`${API}${this.path}`, { agent });
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Whenever gen() is called more than once (i.e. retrying after ratelimited) the query string is appended on extra times which breaks things.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
