### PR TITLE
Fix member.ban() and channel.clone()

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -412,7 +412,7 @@ class GuildChannel extends Channel {
    */
   clone({ name = this.name, withPermissions = true, withTopic = true, reason } = {}) {
     const options = { overwrites: withPermissions ? this.permissionOverwrites : [], reason };
-    return this.guild.channels.create(name, this.type, options)
+    return this.guild.channels.create(name, Object.assign(options, { type: this.type}))
       .then(channel => withTopic ? channel.setTopic(this.topic) : channel);
   }
 

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -412,7 +412,7 @@ class GuildChannel extends Channel {
    */
   clone({ name = this.name, withPermissions = true, withTopic = true, reason } = {}) {
     const options = { overwrites: withPermissions ? this.permissionOverwrites : [], reason };
-    return this.guild.channels.create(name, Object.assign(options, { type: this.type}))
+    return this.guild.channels.create(name, Object.assign(options, { type: this.type }))
       .then(channel => withTopic ? channel.setTopic(this.topic) : channel);
   }
 

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -412,7 +412,7 @@ class GuildChannel extends Channel {
    */
   clone({ name = this.name, withPermissions = true, withTopic = true, reason } = {}) {
     const options = { overwrites: withPermissions ? this.permissionOverwrites : [], reason };
-    return this.guild.createChannel(name, this.type, options)
+    return this.guild.channels.create(name, this.type, options)
       .then(channel => withTopic ? channel.setTopic(this.topic) : channel);
   }
 

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -411,8 +411,8 @@ class GuildChannel extends Channel {
    * @returns {Promise<GuildChannel>}
    */
   clone({ name = this.name, withPermissions = true, withTopic = true, reason } = {}) {
-    const options = { overwrites: withPermissions ? this.permissionOverwrites : [], reason };
-    return this.guild.channels.create(name, Object.assign(options, { type: this.type }))
+    const options = { overwrites: withPermissions ? this.permissionOverwrites : [], reason, type: this.type };
+    return this.guild.channels.create(name, options)
       .then(channel => withTopic ? channel.setTopic(this.topic) : channel);
   }
 

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -543,7 +543,7 @@ class GuildMember extends Base {
    *   .catch(console.error);
    */
   ban(options) {
-    return this.guild.ban(this, options);
+    return this.guild.members.ban(this, options);
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
#2216 broke member.ban() and channel.clone(), this fixes them

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
