### PR TITLE
docs: fix incorrect wording for some Collection prototype methods

### DIFF
--- a/src/util/Collection.js
+++ b/src/util/Collection.js
@@ -174,7 +174,8 @@ class Collection extends Map {
   /**
    * Searches for a single item where its specified property's value is identical to the given value
    * (`item[prop] === value`), or the given function returns a truthy value. In the latter case, this is identical to
-   * [Array.find()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find).
+   * [Array.find()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find), except
+   * it returns `null` instead of `undefined` if the value was not found.
    * <warn>All collections used in Discord.js are mapped using their `id` property, and if you want to find by id you
    * should use the `get` method. See
    * [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/get) for details.</warn>
@@ -207,7 +208,8 @@ class Collection extends Map {
   /**
    * Searches for the key of a single item where its specified property's value is identical to the given value
    * (`item[prop] === value`), or the given function returns a truthy value. In the latter case, this is identical to
-   * [Array.findIndex()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex).
+   * [Array.findIndex()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex),
+   * except it returns `null` instead of `undefined` if the value was not found.
    * @param {string|Function} propOrFn The property to test against, or the function to test with
    * @param {*} [value] The expected value - only applicable and required if using a property for the first argument
    * @returns {*}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Several Collection prototype methods are said to be identical to Array.x(), which is not always true: `client.channels.find(channel => channel.name === "1337")` returns `null` if the value was not found, while according to the docs it is identical to `Array.find()` which returns `undefined` if the value was not found; this resolves #2222 

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.

  