### PR TITLE
Fix ShardClientUtil#broadcastEval - now really accepting functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ deploy/deploy_key.pub
 .vscode/
 docs/docs.json
 webpack/
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,3 @@ deploy/deploy_key.pub
 .vscode/
 docs/docs.json
 webpack/
-.idea/

--- a/src/sharding/ShardClientUtil.js
+++ b/src/sharding/ShardClientUtil.js
@@ -86,7 +86,7 @@ class ShardClientUtil {
    */
   broadcastEval(script) {
     return new Promise((resolve, reject) => {
-      script = typeof script !== 'function' ? `(${script})(this)` : script;
+      script = typeof script === 'function' ? `(${script})(this)` : script;
       const listener = message => {
         if (!message || message._sEval !== script) return;
         process.removeListener('message', listener);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
There is a small typo in the broadcastEval method. 

It should be 
```
script = typeof script === 'function' ? `(${script})(this)` : script;
``` 
instead of 
```
script = typeof script !== 'function' ? `(${script})(this)` : script;
```

Additionally adding `.idea` to the .gitignore file, so that also jetbrain products like Webstorm and Idea are ignored (additionally to vscode)

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
