### PR TITLE
Fix destructuring errors in GuildChannelStore and RoleStore

### DIFF
--- a/src/stores/GuildChannelStore.js
+++ b/src/stores/GuildChannelStore.js
@@ -3,7 +3,7 @@ const Channel = require('../structures/Channel');
 const { ChannelTypes } = require('../util/Constants');
 const DataStore = require('./DataStore');
 const GuildChannel = require('../structures/GuildChannel');
-const { resolve } = require('../util/Permissions');
+const Permissions = require('../util/Permissions');
 
 /**
  * Stores guild channels.
@@ -54,8 +54,8 @@ class GuildChannelStore extends DataStore {
       overwrites = overwrites.map(overwrite => {
         let allow = overwrite.allow || (overwrite.allowed ? overwrite.allowed.bitfield : 0);
         let deny = overwrite.deny || (overwrite.denied ? overwrite.denied.bitfield : 0);
-        if (allow instanceof Array) allow = resolve(allow);
-        if (deny instanceof Array) deny = resolve(deny);
+        if (allow instanceof Array) allow = Permissions.resolve(allow);
+        if (deny instanceof Array) deny = Permissions.resolve(deny);
 
         const role = this.guild.roles.resolve(overwrite.id);
         if (role) {

--- a/src/stores/RoleStore.js
+++ b/src/stores/RoleStore.js
@@ -1,7 +1,7 @@
 const DataStore = require('./DataStore');
 const Role = require('../structures/Role');
 const { resolveColor } = require('../util/Util');
-const { resolve } = require('../util/Permissions');
+const Permissions = require('../util/Permissions');
 
 /**
  * Stores roles.
@@ -42,7 +42,7 @@ class RoleStore extends DataStore {
    */
   create(data = {}, reason) {
     if (data.color) data.color = resolveColor(data.color);
-    if (data.permissions) data.permissions = resolve(data.permissions);
+    if (data.permissions) data.permissions = Permissions.resolve(data.permissions);
 
     return this.guild.client.api.guilds(this.guild.id).roles.post({ data, reason }).then(r => {
       const { role } = this.client.actions.GuildRoleCreate.handle({

--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -108,7 +108,7 @@ class Permissions {
   static resolve(permission) {
     if (typeof permission === 'number' && permission >= 0) return permission;
     if (permission instanceof Permissions) return permission.bitfield;
-    if (permission instanceof Array) return permission.map(p => this.resolve(p)).reduce((prev, p) => prev | p, 0);
+    if (permission instanceof Array) return permission.map(p => Permissions.resolve(p)).reduce((prev, p) => prev | p, 0);
     if (typeof permission === 'string') return this.FLAGS[permission];
     throw new RangeError('PERMISSIONS_INVALID');
   }

--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -108,7 +108,9 @@ class Permissions {
   static resolve(permission) {
     if (typeof permission === 'number' && permission >= 0) return permission;
     if (permission instanceof Permissions) return permission.bitfield;
-    if (permission instanceof Array) return permission.map(p => Permissions.resolve(p)).reduce((prev, p) => prev | p, 0);
+    if (permission instanceof Array) {
+      return permission.map(p => Permissions.resolve(p)).reduce((prev, p) => prev | p, 0);
+    }
     if (typeof permission === 'string') return this.FLAGS[permission];
     throw new RangeError('PERMISSIONS_INVALID');
   }

--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -108,9 +108,7 @@ class Permissions {
   static resolve(permission) {
     if (typeof permission === 'number' && permission >= 0) return permission;
     if (permission instanceof Permissions) return permission.bitfield;
-    if (permission instanceof Array) {
-      return permission.map(p => Permissions.resolve(p)).reduce((prev, p) => prev | p, 0);
-    }
+    if (permission instanceof Array) return permission.map(p => this.resolve(p)).reduce((prev, p) => prev | p, 0);
     if (typeof permission === 'string') return this.FLAGS[permission];
     throw new RangeError('PERMISSIONS_INVALID');
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Permissions#resolve() fix. Using 'this' inside of Array#map() doesn't work except if thisArg is provided to the map function.

**Semantic versioning classification:**  
- [X] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
