### PR TITLE
[v11.3.x] Fix param sent to setPresence in setActivity

### DIFF
--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -271,7 +271,7 @@ class ClientUser extends User {
    * @returns {Promise<Presence>}
    */
   setActivity(name, { url, type } = {}) {
-    if (!name) return this.setPresence({ activity: null });
+    if (!name) return this.setPresence({ game: null });
     return this.setPresence({
       game: { name, type, url },
     });


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`ClientUser#setPresence` in master branch (latest) calls `client.presences.setClientPresence`,
but that in v11.3 does not.
so i change parameter sent to `setPresence` for clearing the game activity,
from `activity:null` to `game:null`,
for now until setPresence function gets updated

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
