### PR TITLE
Guild#roles Documentation Has The Old Class

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -40,7 +40,7 @@ class Guild extends Base {
 
     /**
      * A collection of roles that are in this guild. The key is the role's ID, the value is the role
-     * @type {Collection<Snowflake, Role>}
+     * @type {RoleStore<Snowflake, Role>}
      */
     this.roles = new RoleStore(this);
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Changed `Collection` to `RoleStore`

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
