### PR TITLE
Fix ReactionCollector#remove and make Collector interface more consistent

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,10 +1,7 @@
 {
   "extends": "eslint:recommended",
   "parserOptions": {
-    "ecmaVersion": 2017,
-    "ecmaFeatures": {
-      "experimentalObjectRestSpread": true
-    }
+    "ecmaVersion": 2017
   },
   "env": {
     "es6": true,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,10 @@
 {
   "extends": "eslint:recommended",
   "parserOptions": {
-    "ecmaVersion": 2017
+    "ecmaVersion": 2017,
+    "ecmaFeatures": {
+      "experimentalObjectRestSpread": true
+    }
   },
   "env": {
     "es6": true,

--- a/src/structures/MessageCollector.js
+++ b/src/structures/MessageCollector.js
@@ -51,7 +51,7 @@ class MessageCollector extends Collector {
   /**
    * Handles a message for possible collection.
    * @param {Message} message The message that could be collected
-   * @returns {?{key: Snowflake, value: Message}}
+   * @returns {?Snowflake}
    * @private
    */
   collect(message) {
@@ -67,8 +67,8 @@ class MessageCollector extends Collector {
 
   /**
    * Handles a message for possible disposal.
-   * @param {Message} message The message that could be disposed
-   * @returns {?string}
+   * @param {Message} message The message that could be disposed of
+   * @returns {?Snowflake}
    */
   dispose(message) {
     /**

--- a/src/structures/MessageCollector.js
+++ b/src/structures/MessageCollector.js
@@ -57,10 +57,7 @@ class MessageCollector extends Collector {
   collect(message) {
     if (message.channel.id !== this.channel.id) return null;
     this.received++;
-    return {
-      key: message.id,
-      value: message,
-    };
+    return message.id;
   }
 
   /**

--- a/src/structures/MessageCollector.js
+++ b/src/structures/MessageCollector.js
@@ -55,6 +55,11 @@ class MessageCollector extends Collector {
    * @private
    */
   collect(message) {
+    /**
+     * Emitted whenever a message is collected.
+     * @event MessageCollector#collect
+     * @param {Message} message The message that was collected
+     */
     if (message.channel.id !== this.channel.id) return null;
     this.received++;
     return message.id;
@@ -66,6 +71,11 @@ class MessageCollector extends Collector {
    * @returns {?string}
    */
   dispose(message) {
+    /**
+     * Emitted whenever a message is disposed of.
+     * @event MessageCollector#dispose
+     * @param {Message} message The message that was disposed of
+     */
     return message.channel.id === this.channel.id ? message.id : null;
   }
 

--- a/src/structures/ReactionCollector.js
+++ b/src/structures/ReactionCollector.js
@@ -20,7 +20,8 @@ class ReactionCollector extends Collector {
    * @param {ReactionCollectorOptions} [options={}] The options to apply to this collector
    */
   constructor(message, filter, options = {}) {
-    super(message.client, filter, { ...options, emitOnlyArgs: true });
+    options.emitOnlyArgs = true;
+    super(message.client, filter, options);
 
     /**
      * The message upon which to collect reactions

--- a/src/structures/ReactionCollector.js
+++ b/src/structures/ReactionCollector.js
@@ -66,7 +66,7 @@ class ReactionCollector extends Collector {
   /**
    * Handles an incoming reaction for possible collection.
    * @param {MessageReaction} reaction The reaction to possibly collect
-   * @returns {?Snowflake}
+   * @returns {?Snowflake|string}
    * @private
    */
   collect(reaction) {

--- a/src/structures/ReactionCollector.js
+++ b/src/structures/ReactionCollector.js
@@ -66,7 +66,7 @@ class ReactionCollector extends Collector {
   /**
    * Handles an incoming reaction for possible collection.
    * @param {MessageReaction} reaction The reaction to possibly collect
-   * @returns {?{key: Snowflake, value: MessageReaction}}
+   * @returns {?Snowflake}
    * @private
    */
   collect(reaction) {
@@ -82,7 +82,7 @@ class ReactionCollector extends Collector {
 
   /**
    * Handles a reaction deletion for possible disposal.
-   * @param {MessageReaction} reaction The reaction to possibly dispose
+   * @param {MessageReaction} reaction The reaction to possibly dispose of
    * @param {User} user The user that removed the reaction
    * @returns {?Snowflake|string}
    */

--- a/src/structures/ReactionCollector.js
+++ b/src/structures/ReactionCollector.js
@@ -20,7 +20,6 @@ class ReactionCollector extends Collector {
    * @param {ReactionCollectorOptions} [options={}] The options to apply to this collector
    */
   constructor(message, filter, options = {}) {
-    options.emitOnlyArgs = true;
     super(message.client, filter, options);
 
     /**
@@ -58,7 +57,7 @@ class ReactionCollector extends Collector {
       this.users.set(user.id, user);
     });
 
-    this.on('dispose', (reaction, user) => {
+    this.on('remove', (reaction, user) => {
       this.total--;
       if (!this.collected.some(r => r.users.has(user.id))) this.users.delete(user.id);
     });
@@ -72,10 +71,7 @@ class ReactionCollector extends Collector {
    */
   collect(reaction) {
     if (reaction.message.id !== this.message.id) return null;
-    return {
-      key: ReactionCollector.key(reaction),
-      value: reaction,
-    };
+    return ReactionCollector.key(reaction);
   }
 
   /**

--- a/src/structures/ReactionCollector.js
+++ b/src/structures/ReactionCollector.js
@@ -70,6 +70,12 @@ class ReactionCollector extends Collector {
    * @private
    */
   collect(reaction) {
+    /**
+     * Emitted whenever a reaction is collected.
+     * @event ReactionCollector#collect
+     * @param {MessageReaction} reaction The reaction that was collected
+     * @param {User} user The user that added the reaction
+     */
     if (reaction.message.id !== this.message.id) return null;
     return ReactionCollector.key(reaction);
   }
@@ -81,6 +87,12 @@ class ReactionCollector extends Collector {
    * @returns {?Snowflake|string}
    */
   dispose(reaction, user) {
+    /**
+     * Emitted whenever a reaction is disposed of.
+     * @event ReactionCollector#dispose
+     * @param {MessageReaction} reaction The reaction that was disposed of
+     * @param {User} user The user that removed the reaction
+     */
     if (reaction.message.id !== this.message.id) return null;
 
     /**

--- a/src/structures/interfaces/Collector.js
+++ b/src/structures/interfaces/Collector.js
@@ -14,7 +14,6 @@ const EventEmitter = require('events');
  * @typedef {Object} CollectorOptions
  * @property {number} [time] How long to run the collector for
  * @property {boolean} [dispose=false] Whether to dispose data when it's deleted
- * @property {boolean} [emitOnlyArgs=false] Used in case the processed element
  * is equal to the first argument emitted by the listener.
  */
 
@@ -80,7 +79,7 @@ class Collector extends EventEmitter {
     const collect = this.collect(...args);
 
     if (collect && this.filter(...args, this.collected)) {
-      this.collected.set(collect.key, collect.value);
+      this.collected.set(collect, args[0]);
 
       /**
        * Emitted whenever an element is collected.
@@ -88,7 +87,6 @@ class Collector extends EventEmitter {
        * @param {*} element The element that got collected
        * @param {...*} args Other arguments emitted by the listener
        */
-      if (!this.options.emitOnlyArgs) args.unshift(collect.value);
       this.emit('collect', ...args);
     }
     this.checkEnd();
@@ -104,8 +102,6 @@ class Collector extends EventEmitter {
 
     const dispose = this.dispose(...args);
     if (!dispose || !this.filter(...args) || !this.collected.has(dispose)) return;
-
-    const value = this.collected.get(dispose);
     this.collected.delete(dispose);
 
     /**
@@ -114,7 +110,6 @@ class Collector extends EventEmitter {
      * @param {*} element The element that was disposed
      * @param {...*} args Other arguments emitted by the listener
      */
-    if (!this.options.emitOnlyArgs) args.unshift(value);
     this.emit('dispose', ...args);
     this.checkEnd();
   }

--- a/src/structures/interfaces/Collector.js
+++ b/src/structures/interfaces/Collector.js
@@ -83,8 +83,7 @@ class Collector extends EventEmitter {
       /**
        * Emitted whenever an element is collected.
        * @event Collector#collect
-       * @param {*} element The element that got collected
-       * @param {...*} args Other arguments emitted by the listener
+       * @param {...*} args The arguments emitted by the listener
        */
       this.emit('collect', ...args);
     }
@@ -106,8 +105,7 @@ class Collector extends EventEmitter {
     /**
      * Emitted whenever an element has been disposed.
      * @event Collector#dispose
-     * @param {*} element The element that was disposed
-     * @param {...*} args Other arguments emitted by the listener
+     * @param {...*} args The arguments emitted by the listener
      */
     this.emit('dispose', ...args);
     this.checkEnd();

--- a/src/structures/interfaces/Collector.js
+++ b/src/structures/interfaces/Collector.js
@@ -14,7 +14,6 @@ const EventEmitter = require('events');
  * @typedef {Object} CollectorOptions
  * @property {number} [time] How long to run the collector for
  * @property {boolean} [dispose=false] Whether to dispose data when it's deleted
- * is equal to the first argument emitted by the listener.
  */
 
 /**

--- a/src/structures/interfaces/Collector.js
+++ b/src/structures/interfaces/Collector.js
@@ -103,7 +103,7 @@ class Collector extends EventEmitter {
     this.collected.delete(dispose);
 
     /**
-     * Emitted whenever an element has been disposed.
+     * Emitted whenever an element is disposed of.
      * @event Collector#dispose
      * @param {...*} args The arguments emitted by the listener
      */

--- a/src/structures/interfaces/Collector.js
+++ b/src/structures/interfaces/Collector.js
@@ -14,6 +14,8 @@ const EventEmitter = require('events');
  * @typedef {Object} CollectorOptions
  * @property {number} [time] How long to run the collector for
  * @property {boolean} [dispose=false] Whether to dispose data when it's deleted
+ * @property {boolean} [emitOnlyArgs=false] Used in case the processed element
+ * is equal to the first argument emitted by the listener.
  */
 
 /**
@@ -80,13 +82,14 @@ class Collector extends EventEmitter {
     if (collect && this.filter(...args, this.collected)) {
       this.collected.set(collect.key, collect.value);
 
+      if (!this.options.emitOnlyArgs) args.unshift(collect.value);
       /**
        * Emitted whenever an element is collected.
        * @event Collector#collect
        * @param {*} element The element that got collected
-       * @param {...*} args The arguments emitted by the listener
+       * @param {...*} args Other arguments emitted by the listener
        */
-      this.emit('collect', collect.value, ...args);
+      this.emit('collect', ...args);
     }
     this.checkEnd();
   }
@@ -105,13 +108,14 @@ class Collector extends EventEmitter {
     const value = this.collected.get(dispose);
     this.collected.delete(dispose);
 
+    if (!this.options.emitOnlyArgs) args.unshift(value);
     /**
      * Emitted whenever an element has been disposed.
      * @event Collector#dispose
      * @param {*} element The element that was disposed
-     * @param {...*} args The arguments emitted by the listener
+     * @param {...*} args Other arguments emitted by the listener
      */
-    this.emit('dispose', value, ...args);
+    this.emit('dispose', ...args);
     this.checkEnd();
   }
 

--- a/src/structures/interfaces/Collector.js
+++ b/src/structures/interfaces/Collector.js
@@ -82,13 +82,13 @@ class Collector extends EventEmitter {
     if (collect && this.filter(...args, this.collected)) {
       this.collected.set(collect.key, collect.value);
 
-      if (!this.options.emitOnlyArgs) args.unshift(collect.value);
       /**
        * Emitted whenever an element is collected.
        * @event Collector#collect
        * @param {*} element The element that got collected
        * @param {...*} args Other arguments emitted by the listener
        */
+      if (!this.options.emitOnlyArgs) args.unshift(collect.value);
       this.emit('collect', ...args);
     }
     this.checkEnd();
@@ -108,13 +108,13 @@ class Collector extends EventEmitter {
     const value = this.collected.get(dispose);
     this.collected.delete(dispose);
 
-    if (!this.options.emitOnlyArgs) args.unshift(value);
     /**
      * Emitted whenever an element has been disposed.
      * @event Collector#dispose
      * @param {*} element The element that was disposed
      * @param {...*} args Other arguments emitted by the listener
      */
+    if (!this.options.emitOnlyArgs) args.unshift(value);
     this.emit('dispose', ...args);
     this.checkEnd();
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes the `ReactionCollector#remove`, it is now possible for it to emit!
Plus it now emits the user who removed the reaction as a second argument.

---

I also took the liberty of adding another possible property to the `options` object passed to the `Collector` constructor: `emitOnlyArgs`. It is not really a property that should be used by the lib users.

The property tells the collector whether to emit the element that was collected/disposed, as a separate argument or not. Some collectors collect the values that they receive without processing them into something else, which is why it is not necessary to emit those elements separately from the arguments because we're emitting the same object as 2 separate arguments.

This would change:
```js
collector.on('collect', (collected, reaction, user) => null)
```
Where both `collected` and `reaction` are the same object, to:
```js
collector.on('collect', (reaction, user) => null)
```
Which makes accessing the user object a lot easier and less confusing. I'm pretty sure many people still think that the only useful thing these events emit is the `reaction`.

Beside that, all 3 events on the ReactionCollector will look more consistent:

```js
on('collect', (reaction, user) => null) // currently emits: Reaction, Reaction, User
on('remove', (reaction, user) => null) // currently emits: Reaction
on('dispose', (reaction, user) => null) // currently emits: Reaction, Reaction, User
```

Without the added property, the behavior of the Collector does not change whatsoever.

PS: I think the jsdoc is a bit off. Please help me formulate `if (value !== args[0])` in human words.

EDIT: This does not apply to this PR anymore, see comments below.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
- [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.

  