### PR TITLE
Base Emoji class for ReactionEmoji and renamed GuildEmoji classes

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -15,7 +15,7 @@ const UserStore = require('../stores/UserStore');
 const ChannelStore = require('../stores/ChannelStore');
 const GuildStore = require('../stores/GuildStore');
 const ClientPresenceStore = require('../stores/ClientPresenceStore');
-const EmojiStore = require('../stores/EmojiStore');
+const GuildEmojiStore = require('../stores/GuildEmojiStore');
 const { Events, browser } = require('../util/Constants');
 const DataResolver = require('../util/DataResolver');
 const { Error, TypeError, RangeError } = require('../errors');
@@ -208,11 +208,11 @@ class Client extends BaseClient {
 
   /**
    * All custom emojis that the client has access to, mapped by their IDs
-   * @type {EmojiStore<Snowflake, Emoji>}
+   * @type {GuildEmojiStore<Snowflake, GuildEmoji>}
    * @readonly
    */
   get emojis() {
-    const emojis = new EmojiStore({ client: this });
+    const emojis = new GuildEmojiStore({ client: this });
     for (const guild of this.guilds.values()) {
       if (guild.available) for (const emoji of guild.emojis.values()) emojis.set(emoji.id, emoji);
     }

--- a/src/client/actions/GuildEmojiCreate.js
+++ b/src/client/actions/GuildEmojiCreate.js
@@ -12,7 +12,7 @@ class GuildEmojiCreateAction extends Action {
 /**
  * Emitted whenever a custom emoji is created in a guild.
  * @event Client#emojiCreate
- * @param {Emoji} emoji The emoji that was created
+ * @param {GuildEmoji} emoji The emoji that was created
  */
 
 module.exports = GuildEmojiCreateAction;

--- a/src/client/actions/GuildEmojiDelete.js
+++ b/src/client/actions/GuildEmojiDelete.js
@@ -10,9 +10,9 @@ class GuildEmojiDeleteAction extends Action {
 }
 
 /**
- * Emitted whenever a custom guild emoji is deleted.
+ * Emitted whenever a custom emoji is deleted in a guild.
  * @event Client#emojiDelete
- * @param {Emoji} emoji The emoji that was deleted
+ * @param {GuildEmoji} emoji The emoji that was deleted
  */
 
 module.exports = GuildEmojiDeleteAction;

--- a/src/client/actions/GuildEmojiUpdate.js
+++ b/src/client/actions/GuildEmojiUpdate.js
@@ -10,10 +10,10 @@ class GuildEmojiUpdateAction extends Action {
 }
 
 /**
- * Emitted whenever a custom guild emoji is updated.
+ * Emitted whenever a custom emoji is updated in a guild.
  * @event Client#emojiUpdate
- * @param {Emoji} oldEmoji The old emoji
- * @param {Emoji} newEmoji The new emoji
+ * @param {GuildEmoji} oldEmoji The old emoji
+ * @param {GuildEmoji} newEmoji The new emoji
  */
 
 module.exports = GuildEmojiUpdateAction;

--- a/src/client/actions/MessageReactionAdd.js
+++ b/src/client/actions/MessageReactionAdd.js
@@ -33,7 +33,7 @@ class MessageReactionAdd extends Action {
  * Emitted whenever a reaction is added to a message.
  * @event Client#messageReactionAdd
  * @param {MessageReaction} messageReaction The reaction object
- * @param {User} user The user that applied the emoji or reaction emoji
+ * @param {User} user The user that applied the guild or reaction emoji
  */
 
 module.exports = MessageReactionAdd;

--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -93,7 +93,7 @@ const Messages = {
 
   WEBHOOK_MESSAGE: 'The message was not sent by a webhook.',
 
-  EMOJI_TYPE: 'Emoji must be a string or Emoji/ReactionEmoji',
+  EMOJI_TYPE: 'Emoji must be a string or GuildEmoji/ReactionEmoji',
 
   REACTION_RESOLVE_USER: 'Couldn\'t resolve the user ID to remove from the reaction.',
 };

--- a/src/index.js
+++ b/src/index.js
@@ -26,8 +26,8 @@ module.exports = {
   // Stores
   ChannelStore: require('./stores/ChannelStore'),
   ClientPresenceStore: require('./stores/ClientPresenceStore'),
-  EmojiStore: require('./stores/EmojiStore'),
   GuildChannelStore: require('./stores/GuildChannelStore'),
+  GuildEmojiStore: require('./stores/GuildEmojiStore'),
   GuildMemberStore: require('./stores/GuildMemberStore'),
   GuildStore: require('./stores/GuildStore'),
   ReactionUserStore: require('./stores/ReactionUserStore'),

--- a/src/index.js
+++ b/src/index.js
@@ -64,6 +64,7 @@ module.exports = {
   Guild: require('./structures/Guild'),
   GuildAuditLogs: require('./structures/GuildAuditLogs'),
   GuildChannel: require('./structures/GuildChannel'),
+  GuildEmoji: require('./structures/GuildEmoji'),
   GuildMember: require('./structures/GuildMember'),
   Invite: require('./structures/Invite'),
   Message: require('./structures/Message'),

--- a/src/stores/GuildEmojiStore.js
+++ b/src/stores/GuildEmojiStore.js
@@ -1,17 +1,17 @@
 const Collection = require('../util/Collection');
 const DataStore = require('./DataStore');
-const Emoji = require('../structures/Emoji');
+const GuildEmoji = require('../structures/GuildEmoji');
 const ReactionEmoji = require('../structures/ReactionEmoji');
 const DataResolver = require('../util/DataResolver');
 
 /**
- * Stores emojis.
+ * Stores guild emojis.
  * @private
  * @extends {DataStore}
  */
-class EmojiStore extends DataStore {
+class GuildEmojiStore extends DataStore {
   constructor(guild, iterable) {
-    super(guild.client, iterable, Emoji);
+    super(guild.client, iterable, GuildEmoji);
     this.guild = guild;
   }
 
@@ -61,17 +61,17 @@ class EmojiStore extends DataStore {
   }
 
   /**
-   * Data that can be resolved into an Emoji object. This can be:
+   * Data that can be resolved into an GuildEmoji object. This can be:
    * * A custom emoji ID
-   * * An Emoji object
+   * * A GuildEmoji object
    * * A ReactionEmoji object
-   * @typedef {Snowflake|Emoji|ReactionEmoji} EmojiResolvable
+   * @typedef {Snowflake|GuildEmoji|ReactionEmoji} EmojiResolvable
    */
 
   /**
-   * Resolves a EmojiResolvable to a Emoji object.
+   * Resolves an EmojiResolvable to an Emoji object.
    * @param {EmojiResolvable} emoji The Emoji resolvable to identify
-   * @returns {?Emoji}
+   * @returns {?GuildEmoji}
    */
   resolve(emoji) {
     if (emoji instanceof ReactionEmoji) return super.resolve(emoji.id);
@@ -79,7 +79,7 @@ class EmojiStore extends DataStore {
   }
 
   /**
-   * Resolves a EmojiResolvable to a Emoji ID string.
+   * Resolves an EmojiResolvable to an Emoji ID string.
    * @param {EmojiResolvable} emoji The Emoji resolvable to identify
    * @returns {?Snowflake}
    */
@@ -111,4 +111,4 @@ class EmojiStore extends DataStore {
   }
 }
 
-module.exports = EmojiStore;
+module.exports = GuildEmojiStore;

--- a/src/structures/Emoji.js
+++ b/src/structures/Emoji.js
@@ -1,97 +1,29 @@
-const Collection = require('../util/Collection');
-const Snowflake = require('../util/Snowflake');
 const Base = require('./Base');
-const { TypeError } = require('../errors');
 
 /**
- * Represents a custom emoji.
+ * Represents an emoji, see {@link GuildEmoji} and {@link ReactionEmoji}.
  * @extends {Base}
  */
 class Emoji extends Base {
-  constructor(client, data, guild) {
+  constructor(client, emoji) {
     super(client);
-
-    /**
-     * The guild this emoji is part of
-     * @type {Guild}
-     */
-    this.guild = guild;
-
-    this._patch(data);
-  }
-
-  _patch(data) {
-    /**
-     * The ID of the emoji
-     * @type {Snowflake}
-     */
-    this.id = data.id;
-
-    /**
-     * The name of the emoji
-     * @type {string}
-     */
-    this.name = data.name;
-
-    /**
-     * Whether or not this emoji requires colons surrounding it
-     * @type {boolean}
-     */
-    this.requiresColons = data.require_colons;
-
-    /**
-     * Whether this emoji is managed by an external service
-     * @type {boolean}
-     */
-    this.managed = data.managed;
-
     /**
      * Whether this emoji is animated
      * @type {boolean}
      */
-    this.animated = data.animated;
+    this.animated = emoji.animated;
 
-    this._roles = data.roles;
-  }
+    /**
+     * The name of this emoji
+     * @type {string}
+     */
+    this.name = emoji.name;
 
-  /**
-   * The timestamp the emoji was created at
-   * @type {number}
-   * @readonly
-   */
-  get createdTimestamp() {
-    return Snowflake.deconstruct(this.id).timestamp;
-  }
-
-  /**
-   * The time the emoji was created at
-   * @type {Date}
-   * @readonly
-   */
-  get createdAt() {
-    return new Date(this.createdTimestamp);
-  }
-
-  /**
-   * A collection of roles this emoji is active for (empty if all), mapped by role ID
-   * @type {Collection<Snowflake, Role>}
-   * @readonly
-   */
-  get roles() {
-    const roles = new Collection();
-    for (const role of this._roles) {
-      if (this.guild.roles.has(role)) roles.set(role, this.guild.roles.get(role));
-    }
-    return roles;
-  }
-
-  /**
-   * The URL to the emoji file
-   * @type {string}
-   * @readonly
-   */
-  get url() {
-    return this.client.rest.cdn.Emoji(this.id, this.animated ? 'gif' : 'png');
+    /**
+     * The ID of this emoji
+     * @type {?Snowflake}
+     */
+    this.id = emoji.id;
   }
 
   /**
@@ -100,148 +32,34 @@ class Emoji extends Base {
    * @readonly
    */
   get identifier() {
-    if (this.id) return `${this.name}:${this.id}`;
+    if (this.id) return `${this.animated ? 'a:' : ''}${this.name}:${this.id}`;
     return encodeURIComponent(this.name);
   }
 
   /**
-   * Data for editing an emoji.
-   * @typedef {Object} EmojiEditData
-   * @property {string} [name] The name of the emoji
-   * @property {Collection<Snowflake, Role>|RoleResolvable[]} [roles] Roles to restrict emoji to
+   * The URL to the emoji file if its a custom emoji
+   * @type {?string}
+   * @readonly
    */
-
-  /**
-   * Edits the emoji.
-   * @param {EmojiEditData} data The new data for the emoji
-   * @param {string} [reason] Reason for editing this emoji
-   * @returns {Promise<Emoji>}
-   * @example
-   * // Edit an emoji
-   * emoji.edit({name: 'newemoji'})
-   *   .then(e => console.log(`Edited emoji ${e}`))
-   *   .catch(console.error);
-   */
-  edit(data, reason) {
-    return this.client.api.guilds(this.guild.id).emojis(this.id)
-      .patch({ data: {
-        name: data.name,
-        roles: data.roles ? data.roles.map(r => r.id ? r.id : r) : undefined,
-      }, reason })
-      .then(() => this);
+  get url() {
+    if (!this.id) return null;
+    return this.client.rest.cdn.Emoji(this.id, this.animated ? 'gif' : 'png');
   }
 
   /**
-   * Sets the name of the emoji.
-   * @param {string} name The new name for the emoji
-   * @param {string} [reason] Reason for changing the emoji's name
-   * @returns {Promise<Emoji>}
-   */
-  setName(name, reason) {
-    return this.edit({ name }, reason);
-  }
-
-  /**
-   * Adds a role to the list of roles that can use this emoji.
-   * @param {Role} role The role to add
-   * @returns {Promise<Emoji>}
-   */
-  addRestrictedRole(role) {
-    return this.addRestrictedRoles([role]);
-  }
-
-  /**
-   * Adds multiple roles to the list of roles that can use this emoji.
-   * @param {Collection<Snowflake, Role>|RoleResolvable[]} roles Roles to add
-   * @returns {Promise<Emoji>}
-   */
-  addRestrictedRoles(roles) {
-    const newRoles = new Collection(this.roles);
-    for (let role of roles instanceof Collection ? roles.values() : roles) {
-      role = this.guild.roles.resolve(role);
-      if (!role) {
-        return Promise.reject(new TypeError('INVALID_TYPE', 'roles',
-          'Array or Collection of Roles or Snowflakes', true));
-      }
-      newRoles.set(role.id, role);
-    }
-    return this.edit({ roles: newRoles });
-  }
-
-  /**
-   * Removes a role from the list of roles that can use this emoji.
-   * @param {Role} role The role to remove
-   * @returns {Promise<Emoji>}
-   */
-  removeRestrictedRole(role) {
-    return this.removeRestrictedRoles([role]);
-  }
-
-  /**
-   * Removes multiple roles from the list of roles that can use this emoji.
-   * @param {Collection<Snowflake, Role>|RoleResolvable[]} roles Roles to remove
-   * @returns {Promise<Emoji>}
-   */
-  removeRestrictedRoles(roles) {
-    const newRoles = new Collection(this.roles);
-    for (let role of roles instanceof Collection ? roles.values() : roles) {
-      role = this.guild.roles.resolve(role);
-      if (!role) {
-        return Promise.reject(new TypeError('INVALID_TYPE', 'roles',
-          'Array or Collection of Roles or Snowflakes', true));
-      }
-      if (newRoles.has(role.id)) newRoles.delete(role.id);
-    }
-    return this.edit({ roles: newRoles });
-  }
-
-  /**
-   * When concatenated with a string, this automatically concatenates the emoji's mention instead of the Emoji object.
+   * When concatenated with a string, this automatically returns the text required to form a graphical emoji on Discord
+   * instead of the Emoji object.
    * @returns {string}
    * @example
-   * // Send an emoji:
+   * // Send a custom emoji from a guild:
    * const emoji = guild.emojis.first();
    * msg.reply(`Hello! ${emoji}`);
+   * @example
+   * // Send the emoji used in a reaction to the channel the reaction is part of
+   * reaction.message.channel.send(`The emoji used was: ${reaction.emoji}`);
    */
   toString() {
-    if (!this.id || !this.requiresColons) {
-      return this.name;
-    }
-
-    return `<${this.animated ? 'a' : ''}:${this.name}:${this.id}>`;
-  }
-
-  /**
-   * Deletes the emoji.
-   * @param {string} [reason] Reason for deleting the emoji
-   * @returns {Promise<Emoji>}
-   */
-  delete(reason) {
-    return this.client.api.guilds(this.guild.id).emojis(this.id).delete({ reason })
-      .then(() => this);
-  }
-
-  /**
-   * Whether this emoji is the same as another one.
-   * @param {Emoji|Object} other The emoji to compare it to
-   * @returns {boolean} Whether the emoji is equal to the given emoji or not
-   */
-  equals(other) {
-    if (other instanceof Emoji) {
-      return (
-        other.id === this.id &&
-        other.name === this.name &&
-        other.managed === this.managed &&
-        other.requiresColons === this.requiresColons &&
-        other._roles === this._roles
-      );
-    } else {
-      return (
-        other.id === this.id &&
-        other.name === this.name &&
-        other._roles === this._roles
-      );
-    }
+    return this.id ? `<${this.animated ? 'a' : ''}:${this.name}:${this.id}>` : this.name;
   }
 }
 

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -10,7 +10,7 @@ const Snowflake = require('../util/Snowflake');
 const Shared = require('./shared');
 const GuildMemberStore = require('../stores/GuildMemberStore');
 const RoleStore = require('../stores/RoleStore');
-const EmojiStore = require('../stores/EmojiStore');
+const GuildEmojiStore = require('../stores/GuildEmojiStore');
 const GuildChannelStore = require('../stores/GuildChannelStore');
 const PresenceStore = require('../stores/PresenceStore');
 const Base = require('./Base');
@@ -218,9 +218,9 @@ class Guild extends Base {
     if (!this.emojis) {
       /**
        * A collection of emojis that are in this guild. The key is the emoji's ID, the value is the emoji.
-       * @type {EmojiStore<Snowflake, Emoji>}
+       * @type {GuildEmojiStore<Snowflake, GuildEmoji>}
        */
-      this.emojis = new EmojiStore(this);
+      this.emojis = new GuildEmojiStore(this);
       if (data.emojis) for (const emoji of data.emojis) this.emojis.add(emoji);
     } else {
       this.client.actions.GuildEmojisUpdate.handle({

--- a/src/structures/GuildAuditLogs.js
+++ b/src/structures/GuildAuditLogs.js
@@ -148,7 +148,7 @@ class GuildAuditLogs {
    * * An invite
    * * A webhook
    * * An object where the keys represent either the new value or the old value
-   * @typedef {?Object|Guild|User|Role|Emoji|Invite|Webhook} AuditLogEntryTarget
+   * @typedef {?Object|Guild|User|Role|GuildEmoji|Invite|Webhook} AuditLogEntryTarget
    */
 
   /**

--- a/src/structures/GuildEmoji.js
+++ b/src/structures/GuildEmoji.js
@@ -71,14 +71,14 @@ class GuildEmoji extends Emoji {
 
   /**
    * Data for editing an emoji.
-   * @typedef {Object} EmojiEditData
+   * @typedef {Object} GuildEmojiEditData
    * @property {string} [name] The name of the emoji
    * @property {Collection<Snowflake, Role>|RoleResolvable[]} [roles] Roles to restrict emoji to
    */
 
   /**
    * Edits the emoji.
-   * @param {EmojiEditData} data The new data for the emoji
+   * @param {Guild} data The new data for the emoji
    * @param {string} [reason] Reason for editing this emoji
    * @returns {Promise<GuildEmoji>}
    * @example

--- a/src/structures/GuildEmoji.js
+++ b/src/structures/GuildEmoji.js
@@ -1,0 +1,197 @@
+const Collection = require('../util/Collection');
+const Snowflake = require('../util/Snowflake');
+const Emoji = require('./Emoji');
+const { TypeError } = require('../errors');
+
+/**
+ * Represents a custom emoji.
+ * @extends {Emoji}
+ */
+class GuildEmoji extends Emoji {
+  constructor(client, data, guild) {
+    super(client, data);
+
+    /**
+     * The guild this emoji is part of
+     * @type {Guild}
+     */
+    this.guild = guild;
+
+    this._patch(data);
+  }
+
+  _patch(data) {
+    this.name = data.name;
+
+    /**
+     * Whether or not this emoji requires colons surrounding it
+     * @type {boolean}
+     */
+    this.requiresColons = data.require_colons;
+
+    /**
+     * Whether this emoji is managed by an external service
+     * @type {boolean}
+     */
+    this.managed = data.managed;
+
+    this._roles = data.roles;
+  }
+
+  /**
+   * The timestamp the emoji was created at
+   * @type {number}
+   * @readonly
+   */
+  get createdTimestamp() {
+    return Snowflake.deconstruct(this.id).timestamp;
+  }
+
+  /**
+   * The time the emoji was created at
+   * @type {Date}
+   * @readonly
+   */
+  get createdAt() {
+    return new Date(this.createdTimestamp);
+  }
+
+  /**
+   * A collection of roles this emoji is active for (empty if all), mapped by role ID
+   * @type {Collection<Snowflake, Role>}
+   * @readonly
+   */
+  get roles() {
+    const roles = new Collection();
+    for (const role of this._roles) {
+      if (this.guild.roles.has(role)) roles.set(role, this.guild.roles.get(role));
+    }
+    return roles;
+  }
+
+  /**
+   * Data for editing an emoji.
+   * @typedef {Object} EmojiEditData
+   * @property {string} [name] The name of the emoji
+   * @property {Collection<Snowflake, Role>|RoleResolvable[]} [roles] Roles to restrict emoji to
+   */
+
+  /**
+   * Edits the emoji.
+   * @param {EmojiEditData} data The new data for the emoji
+   * @param {string} [reason] Reason for editing this emoji
+   * @returns {Promise<GuildEmoji>}
+   * @example
+   * // Edit an emoji
+   * emoji.edit({name: 'newemoji'})
+   *   .then(e => console.log(`Edited emoji ${e}`))
+   *   .catch(console.error);
+   */
+  edit(data, reason) {
+    return this.client.api.guilds(this.guild.id).emojis(this.id)
+      .patch({ data: {
+        name: data.name,
+        roles: data.roles ? data.roles.map(r => r.id ? r.id : r) : undefined,
+      }, reason })
+      .then(() => this);
+  }
+
+  /**
+   * Sets the name of the emoji.
+   * @param {string} name The new name for the emoji
+   * @param {string} [reason] Reason for changing the emoji's name
+   * @returns {Promise<GuildEmoji>}
+   */
+  setName(name, reason) {
+    return this.edit({ name }, reason);
+  }
+
+  /**
+   * Adds a role to the list of roles that can use this emoji.
+   * @param {Role} role The role to add
+   * @returns {Promise<GuildEmoji>}
+   */
+  addRestrictedRole(role) {
+    return this.addRestrictedRoles([role]);
+  }
+
+  /**
+   * Adds multiple roles to the list of roles that can use this emoji.
+   * @param {Collection<Snowflake, Role>|RoleResolvable[]} roles Roles to add
+   * @returns {Promise<GuildEmoji>}
+   */
+  addRestrictedRoles(roles) {
+    const newRoles = new Collection(this.roles);
+    for (let role of roles instanceof Collection ? roles.values() : roles) {
+      role = this.guild.roles.resolve(role);
+      if (!role) {
+        return Promise.reject(new TypeError('INVALID_TYPE', 'roles',
+          'Array or Collection of Roles or Snowflakes', true));
+      }
+      newRoles.set(role.id, role);
+    }
+    return this.edit({ roles: newRoles });
+  }
+
+  /**
+   * Removes a role from the list of roles that can use this emoji.
+   * @param {Role} role The role to remove
+   * @returns {Promise<GuildEmoji>}
+   */
+  removeRestrictedRole(role) {
+    return this.removeRestrictedRoles([role]);
+  }
+
+  /**
+   * Removes multiple roles from the list of roles that can use this emoji.
+   * @param {Collection<Snowflake, Role>|RoleResolvable[]} roles Roles to remove
+   * @returns {Promise<GuildEmoji>}
+   */
+  removeRestrictedRoles(roles) {
+    const newRoles = new Collection(this.roles);
+    for (let role of roles instanceof Collection ? roles.values() : roles) {
+      role = this.guild.roles.resolve(role);
+      if (!role) {
+        return Promise.reject(new TypeError('INVALID_TYPE', 'roles',
+          'Array or Collection of Roles or Snowflakes', true));
+      }
+      if (newRoles.has(role.id)) newRoles.delete(role.id);
+    }
+    return this.edit({ roles: newRoles });
+  }
+
+  /**
+   * Deletes the emoji.
+   * @param {string} [reason] Reason for deleting the emoji
+   * @returns {Promise<GuildEmoji>}
+   */
+  delete(reason) {
+    return this.client.api.guilds(this.guild.id).emojis(this.id).delete({ reason })
+      .then(() => this);
+  }
+
+  /**
+   * Whether this emoji is the same as another one.
+   * @param {GuildEmoji|Object} other The emoji to compare it to
+   * @returns {boolean} Whether the emoji is equal to the given emoji or not
+   */
+  equals(other) {
+    if (other instanceof GuildEmoji) {
+      return (
+        other.id === this.id &&
+        other.name === this.name &&
+        other.managed === this.managed &&
+        other.requiresColons === this.requiresColons &&
+        other._roles === this._roles
+      );
+    } else {
+      return (
+        other.id === this.id &&
+        other.name === this.name &&
+        other._roles === this._roles
+      );
+    }
+  }
+}
+
+module.exports = GuildEmoji;

--- a/src/structures/MessageReaction.js
+++ b/src/structures/MessageReaction.js
@@ -1,4 +1,4 @@
-const Emoji = require('./Emoji');
+const GuildEmoji = require('./GuildEmoji');
 const ReactionEmoji = require('./ReactionEmoji');
 const ReactionUserStore = require('../stores/ReactionUserStore');
 
@@ -31,18 +31,18 @@ class MessageReaction {
      */
     this.users = new ReactionUserStore(client, undefined, this);
 
-    this._emoji = new ReactionEmoji(this, data.emoji.name, data.emoji.id);
+    this._emoji = new ReactionEmoji(this, data.emoji);
   }
 
   /**
-   * The emoji of this reaction, either an Emoji object for known custom emojis, or a ReactionEmoji
+   * The emoji of this reaction, either an GuildEmoji object for known custom emojis, or a ReactionEmoji
    * object which has fewer properties. Whatever the prototype of the emoji, it will still have
    * `name`, `id`, `identifier` and `toString()`
-   * @type {Emoji|ReactionEmoji}
+   * @type {GuildEmoji|ReactionEmoji}
    * @readonly
    */
   get emoji() {
-    if (this._emoji instanceof Emoji) return this._emoji;
+    if (this._emoji instanceof GuildEmoji) return this._emoji;
     // Check to see if the emoji has become known to the client
     if (this._emoji.id) {
       const emojis = this.message.client.emojis;

--- a/src/structures/ReactionEmoji.js
+++ b/src/structures/ReactionEmoji.js
@@ -1,49 +1,19 @@
+const Emoji = require('./Emoji');
+
 /**
  * Represents a limited emoji set used for both custom and unicode emojis. Custom emojis
  * will use this class opposed to the Emoji class when the client doesn't know enough
  * information about them.
+ * @extends {Emoji}
  */
-class ReactionEmoji {
-  constructor(reaction, name, id) {
+class ReactionEmoji extends Emoji {
+  constructor(reaction, emoji) {
+    super(reaction.message.client, emoji);
     /**
      * The message reaction this emoji refers to
      * @type {MessageReaction}
      */
     this.reaction = reaction;
-
-    /**
-     * The name of this reaction emoji
-     * @type {string}
-     */
-    this.name = name;
-
-    /**
-     * The ID of this reaction emoji
-     * @type {?Snowflake}
-     */
-    this.id = id;
-  }
-
-  /**
-   * The identifier of this emoji, used for message reactions
-   * @type {string}
-   * @readonly
-   */
-  get identifier() {
-    if (this.id) return `${this.name}:${this.id}`;
-    return encodeURIComponent(this.name);
-  }
-
-  /**
-   * When concatenated with a string, this automatically returns the text required to form a graphical emoji on Discord
-   * instead of the ReactionEmoji object.
-   * @returns {string}
-   * @example
-   * // Send the emoji used in a reaction to the channel the reaction is part of
-   * reaction.message.channel.send(`The emoji used was: ${reaction.emoji}`);
-   */
-  toString() {
-    return this.id ? `<:${this.name}:${this.id}>` : this.name;
   }
 }
 

--- a/src/util/Structures.js
+++ b/src/util/Structures.js
@@ -61,7 +61,7 @@ class Structures {
 }
 
 const structures = {
-  Emoji: require('../structures/Emoji'),
+  GuildEmoji: require('../structures/GuildEmoji'),
   DMChannel: require('../structures/DMChannel'),
   GroupDMChannel: require('../structures/GroupDMChannel'),
   TextChannel: require('../structures/TextChannel'),


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Create new `Emoji` class as base for `GuildEmoji` and `ReactionEmoji` to avoid code duplication

Summary:
- Renamed `Emoji` to `GuildEmoji`, refelects in [Structures](https://github.com/hydrabolt/discord.js/pull/2230/files#diff-3bc3a95553c59d189184dba493493738L64)
- Created new `Emoji` class to avoid code duplication between `GuildEmoji` and `ReactionEmoji`
- Both `GuildEmoji` and `ReactionEmoji` extend said `Emoji` class
- Renamed `EmojiStore` to `GuildEmojiStore` to stay consistent with the class' name `GuildEmoji`

TODO:
- [x] Verify all docstrings are correct with new/renamed classes
- [x] Verify all `instanceof`s and similar are correct
- [x] Verify reacting / removing of such works properly
- [x] Verify all received emojis are in their proper places and classes (GuildEmoji, ReactionEmoji)
- [x] Verify resolving of Reaction and GuildEmojis works properly


**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.

  
  
  
  