### PR TITLE
Remove pointless function from GuildEmojisUpdate

### DIFF
--- a/src/client/actions/GuildEmojisUpdate.js
+++ b/src/client/actions/GuildEmojisUpdate.js
@@ -1,17 +1,11 @@
 const Action = require('./Action');
 
-function mappify(iterable) {
-  const map = new Map();
-  for (const x of iterable) map.set(...x);
-  return map;
-}
-
 class GuildEmojisUpdateAction extends Action {
   handle(data) {
     const guild = this.client.guilds.get(data.guild_id);
     if (!guild || !guild.emojis) return;
 
-    const deletions = mappify(guild.emojis.entries());
+    const deletions = new Map(guild.emojis);
 
     for (const emoji of data.emojis) {
       // Determine type of emoji event


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Maps take iterables; and DataStores, collections, and maps are all iterables. Meaning we can pass the collection into a new Map() instead of using a function to create a map from the map.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
