### PR TITLE
fix(Collection.firstKey) this.iter is not a function

### DIFF
--- a/src/util/Collection.js
+++ b/src/util/Collection.js
@@ -85,7 +85,7 @@ class Collection extends Map {
     if (!Number.isInteger(count) || count < 1) throw new RangeError('The count must be an integer greater than 0.');
     count = Math.min(this.size, count);
     const arr = new Array(count);
-    const iter = this.iter();
+    const iter = this.keys();
     for (let i = 0; i < count; i++) arr[i] = iter.next().value;
     return arr;
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This fixes #2236 and replaces `iter` with `keys`, which in turn is an iterator

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
