### PR TITLE
fix(voiceStateUpdate): incorrect members.size

### DIFF
--- a/src/client/websocket/packets/handlers/VoiceStateUpdate.js
+++ b/src/client/websocket/packets/handlers/VoiceStateUpdate.js
@@ -25,7 +25,10 @@ class VoiceStateUpdateHandler extends AbstractHandler {
         }
 
         const newChannel = client.channels.get(data.channel_id);
-        if (newChannel) newChannel.members.set(member.user.id, member);
+        if (newChannel) {
+          newChannel.members.set(member.id, member);
+          member.guild.channels.set(data.channel_id, newChannel);
+        }
 
         member.serverMute = data.mute;
         member.serverDeaf = data.deaf;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Issue where creating a new voice channel (and then connecting to it) would not have the member set in the guild's perspective. This should ensure it's appropriately updated.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
