### PR TITLE
fix setPresence parameter in setActivity

### DIFF
--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -231,7 +231,7 @@ class ClientUser extends Structures.get('User') {
    * @returns {Promise<Presence>}
    */
   setActivity(name, { url, type } = {}) {
-    if (!name) return this.setPresence({ activity: null });
+    if (!name) return this.setPresence({ game: null });
     return this.setPresence({
       activity: { name, type, url },
     });


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
fix `ClientUser.setPresence` parameter in `.setActivity` from `activity:null` to `game:null`
This PR fix the issue that clientuser cannot clear its game activity by invoking `.setActivity(null)`

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
