### PR TITLE
feat: backport after and before parameter when fetching a reaction's users

### DIFF
--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -914,8 +914,10 @@ class RESTMethods {
       .then(() => message);
   }
 
-  getMessageReactionUsers(message, emoji, limit = 100) {
-    return this.rest.makeRequest('get', Endpoints.Message(message).Reaction(emoji, limit), true);
+  getMessageReactionUsers(message, emoji, options) {
+    const queryString = (querystring.stringify(options).match(/[^=&?]+=[^=&?]+/g) || []).join('&');
+
+    return this.rest.makeRequest('get', `${Endpoints.Message(message).Reaction(emoji)}?${queryString}`, true);
   }
 
   getApplication(id) {

--- a/src/structures/MessageReaction.js
+++ b/src/structures/MessageReaction.js
@@ -72,19 +72,20 @@ class MessageReaction {
   /**
    * Fetch all the users that gave this reaction. Resolves with a collection of users, mapped by their IDs.
    * @param {number} [limit=100] The maximum amount of users to fetch, defaults to 100
+   * @param {Object} [options] Options to fetch users
+   * @param {Snowflake} [options.before] Limit fetching users to those with an id lower than the supplied id
+   * @param {Snowflake} [options.after] Limit fetching users to those with an id greater than the supplied id
    * @returns {Promise<Collection<Snowflake, User>>}
    */
-  fetchUsers(limit = 100) {
+  fetchUsers(limit = 100, { after, before } = {}) {
     const message = this.message;
     return message.client.rest.methods.getMessageReactionUsers(
-      message, this.emoji.identifier, limit
+      message, this.emoji.identifier, { after, before, limit }
     ).then(users => {
-      this.users = new Collection();
       for (const rawUser of users) {
         const user = this.message.client.dataManager.newUser(rawUser);
         this.users.set(user.id, user);
       }
-      this.count = this.users.size;
       return this.users;
     });
   }

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -187,8 +187,8 @@ const Endpoints = exports.Endpoints = {
           toString: () => mbase,
           reactions: `${mbase}/reactions`,
           ack: `${mbase}/ack`,
-          Reaction: (emoji, limit) => {
-            const rbase = `${mbase}/reactions/${emoji}${limit ? `?limit=${limit}` : ''}`;
+          Reaction: emoji => {
+            const rbase = `${mbase}/reactions/${emoji}`;
             return {
               toString: () => rbase,
               User: userID => `${rbase}/${userID}`,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Commits:
- https://github.com/hydrabolt/discord.js/commit/f40a5e9f8875299aa6ec25a0491e4dc92868f54d
- https://github.com/hydrabolt/discord.js/commit/5cd42695aeb974e998d4b220cba1c27b30a55628

Summary:
- `MessageReaction#fetchUsers` now accepts as second argument an object with the optional keys `after` and `before` to allow fetching of more than the first 100 users.
- Internally moved its querystring building from Constants to RestMethods in favour, it's only used from that method anyway.

This resolves #2214 for 11.3; In master it's already possible to do so.

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
