### PR TITLE
fix: allow the Util#parseEmoji regex to match emoji identifier

### DIFF
--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -78,7 +78,7 @@ class Util {
   static parseEmoji(text) {
     if (text.includes('%')) text = decodeURIComponent(text);
     if (!text.includes(':')) return { animated: false, name: text, id: null };
-    const m = text.match(/<?(a)?:(\w{2,32}):(\d{17,19})>?/);
+    const m = text.match(/<?(a)?:?(\w{2,32}):(\d{17,19})>?/);
     if (!m) return null;
     return { animated: Boolean(m[1]), name: m[2], id: m[3] };
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixes #2228

The current regex does not match identifiers `name:id`, this will now allow it to.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
